### PR TITLE
fix(mobile): grey gap at bottom of profile scroll

### DIFF
--- a/apps/mobile/src/views/(tabs)/Profile/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Profile/index.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFocusEffect, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import { useIsFocused, useScrollToTop } from "@react-navigation/native";
 import { t } from "i18next";
 import { useTranslation } from "react-i18next";
@@ -103,6 +104,8 @@ const Profile = () => {
 
   const dogProfileHeight = useDogProfileHeight();
 
+  const tabBarHeight = useBottomTabBarHeight();
+
   return (
     <Container testID="profile-screen">
       {isFocused ? <StatusBar style="light" /> : null}
@@ -122,7 +125,7 @@ const Profile = () => {
         <SettingsList
           bounces={false}
           contentContainerStyle={{
-            paddingBottom: theme.spacing[4],
+            paddingBottom: theme.spacing[4] + tabBarHeight,
             paddingTop: dogProfileHeight - marginTop,
             flexGrow: 1,
             zIndex: 10,

--- a/apps/mobile/src/views/(tabs)/Profile/styles.ts
+++ b/apps/mobile/src/views/(tabs)/Profile/styles.ts
@@ -16,6 +16,7 @@ export const PlanContainer = styled(PressableArea)`
 
 export const ScrollContainer = styled.View`
   overflow: hidden;
+  background-color: ${({ theme }) => theme.colors.background};
 `;
 
 export const SettingsList = styled(Animated.ScrollView)`
@@ -25,6 +26,7 @@ export const SettingsList = styled(Animated.ScrollView)`
 
 export const Container = styled.View.attrs({ accessible: true })`
   flex-grow: 1;
+  background-color: ${({ theme }) => theme.colors.background};
 `;
 
 export const BackgroundProfileContainer = styled.View`


### PR DESCRIPTION
## Summary
Same family as #22. Maestro+human caught a grey strip between the bottom of the Profile content and the floating tab bar, with tab icons faintly visible underneath.

## Fix
- `styles.ts`: paint `Container` + `ScrollContainer` with `theme.colors.background`
- `index.tsx`: pull `useBottomTabBarHeight()` and add it to `SettingsList.contentContainerStyle.paddingBottom` so the scroll content clears the floating tab bar

## Test plan
- [x] Maestro probe: login -> Profile tab -> scroll to bottom -> screenshot confirms no grey strip, settings list ends cleanly above tab bar
- [ ] CI e2e-mobile (continue-on-error)