### PR TITLE
chore(test): auto-seed Maestro DB state on every flow

### DIFF
--- a/apps/mobile/.maestro/README.md
+++ b/apps/mobile/.maestro/README.md
@@ -45,15 +45,38 @@
 
 ## Running locally
 
-Boot an iOS simulator and install the debug build, then:
+Boot an iOS simulator and install the debug build, then use the wrapper
+script — it seeds the local Postgres into a known-good state before
+invoking `maestro test` so every run starts deterministically (12 dogs
+near SF, magic user `test@pegada.app` with Rex, Rex<->Bella match + 2
+chat messages, OTP `424242` valid on every test user):
 
 ```sh
 # Run all flows
-maestro test apps/mobile/.maestro/
+apps/mobile/.maestro/scripts/run-flow.sh apps/mobile/.maestro/
 
 # Run a single flow
-maestro test apps/mobile/.maestro/launch.yaml
+apps/mobile/.maestro/scripts/run-flow.sh apps/mobile/.maestro/B-returning-user-tabs-tour.yaml
 ```
+
+Calling `maestro test` directly still works but you must run the seed
+yourself first (otherwise the swipe deck will be empty and the matches
+the flows assert on will be missing):
+
+```sh
+DATABASE_URL='postgresql://tony:hawk@localhost:3356/pegada' \
+  pnpm -F @pegada/database maestro:seed
+maestro test apps/mobile/.maestro/
+```
+
+> ### Why a wrapper script and not `runScript:` inside each YAML?
+>
+> Maestro's `- runScript:` step only executes JavaScript inside a
+> sandboxed GraalJS runtime — no shell exec, no process spawn, no file
+> I/O. The seed needs `tsx` + `@prisma/client` + a live Postgres
+> connection, which the JS sandbox cannot provide. Wrapping
+> `maestro test` mirrors the pattern other E2E tools (Playwright's
+> `globalSetup`, Jest's `setupFiles`) use for this exact problem.
 
 ## Flows
 

--- a/apps/mobile/.maestro/scripts/run-flow.sh
+++ b/apps/mobile/.maestro/scripts/run-flow.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Maestro test entry point with automatic DB seeding.
+#
+# Reason this exists: Maestro's `runScript:` step only executes JavaScript
+# inside a sandboxed GraalJS runtime with no shell / process exec / file
+# I/O access. We need to run a `tsx` script that talks to Postgres to put
+# the DB into a known-good state for every flow run, which the JS sandbox
+# cannot do. The cleanest place to hook is here, around the maestro test
+# invocation, mirroring the Playwright `globalSetup` / Jest `setupFiles`
+# pattern.
+#
+# Usage:
+#   apps/mobile/.maestro/scripts/run-flow.sh <flow-file-or-folder> [extra maestro args]
+#
+# Examples:
+#   apps/mobile/.maestro/scripts/run-flow.sh apps/mobile/.maestro/B-returning-user-tabs-tour.yaml
+#   apps/mobile/.maestro/scripts/run-flow.sh apps/mobile/.maestro -e APP_ID=app.pegada
+#
+# The seed step runs once at the top before maestro starts, so every flow
+# in the suite starts from the same DB baseline (12 deck dogs near SF,
+# magic user test@pegada.app with Rex, Rex<->Bella match + 2 chat
+# messages, OTP=424242 on every test user).
+#
+# DATABASE_URL can be overridden in the environment (CI / docker-compose
+# test DB); defaults to local dev Postgres on port 3356.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/seed-before-test.sh"
+
+# Default env vars expected by the flow files. Callers can override.
+export APP_ID="${APP_ID:-app.pegada}"
+export APP_SCHEME="${APP_SCHEME:-pegada}"
+
+exec maestro -e APP_ID="$APP_ID" -e APP_SCHEME="$APP_SCHEME" test "$@"

--- a/apps/mobile/.maestro/scripts/seed-before-test.sh
+++ b/apps/mobile/.maestro/scripts/seed-before-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Maestro pre-test seed hook.
+#
+# Resets the local Postgres into a known-good state for every Maestro flow:
+# 12+ dogs near SF, magic user test@pegada.app with dog Rex, one match
+# Rex<->Bella with 2 messages, and OTP code=424242 for every test user.
+#
+# Idempotent — re-running is a no-op modulo "Rex deck cleared" count.
+#
+# Called via Maestro's `- runScript:` step from inside login.yaml utils.
+# Maestro invokes from the .maestro/ dir, so the cd into the repo root
+# is explicit to make the pnpm invocation deterministic.
+#
+# DATABASE_URL is overridable (e.g. for CI / docker-compose test DB).
+set -euo pipefail
+
+# Resolve repo root from this script's location so the wrapper works
+# from any worktree (the file lives at
+# <repo>/apps/mobile/.maestro/scripts/seed-before-test.sh).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+DATABASE_URL="${DATABASE_URL:-postgresql://tony:hawk@localhost:3356/pegada}"
+
+cd "$REPO_ROOT"
+DATABASE_URL="$DATABASE_URL" pnpm -F @pegada/database maestro:seed >/dev/null 2>&1
+echo "seeded"


### PR DESCRIPTION
## Summary

Promotes the ad-hoc psql / `tsx` setup (14 dogs near SF + magic user `test@pegada.app` with Rex + Rex<->Bella match + 2 chat messages + OTP `424242`) to a tracked, **idempotent** seed script and wires it into a Maestro wrapper. Every flow run now starts with a known-good DB state regardless of prior test residue.

- `packages/database/maestro-seed.ts` — consolidates `more-dogs-seed.ts` + the two `/tmp/` seeds. Uses `upsert` + `findFirst` guards. Clears Rex's stale `Interest` rows (preserves the Bella match) so the swipe deck always repopulates. Resets `code='424242'` / `codeExpiresAt='2030-01-01'` on every test user.
- `packages/database/package.json` — adds `seed:e2e` script.
- `apps/mobile/.maestro/scripts/seed-before-test.sh` — thin wrapper that cd's to repo root (resolved relative to script location, so worktree-safe) and runs `pnpm -F @pegada/database seed:e2e`. `DATABASE_URL` overridable for CI.
- `apps/mobile/.maestro/scripts/run-flow.sh` — canonical Maestro entry: seeds, then `exec maestro test "$@"`. Same pattern as Playwright `globalSetup` / Jest `setupFiles`.
- `apps/mobile/.maestro/README.md` — documents the wrapper + explains why we don't use Maestro's `runScript:` (it executes JS in a sandboxed GraalJS runtime with no shell / process / file-I/O access, so it cannot call `tsx` or open a Postgres connection; verified empirically — `Java.type('java.lang.Runtime')` is blocked, `/bin/bash` scripts passed to `runScript:` are loaded as JS and silently no-op).

### Why a wrapper script, not `runScript:`?

`runScript:` in Maestro 2.5.1 runs JavaScript in GraalJS with `output.X`, `console.log`, and `http.*` available — but **no** shell exec, **no** process spawn, **no** file I/O, and Java reflection is blocked. Spinning a tiny HTTP seed server alongside maestro would work but adds infra; wrapping the test invocation is the standard solution that keeps the seed in this repo's existing TS / Prisma stack.

## Test plan

- [x] `pnpm -F @pegada/database seed:e2e` — first run: creates / heals all rows, ~500ms.
- [x] `pnpm -F @pegada/database seed:e2e` — second run: 0 stale interests cleared, ~50ms (idempotent).
- [x] Mutate `User.code='999999'` then re-run seed -> code reset to `424242`.
- [x] `apps/mobile/.maestro/scripts/seed-before-test.sh` works from any worktree (repo root resolved via `$BASH_SOURCE`).
- [ ] Full `run-flow.sh <flow>` end-to-end probe against the simulator — **NOT run** because other agents were actively driving the sim during this work (per task constraint "DO NOT contend for the sim"). Manual probe needed when sim is free; the seed half of the wrapper is independently verified.