### PR TITLE
fix(test): Maestro login email tap coord regression

### DIFF
--- a/apps/mobile/.maestro/utils/login-returning.yaml
+++ b/apps/mobile/.maestro/utils/login-returning.yaml
@@ -27,7 +27,7 @@ tags:
 # Email screen: tap email field, type, submit with Enter (Continue button
 # point taps are unreliable on this build).
 - tapOn:
-    point: "50%, 65%"
+    point: "50%, 84%"
 - waitForAnimationToEnd
 - inputText: "test@pegada.app"
 - pressKey: Enter

--- a/apps/mobile/.maestro/utils/login.yaml
+++ b/apps/mobile/.maestro/utils/login.yaml
@@ -24,7 +24,7 @@ tags:
 # The Continue button cannot be hit reliably via point taps on this build;
 # the email TextInput has returnKeyType=Done|next so Enter submits the form.
 - tapOn:
-    point: "50%, 65%"
+    point: "50%, 84%"
 - waitForAnimationToEnd
 - inputText: "test@pegada.app"
 - pressKey: Enter


### PR DESCRIPTION
Email field moved to 84% Y after recent layout fixes (#22 #25 #27). Coord update so login utils don't hang at SignIn.