### PR TITLE
fix(mobile): surface real error when EditProfile image upload fails

### DIFF
--- a/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import * as React from "react";
-import { ActivityIndicator, Alert } from "react-native";
+import { ActivityIndicator } from "react-native";
+import { magicToast } from "react-native-magic-toast";
 import Animated, { FadeOut, useAnimatedStyle, withSpring } from "react-native-reanimated";
 import { FileSystemUploadType, uploadAsync } from "expo-file-system/legacy";
+import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/native";
 
 import AddRemove from "@/assets/images/AddRemove.svg";
@@ -34,6 +36,7 @@ const hitSlop = {
 
 export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({ picture, onDelete, onAdd }) => {
   const [localPicture, setLocalPicture] = useState(picture.url);
+  const { t } = useTranslation();
 
   const theme = useTheme();
 
@@ -51,6 +54,7 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({ picture, onDelete, o
   };
 
   const handleAdd = async () => {
+    let stage: "pick" | "presign" | "compress" | "upload" | "finalize" = "pick";
     try {
       const selectedImage = await showImagePickerOptions();
 
@@ -58,14 +62,17 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({ picture, onDelete, o
       onAdd({ url: selectedImage.uri });
       setLocalPicture(selectedImage.uri);
 
+      stage = "presign";
       const presignedUrl = await getTrcpContext().image.signedUrl.fetch();
 
       /**
        * Compress the image before uploading. Expensive operation,
        * so we do it only after the visual feedback is shown.
        */
+      stage = "compress";
       const compressedImage = await compressImage(selectedImage.uri);
 
+      stage = "upload";
       const response = await uploadAsync(presignedUrl, compressedImage.uri, {
         mimeType: getMimeType(compressedImage.uri),
         uploadType: FileSystemUploadType.BINARY_CONTENT,
@@ -73,9 +80,10 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({ picture, onDelete, o
       });
 
       if (response.status !== 200) {
-        throw new Error("Failed to upload image");
+        throw new Error(`S3 PUT returned ${response.status}`);
       }
 
+      stage = "finalize";
       const finalUrl = presignedUrl.split("?")[0] as string;
 
       onAdd({ url: finalUrl });
@@ -85,9 +93,28 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({ picture, onDelete, o
         return;
       }
 
-      sendError(err);
+      // Permissions denied — pickImage/takeImage already showed a native alert
+      // explaining what to do. Don't double-toast.
+      if (err instanceof Error && err.message === ImagePickerError.NO_PERMISSION) {
+        handleDelete();
+        return;
+      }
 
-      Alert.alert("Erro ao adicionar imagem");
+      const reason = err instanceof Error ? err.message : String(err);
+
+      const trackedError =
+        err instanceof Error
+          ? Object.assign(err, { context: "ProfileImageUploader.handleAdd", stage })
+          : new Error(`ProfileImageUploader.handleAdd[${stage}]: ${reason}`);
+      sendError(trackedError);
+
+      // Surface a real error to the user (was a silent Portuguese-only Alert).
+      // In dev mode include the underlying reason so devs/QA can debug.
+      if (__DEV__) {
+        magicToast.alert(t("imagePicker.uploadFailedDev", { reason: `[${stage}] ${reason}` }));
+      } else {
+        magicToast.alert(t("imagePicker.uploadFailed"));
+      }
       handleDelete();
     }
   };

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -152,7 +152,9 @@
     "permissionsRequiredMessage": "Please grant the required permissions to access the camera and photo library.",
     "permissionsRequiredTitle": "Sorry, we need these permissions to make this work!",
     "takePhoto": "Take Photo",
-    "title": "What do you prefer?"
+    "title": "What do you prefer?",
+    "uploadFailed": "Couldn't upload image. Please try again.",
+    "uploadFailedDev": "Upload failed: {{reason}}"
   },
   "insertEmail": {
     "accountCode": "We will send a 6-digit code to authorize your account. If you don't have one yet, we'll create it.",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -152,7 +152,9 @@
     "permissionsRequiredMessage": "Por favor, conceda as permissões necessárias para acessar a câmera e a galeria de fotos.",
     "permissionsRequiredTitle": "Desculpe, precisamos dessa permissão para que isso funcione!",
     "takePhoto": "Tirar Foto",
-    "title": "O que você prefere?"
+    "title": "O que você prefere?",
+    "uploadFailed": "Não foi possível enviar a imagem. Tente novamente.",
+    "uploadFailedDev": "Falha no upload: {{reason}}"
   },
   "insertEmail": {
     "accountCode": "Vamos enviar um código de 6 dígitos para autorizar sua conta. Se ainda não tem uma, vamos criá-la.",


### PR DESCRIPTION
## Summary
User reported that adding an image on the Edit Profile screen "just silently fails." The chain is: tap photo slot → pick image → optimistic preview shown → background tries to fetch a presigned S3 URL, compress, and PUT to S3 → on any failure, the only feedback was a hardcoded Portuguese-only native `Alert("Erro ao adicionar imagem")` fired *after* the underlying error was swallowed by `sendError` into Bugsnag, with no stage / reason hint. In environments where AWS keys are stubbed (local dev, CI), the S3 PUT fails and the user sees the cryptic alert — looks like a silent break.

## Changes
- Replace the bare native `Alert` with `magicToast.alert` to match the rest of the screen's UX (the same view already uses `magicToast` for profile-save success / error).
- i18n the message — add `imagePicker.uploadFailed` and `imagePicker.uploadFailedDev` in `en` and `pt-BR`.
- Track the failure stage (`pick` / `presign` / `compress` / `upload` / `finalize`) and attach it to both the toast (in `__DEV__`) and the Bugsnag error, so we can tell at a glance whether the picker, the tRPC route, the manipulator, or S3 failed.
- Stop double-toasting when the picker was canceled or permission denied (permissions flow already shows its own native alert).
- Use the actual S3 status code in the error message (`S3 PUT returned 403`) instead of a generic "Failed to upload image".

No backend / native changes — JS-only, no native rebuild required.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec oxlint` shows no new errors (only pre-existing warnings)
- [x] JS bundle rebuilt via `expo export:embed --platform ios --dev false` — strings `uploadFailed`, `uploadFailedDev`, "Couldn't upload image...", and pt-BR equivalents all present in the bundle
- [ ] On a sim with stubbed AWS creds: tap a photo slot, pick an image, confirm magicToast surfaces `Upload failed: [upload] S3 PUT returned ...` (dev) or `Couldn't upload image. Please try again.` (prod)
- [ ] On a sim with real AWS creds: confirm happy-path upload still works (no regression in success branch)