### PR TITLE
fix(mobile): new chat messages appear at the bottom (FlashList v2 inverted drop)

### DIFF
--- a/apps/mobile/.maestro/19-chat-message-order.yaml
+++ b/apps/mobile/.maestro/19-chat-message-order.yaml
@@ -1,0 +1,54 @@
+appId: ${APP_ID}
+name: Chat — new sent message appears at the bottom (regression for FlashList v2 inverted drop)
+tags:
+  - smoke
+  - regression
+---
+# Regression: a user-caught bug where new messages appeared at the TOP of the
+# conversation instead of the BOTTOM. Root cause: FlashList v2 dropped the
+# `inverted` prop; the API returns messages newest-first (DESC), so without
+# reversing in the UI, newest renders at top. Fixed by reversing in
+# useChatPagination so newest is at the bottom adjacent to the Send composer.
+#
+# This flow opens the seeded chat with Bella, sends a unique message, then
+# asserts both the unique text and the OLDEST seeded message ("Hey Bella!")
+# are visible. With the bug active, the oldest is offscreen-above and only
+# the newest two messages render in the visible viewport.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd
+- runFlow: utils/login-returning.yaml
+- waitForAnimationToEnd:
+    timeout: 15000
+- takeScreenshot: 19-after-login
+# Messages tab is at the bottom-center of the tab bar
+- tapOn:
+    point: "50%, 95%"
+- waitForAnimationToEnd
+- takeScreenshot: 19-on-messages
+# First chat row near the top of the list (~50%, 25% Y)
+- tapOn:
+    point: "50%, 25%"
+- waitForAnimationToEnd:
+    timeout: 8000
+- takeScreenshot: 19-on-chat
+# Send a unique new message — it MUST render at the bottom.
+- tapOn:
+    id: "chat-input"
+- waitForAnimationToEnd:
+    timeout: 1000
+- inputText: "REGRESSION_BOTTOM_CHECK"
+- takeScreenshot: 19-typed
+# Send button on the right of the input (~92%, 70% Y when keyboard is up)
+- tapOn:
+    point: "92%, 70%"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: 19-after-send
+# The unique text must be on screen.
+- assertVisible: "REGRESSION_BOTTOM_CHECK"
+# The seeded greeting is the OLDEST message and must appear ABOVE the new
+# message (visible in the viewport, scrolled to top of conversation).
+- assertVisible:
+    text: "Hey Bella! Want to meet up at the dog park?"

--- a/apps/mobile/.maestro/config.yaml
+++ b/apps/mobile/.maestro/config.yaml
@@ -22,3 +22,4 @@ executionOrder:
     - 16-upgrade-wall
     - 17-location-map
     - 18-new-match
+    - 19-chat-message-order

--- a/apps/mobile/src/views/Chat/hooks/useChatPagination.ts
+++ b/apps/mobile/src/views/Chat/hooks/useChatPagination.ts
@@ -46,7 +46,11 @@ export const useChatPagination = () => {
 
   useFetchNewMessages();
 
-  const messages = data ? data.pages.flatMap((page) => page) : [];
+  // API returns messages newest-first (createdAt DESC) for cursor pagination.
+  // FlashList v2 dropped the `inverted` prop, so the list renders top-down.
+  // Reverse so the oldest message renders at the top and the newest renders
+  // at the bottom — adjacent to the Send composer, matching chat UX.
+  const messages = data ? data.pages.flatMap((page) => page).slice().reverse() : [];
 
   return {
     messages,

--- a/apps/mobile/src/views/Chat/hooks/useChatPagination.ts
+++ b/apps/mobile/src/views/Chat/hooks/useChatPagination.ts
@@ -50,7 +50,12 @@ export const useChatPagination = () => {
   // FlashList v2 dropped the `inverted` prop, so the list renders top-down.
   // Reverse so the oldest message renders at the top and the newest renders
   // at the bottom — adjacent to the Send composer, matching chat UX.
-  const messages = data ? data.pages.flatMap((page) => page).slice().reverse() : [];
+  const messages = data
+    ? data.pages
+        .flatMap((page) => page)
+        .slice()
+        .reverse()
+    : [];
 
   return {
     messages,

--- a/apps/mobile/src/views/Chat/index.tsx
+++ b/apps/mobile/src/views/Chat/index.tsx
@@ -40,24 +40,28 @@ const ChatMessageList = () => {
   const topPadding = insets.top + HEADER_HEIGHT + theme.spacing[3];
   const bottomPadding = insets.bottom + SEND_HEIGHT + theme.spacing[3];
 
-  const inverted = !!messages?.length;
-
+  // FlashList v2 dropped the `inverted` prop; the list now always renders
+  // top-down. `useChatPagination` returns messages oldest→newest so the
+  // newest message renders at the bottom (next to the Send composer) and
+  // older history paginates by scrolling up (onStartReached).
   const contentContainerStyle = {
-    paddingVertical: theme.spacing[3],
     paddingHorizontal: theme.spacing[3],
-    paddingBottom: inverted ? topPadding : bottomPadding,
-    paddingTop: inverted ? bottomPadding : topPadding,
+    paddingTop: topPadding,
+    paddingBottom: bottomPadding,
   };
 
   const ListEmptyComponent = () => <Empty />;
 
   const renderItem = ({ item, index }: { item: MessageProps; index: number }) => {
-    // Don't show the date if it's the first message or if it's loading
-    const showNextDay = index !== messages.length - 1 || !hasNextPage;
+    // Show the date separator above this message when the previous (older)
+    // message is on a different day. Hide it for the very first item when
+    // older pages may still load — we don't yet know if it's truly first.
+    const previousMessage = messages?.[index - 1];
+    const showNextDay = index !== 0 || !hasNextPage;
 
     return (
       <>
-        {showNextDay ? <NextDay message={item} nextMessage={messages?.[index + 1]} /> : null}
+        {showNextDay ? <NextDay message={item} nextMessage={previousMessage} /> : null}
         <Message {...item} self={item.senderId !== dogId}>
           {item.content}
         </Message>
@@ -65,17 +69,18 @@ const ChatMessageList = () => {
     );
   };
 
-  // inverted is passed through to the underlying ScrollView; FlashList v2 types don't expose it
+  // Older messages are at the top, so the loading spinner goes in the
+  // header and pagination triggers via onStartReached.
   const flashListProps = {
     contentContainerStyle,
-    inverted,
     data: messages,
     keyExtractor,
-    ListFooterComponent: FooterComponent,
+    ListHeaderComponent: FooterComponent,
     ListEmptyComponent,
     renderItem,
-    onEndReached: loadMore,
-    onEndReachedThreshold: 0.5,
+    onStartReached: loadMore,
+    onStartReachedThreshold: 0.5,
+    maintainVisibleContentPosition: { autoscrollToBottomThreshold: 0.2 },
   };
 
   return (


### PR DESCRIPTION
## Summary

User-caught bug: when sending a new message in Chat, the new message appeared at the **top** of the conversation instead of the **bottom**.

### Root cause

- `MessageService.getMessages` returns messages with `orderBy: { createdAt: "desc" }` — newest at index 0.
- `apps/mobile/package.json` pins `@shopify/flash-list: 2.0.2`.
- **FlashList v2 dropped the `inverted` prop entirely** (zero references in its `dist/`). The UI was passing `inverted={inverted}` via a `as any` cast — silently ignored.
- DESC data + no inversion → newest renders at the top. The optimistic-update prepended to `pages[0]`, so each new send landed at the top of the DESC list.

DB seed timestamps are correct (Rex 03:47:59 → Bella reply 04:12:59); the bug is purely the missing inversion in the UI layer.

### Fix (UI only — small surface change)

- `useChatPagination` reverses the flattened pages so messages flow oldest → newest. Newest message renders adjacent to the Send composer.
- `Chat/index.tsx`:
  - Drop the no-op `inverted` prop and `paddingTop`/`paddingBottom` swap.
  - Move "loading older" spinner from `ListFooterComponent` to `ListHeaderComponent`.
  - Swap `onEndReached` → `onStartReached` so pagination fires when scrolling UP for older history.
  - Enable `maintainVisibleContentPosition.autoscrollToBottomThreshold` so new messages pin to the bottom.
  - Fix `renderItem` date-separator to index the previous (older) message, matching ASC order.

The optimistic-update code (`useSendMessage`, `useFetchNewMessages`) is unchanged — it still prepends to `pages[0]` (DESC slot), which after reversal lands the new message at the end of the displayed list (visual bottom).

## Regression test

`apps/mobile/.maestro/19-chat-message-order.yaml`:

- Logs in as the seeded returning user, opens the chat with Bella.
- Sends a unique `REGRESSION_BOTTOM_CHECK` message.
- Asserts both the new message AND the oldest seeded greeting ("Hey Bella! Want to meet up at the dog park?") are visible — with the bug active, the older message would be scrolled off-screen above the newest pair.

Registered in `apps/mobile/.maestro/config.yaml` `flowsOrder`.

## Test plan

- [ ] CI: e2e-mobile job runs `19-chat-message-order` flow and asserts pass.
- [ ] Manual: open existing chat, send a message → new bubble appears at the bottom next to the input.
- [ ] Manual: open existing chat, scroll up → older history pages in via `onStartReached`; spinner appears at the top.
- [ ] Manual: date separators still render correctly when the seeded history spans multiple days.