### PR TITLE
fix(mobile): swipe screen top inset color

### DIFF
--- a/apps/mobile/src/views/(tabs)/Swipe/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/index.tsx
@@ -71,7 +71,7 @@ const Matches = () => {
   }, [dispatch]);
 
   return (
-    <Container style={{ marginTop: topInset }}>
+    <Container style={{ paddingTop: topInset }}>
       <ChangeLocation />
       <Container>
         <SwipeBackButton />


### PR DESCRIPTION
## Summary
Maestro+human caught a grey #F2F2F7 strip in the Swipe tab status-bar inset where it should match the white Container background.

One-line fix on the SafeAreaView Container in `apps/mobile/src/views/(tabs)/Swipe/index.tsx`:

```diff
-<Container style={{ marginTop: topInset }}>
+<Container style={{ paddingTop: topInset }}>
```

The Container is a `SafeAreaView` with `edges: ["left","right"]` (top excluded so the screen handles it) and `background-color: theme.colors.background` (white in light mode). `marginTop` pushed the white background DOWN, exposing the iOS system grey through the inset. `paddingTop` keeps the same `ChangeLocation` offset while letting the white SafeAreaView background fill the inset region.

## Test plan
- [x] Verified on iPhone 17 Pro Max sim (iOS 26.4) post-fix screenshot: status bar inset now white, matching the header
- [x] Other tabs unaffected (Messages uses KeyboardAvoidingView, Profile uses its own animated background)