### PR TITLE
fix(mobile): make RevenueCat failures non-fatal (don't crash to global ErrorBoundary)

### DIFF
--- a/apps/mobile/src/hooks/usePayments.tsx
+++ b/apps/mobile/src/hooks/usePayments.tsx
@@ -103,7 +103,13 @@ export const useOfferings = () => {
 // Automatically initialize the payments service
 payments.init();
 
-// Automatically update the query data when the customer info changes
-payments.addCustomerInfoUpdateListener(async (customerInfo: CustomerInfo) => {
-  queryClient.setQueryData([PaymentCacheKey.CustomerInfo], customerInfo);
-});
+// Automatically update the query data when the customer info changes.
+// Guarded so that a misbehaving / unconfigured RevenueCat (e.g. stub API key)
+// can't take down the rest of the app at module-import time.
+try {
+  payments.addCustomerInfoUpdateListener(async (customerInfo: CustomerInfo) => {
+    queryClient.setQueryData([PaymentCacheKey.CustomerInfo], customerInfo);
+  });
+} catch {
+  // Listener attach failed (e.g. RC not configured because of stub API key). Safe to ignore.
+}

--- a/apps/mobile/src/services/payments/index.ts
+++ b/apps/mobile/src/services/payments/index.ts
@@ -22,12 +22,38 @@ const revenueCatApiKey = Platform.select({
   default: "", // This is not used, but it's needed to make TypeScript happy
 });
 
+/**
+ * Some build environments (CI, local sims, preview builds) ship with placeholder
+ * RevenueCat keys (e.g. "ci-stub", "placeholder_revenuecat", empty). RevenueCat
+ * throws on every call when the key is invalid, which would crash the app to
+ * the global ErrorBoundary if a useSuspenseQuery hook propagated the error.
+ * Detect those keys up-front so the payments service can degrade gracefully
+ * without making real network calls. Real RevenueCat iOS keys start with
+ * "appl_" and Android keys start with "goog_".
+ */
+const isStubRevenueCatKey =
+  !revenueCatApiKey ||
+  revenueCatApiKey === "ci-stub" ||
+  revenueCatApiKey.startsWith("ci-stub") ||
+  revenueCatApiKey.startsWith("placeholder") ||
+  (!revenueCatApiKey.startsWith("appl_") && !revenueCatApiKey.startsWith("goog_"));
+
 const init = () => {
   if (__DEV__) {
     Purchases.setLogLevel(LOG_LEVEL.VERBOSE).catch(sendError);
   }
 
-  Purchases.configure({ apiKey: revenueCatApiKey });
+  if (isStubRevenueCatKey) {
+    // Skip configure with a known-bad key. Every subsequent call would otherwise
+    // throw "Invalid API Key" and propagate through the suspense boundary.
+    return;
+  }
+
+  try {
+    Purchases.configure({ apiKey: revenueCatApiKey });
+  } catch (error) {
+    sendError(error);
+  }
 };
 
 const logIn = async () => {
@@ -37,30 +63,64 @@ const logIn = async () => {
     throw new Error("Make sure the login is only called when the user is authenticated");
   }
 
-  const userData = await Purchases.logIn(userID);
+  if (isStubRevenueCatKey) {
+    return null;
+  }
 
-  queryClient.setQueryData([PaymentCacheKey.CustomerInfo], () => userData.customerInfo);
+  try {
+    const userData = await Purchases.logIn(userID);
 
-  // Asynchronously set the email and display name
-  getTrcpContext()
-    .myDog.get.fetch()
-    .then(async (response) => {
-      await Purchases.setEmail(response?.user.email ?? "");
-      await Purchases.setDisplayName(response?.name ?? "");
-    })
-    .catch(sendError);
+    queryClient.setQueryData([PaymentCacheKey.CustomerInfo], () => userData.customerInfo);
 
-  return userData;
+    // Asynchronously set the email and display name
+    getTrcpContext()
+      .myDog.get.fetch()
+      .then(async (response) => {
+        await Purchases.setEmail(response?.user.email ?? "");
+        await Purchases.setDisplayName(response?.name ?? "");
+      })
+      .catch(sendError);
+
+    return userData;
+  } catch (error) {
+    // RevenueCat login can fail in CI/preview builds with placeholder API keys,
+    // or for transient backend issues. Swallow the error so the rest of the app
+    // (swipe, messages, profile) stays usable. Premium features will be unavailable.
+    sendError(error);
+    return null;
+  }
 };
 
 const getOfferings = async () => {
-  const offerings = await Purchases.getOfferings();
-
-  if (!offerings.current) {
-    throw new Error("No offerings available");
+  if (isStubRevenueCatKey) {
+    return null;
   }
 
-  return offerings.current;
+  try {
+    const offerings = await Purchases.getOfferings();
+
+    if (!offerings.current) {
+      return null;
+    }
+
+    return offerings.current;
+  } catch (error) {
+    sendError(error);
+    return null;
+  }
+};
+
+const getCustomerInfo = async (): Promise<CustomerInfo | null> => {
+  if (isStubRevenueCatKey) {
+    return null;
+  }
+
+  try {
+    return await Purchases.getCustomerInfo();
+  } catch (error) {
+    sendError(error);
+    return null;
+  }
 };
 
 export enum ProductIdentifier {
@@ -112,7 +172,7 @@ const getPlanByEntitlement = (entitlement: Entitlement) => {
   }
 };
 
-const getPlan = (customerInfo?: CustomerInfo) => {
+const getPlan = (customerInfo?: CustomerInfo | null) => {
   if (!customerInfo) {
     return undefined;
   }
@@ -152,6 +212,6 @@ export const payments = {
   logIn,
   restorePurchases: restorePurchases,
   logOut: Purchases.logOut,
-  getCustomerInfo: Purchases.getCustomerInfo,
+  getCustomerInfo,
   addCustomerInfoUpdateListener: Purchases.addCustomerInfoUpdateListener,
 };


### PR DESCRIPTION
## Summary
- Maestro caught a real bug: after login the app crashed straight to the global Bugsnag ErrorBoundary "Oops, something went wrong" screen, blocking access to swipe / messages / profile.
- Root cause: `Purchases.logIn` / `getCustomerInfo` / `getOfferings` throw `Invalid API Key` whenever the build ships with a placeholder RevenueCat key (`ci-stub`, `placeholder_revenuecat`, empty). Those throws come out of `useSuspenseQuery` hooks in `apps/mobile/src/hooks/usePayments.tsx`, bubble through `Suspense`, and trip the top-level `BugsnagErrorBoundary` in `NetworkBoundary` (mounted in `src/app/_layout.tsx`). Confirmed via device log: `[RevenueCat] There was a credentials issue ... Invalid API Key.`
- Fix: detect stub/invalid keys up-front (real iOS keys start with `appl_`, Android with `goog_`); skip `Purchases.configure` entirely in that case, and wrap the query functions in `try/catch` returning `null`. Consumers (`UpgradeWall`, `CurrentPlanConfig`, `SwipeBackButton`, `useEligibleForTrial`) already optional-chain the data and fall back to the Free plan, so no consumer-side changes are needed beyond widening `getPlan()` to accept `null`.

## Test plan
- [x] `pnpm exec tsc --noEmit` in `apps/mobile` passes
- [x] Local Release iOS build + reinstall on iPhone 17 Pro Max sim (iOS 26.4)
- [x] Maestro flow (`launchApp + login-returning + screenshot`) confirms post-login screen is the **Swipe tab with empty-deck state**, not the Oops screen. Screenshot hash `8f9da3dfe87a8846726bc085b0278e13` differs from known-bad Oops hash `6bcedeb81a35b131e9d52557c99dcedf`.
- [ ] CI typecheck (`Branch Checkup`)