### PR TITLE
test(mobile): tighten Maestro login helpers (real screen-advancing flows)

### DIFF
--- a/apps/mobile/.maestro/utils/login-returning.yaml
+++ b/apps/mobile/.maestro/utils/login-returning.yaml
@@ -5,22 +5,49 @@ tags:
 ---
 # Logs in as test+returning@pegada.app which has dog Rex + match Bella + chats,
 # so the auth router pushes straight to the swipe tab. Caller must already
-# launchApp'd. Coordinates calibrated on iPhone 17 Pro Max.
+# have launchApp'd. Coordinates calibrated on iPhone 17 Pro Max.
+- tapOn:
+    text: "Ask App Not to Track"
+    optional: true
+- tapOn:
+    text: "Allow Once"
+    optional: true
+- tapOn:
+    text: "Don.t Allow"
+    optional: true
 - tapOn:
     point: "50%, 55%"
 - waitForAnimationToEnd
 - inputText: "test+returning@pegada.app"
+- hideKeyboard
 - tapOn:
     point: "50%, 62%"
 - extendedWaitUntil:
     notVisible: "__wait_for_otp_screen__"
     timeout: 10000
     optional: true
+# OTP — type one digit at a time, tapping each cell first to give it focus.
 - tapOn:
     point: "12%, 40%"
 - waitForAnimationToEnd
-- inputText: "424242"
+- inputText: "4"
+- tapOn:
+    point: "25%, 40%"
+- inputText: "2"
+- tapOn:
+    point: "38%, 40%"
+- inputText: "4"
+- tapOn:
+    point: "51%, 40%"
+- inputText: "2"
+- tapOn:
+    point: "64%, 40%"
+- inputText: "4"
+- tapOn:
+    point: "77%, 40%"
+- inputText: "2"
+- hideKeyboard
 - extendedWaitUntil:
     notVisible: "__wait_for_tabs__"
-    timeout: 20000
+    timeout: 25000
     optional: true

--- a/apps/mobile/.maestro/utils/login.yaml
+++ b/apps/mobile/.maestro/utils/login.yaml
@@ -1,31 +1,59 @@
 appId: ${APP_ID}
-name: util - login via magic OTP (point-based)
+name: util - login via magic OTP (point-based) - new user
 tags:
   - util
 ---
-# Reusable subflow: sign-in using magic email + OTP (424242).
+# Reusable subflow: sign-in as fresh test user (no dog, no match) so the
+# auth router lands on CreateProfile after OTP.
+# Email is hardcoded (test account, not a secret) because env var
+# interpolation was producing the literal string "undefined" in inputText.
 # Point-based because the RN view tree is invisible to the XCUITest
-# accessibility snapshot for this app (see /tmp/pegada-maestro-status.md).
+# accessibility snapshot for this app.
 # Coordinates calibrated on iPhone 17 Pro Max (440x956 logical, 1320x2868 px).
-# Requires env vars APPLE_MAGIC_EMAIL and APPLE_MAGIC_CODE.
-# Caller must already have launchApp'd. Leaves user on whichever post-OTP
-# route the API resolves to (CreateProfile / CompleteProfile / AskForLocation
-# / tabs).
+# Caller must already have launchApp'd.
+- tapOn:
+    text: "Ask App Not to Track"
+    optional: true
+- tapOn:
+    text: "Allow Once"
+    optional: true
+- tapOn:
+    text: "Don.t Allow"
+    optional: true
 - tapOn:
     point: "50%, 55%"
 - waitForAnimationToEnd
-- inputText: ${APPLE_MAGIC_EMAIL}
+- inputText: "test@pegada.app"
+- hideKeyboard
 - tapOn:
     point: "50%, 62%"
 - extendedWaitUntil:
     notVisible: "__wait_for_otp_screen__"
     timeout: 10000
     optional: true
+# OTP — type one digit at a time into the 6-digit input row.
+# Row is at ~40% Y, cells distributed roughly 12%/25%/38%/51%/64%/77% X.
 - tapOn:
     point: "12%, 40%"
 - waitForAnimationToEnd
-- inputText: ${APPLE_MAGIC_CODE}
+- inputText: "4"
+- tapOn:
+    point: "25%, 40%"
+- inputText: "2"
+- tapOn:
+    point: "38%, 40%"
+- inputText: "4"
+- tapOn:
+    point: "51%, 40%"
+- inputText: "2"
+- tapOn:
+    point: "64%, 40%"
+- inputText: "4"
+- tapOn:
+    point: "77%, 40%"
+- inputText: "2"
+- hideKeyboard
 - extendedWaitUntil:
     notVisible: "__wait_for_post_otp__"
-    timeout: 15000
+    timeout: 20000
     optional: true


### PR DESCRIPTION
## Summary
Follow-up to #15. The original Maestro infrastructure shipped sentinel-only assertions — flows passed without actually advancing screens. This PR fixes the login helpers so 10 of 14 non-manual flows now genuinely drive the UI.

## What's verified
Screenshot-hash diff (distinct MD5 hashes across steps = real transitions):
- 01-launch
- 07-tabs-navigation (5 distinct hashes)
- 08-swipe-like
- 09-swipe-dislike
- 11-messages-list
- 12-chat-conversation (6 distinct hashes)
- 13-profile-view
- 14-profile-edit
- 15-preferences
- 17-location-map

## Known limits
- RN view tree invisible to XCUITest on this app's native config (new arch + react-native-screens GAMMA + portals). Flows verify by screen transition, not content assertion.
- 03/04/05/10 still need coordinate calibration; 16 needs real RevenueCat keys.

## Test plan
- [x] YAML syntax valid
- [x] maestro check-syntax clean
- [x] Per-flow screenshot-hash diff shows real screen advancement