### PR TITLE
fix(mobile): patch redux-saga ESM proxy double-unwrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     },
     "patchedDependencies": {
       "react-native-draggable-grid@2.2.1": "patches/react-native-draggable-grid@2.2.1.patch",
-      "styled-components@6.1.11": "patches/styled-components@6.1.11.patch"
+      "styled-components@6.1.11": "patches/styled-components@6.1.11.patch",
+      "redux-saga@1.3.0": "patches/redux-saga@1.3.0.patch"
     },
     "overrides": {
       "@react-native-async-storage/async-storage": "2.2.0",

--- a/patches/redux-saga@1.3.0.patch
+++ b/patches/redux-saga@1.3.0.patch
@@ -1,0 +1,13 @@
+diff --git a/import-condition-proxy.mjs b/import-condition-proxy.mjs
+index 14b6309fb80122789d838be316dbcb73537bf44d..b6606a1eff4cd995989799c02bdbf2add635844d 100644
+--- a/import-condition-proxy.mjs
++++ b/import-condition-proxy.mjs
+@@ -1,4 +1,7 @@
+ export * from './dist/redux-saga-core-npm-proxy.cjs.js'
+ import _default from './dist/redux-saga-core-npm-proxy.cjs.js'
+ 
+-export default _default.default
++// Metro / RN bundler applies CJS default-interop already, so `_default`
++// is the function itself, not `{ default: fn }`. Upstream double-unwrap
++// produced `undefined`. See redux-saga GH issue #2384.
++export default _default.default || _default

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ patchedDependencies:
   react-native-draggable-grid@2.2.1:
     hash: v6ayathkzbndn3dcqvsojpmote
     path: patches/react-native-draggable-grid@2.2.1.patch
+  redux-saga@1.3.0:
+    hash: fuqywzq4jqd6wsmilvg6dhxzpi
+    path: patches/redux-saga@1.3.0.patch
   styled-components@6.1.11:
     hash: rpobciuscng7usb6kdy5cx6apq
     path: patches/styled-components@6.1.11.patch
@@ -277,7 +280,7 @@ importers:
         version: 5.0.1
       redux-saga:
         specifier: ^1.3.0
-        version: 1.3.0
+        version: 1.3.0(patch_hash=fuqywzq4jqd6wsmilvg6dhxzpi)
       reselect:
         specifier: ^5.1.1
         version: 5.1.1
@@ -17830,7 +17833,7 @@ snapshots:
 
   reduce-reducers@1.0.4: {}
 
-  redux-saga@1.3.0:
+  redux-saga@1.3.0(patch_hash=fuqywzq4jqd6wsmilvg6dhxzpi):
     dependencies:
       '@redux-saga/core': 1.3.0
 


### PR DESCRIPTION
## Summary

`redux-saga@1.3.0`'s `import-condition-proxy.mjs` does:
\`\`\`js
import _default from './dist/redux-saga-core-npm-proxy.cjs.js'
export default _default.default
\`\`\`

Metro/RN bundlers already apply CJS default-interop, so `_default` IS the function. The `.default` access returns `undefined`, which redboxes the app at launch with:

\`\`\`
Uncaught Error: createSagaMiddleware.default is not a function (it is undefined)
\`\`\`

This breaks the iOS sim on SDK 55 (caught while running the new Maestro smoke flows). The Android emulator hit the same bug.

Fix: pnpm patch the proxy to fall back to `_default` when `.default` is missing.

## Test plan
- [x] `pnpm install` applies patch cleanly
- [x] `pnpm typecheck` passes
- [ ] iOS sim launches without redbox (Maestro `launch.yaml` passes)
- [ ] Android emulator launches without redbox