### PR TITLE
fix(mobile): swipe stack UX (hit target, back nav, seed coverage)

### DIFF
--- a/apps/mobile/.maestro/10-dog-profile.yaml
+++ b/apps/mobile/.maestro/10-dog-profile.yaml
@@ -18,6 +18,11 @@ tags:
 - scroll
 - waitForAnimationToEnd
 - takeScreenshot: 10-after-scroll
-# Close (back arrow top-left)
-- runFlow: utils/back.yaml
+# Close (DogProfile renders its close button as a top-RIGHT glass button,
+# not the standard top-left chevron — tap by testID for stability).
+- tapOn:
+    id: "dog-profile-close"
+- waitForAnimationToEnd
+- assertVisible:
+    id: "swipe-card"
 - takeScreenshot: 10-back-on-swipe

--- a/apps/mobile/.maestro/21-swipe-journey.yaml
+++ b/apps/mobile/.maestro/21-swipe-journey.yaml
@@ -28,6 +28,13 @@ tags:
 #   (21-on-swipe / 21-after-like / 21-after-dislike / 21-after-maybe) for
 #   hash-diff verification that the rendered card actually changed.
 #
+# IMPORTANT: MatchMe sits at the TOP of Rex's deck (priority=1, premium
+# pre-liker — see packages/database/maestro-seed.ts). Liking her would
+# fire the new-match modal and derail this flow. Step 4 below DISLIKES
+# her first to clear her out, then the like/dislike/maybe/report cycle
+# runs against the SwipeDog1..SwipeDog6 nearby pool that keeps the deck
+# populated.
+#
 # Report flow:
 # - reportUser in views/DogProfile/index.tsx fires a native Alert ("Report"
 #   title, "Cancel" / "Yes" buttons). Tapping Yes calls Linking.openURL
@@ -73,14 +80,35 @@ tags:
 - takeScreenshot: 21-profile-scrolled
 
 # --- 3. Back to swipe deck ------------------------------------------------
-- runFlow: utils/back.yaml
+# Tap the DogProfile close button by testID. The standard utils/back.yaml
+# helper assumes a top-LEFT chevron, but DogProfile renders its close as a
+# top-RIGHT glass button (GoBack, align-self: flex-end). Tapping by
+# testID is the only stable anchor across screen sizes / safe-area
+# insets and proves the dedicated close handler fires.
+- tapOn:
+    id: "dog-profile-close"
 - waitForAnimationToEnd:
     timeout: 5000
 - assertVisible:
     id: "swipe-card"
+- assertVisible:
+    id: "swipe-like"
 - takeScreenshot: 21-back-on-swipe
 
-# --- 4. LIKE → deck must advance to a new top card ------------------------
+# --- 4. DISLIKE MatchMe first → clears the pre-liked dog without firing ----
+# the new-match modal. The next top card will be SwipeDog1 (no
+# reciprocal interest), safe to like/maybe/report in subsequent steps.
+- tapOn:
+    id: "swipe-dislike"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible:
+    id: "swipe-card"
+- takeScreenshot: 21-after-dislike-matchme
+
+# --- 5. LIKE → deck must advance to a new top card ------------------------
+# SwipeDog pool dogs have no reciprocal interest, so liking never opens
+# the new-match modal — the deck simply advances.
 - tapOn:
     id: "swipe-like"
 - waitForAnimationToEnd:
@@ -89,7 +117,7 @@ tags:
     id: "swipe-card"
 - takeScreenshot: 21-after-like
 
-# --- 5. DISLIKE → deck advances again -------------------------------------
+# --- 6. DISLIKE → deck advances again -------------------------------------
 - tapOn:
     id: "swipe-dislike"
 - waitForAnimationToEnd:
@@ -98,7 +126,7 @@ tags:
     id: "swipe-card"
 - takeScreenshot: 21-after-dislike
 
-# --- 6. MAYBE (super-like equivalent) → deck advances ---------------------
+# --- 7. MAYBE (super-like equivalent) → deck advances ---------------------
 # Swipe.Maybe is the third direction wired through swipeHandlerRef +
 # MatchActionBar onMaybe in src/components/MatchActionBar/index.tsx.
 - tapOn:
@@ -109,7 +137,7 @@ tags:
     id: "swipe-card"
 - takeScreenshot: 21-after-maybe
 
-# --- 7. Re-open the (now different) top dog's profile to report -----------
+# --- 8. Re-open the (now different) top dog's profile to report -----------
 - tapOn:
     point: "50%, 75%"
 - waitForAnimationToEnd:
@@ -120,7 +148,7 @@ tags:
 - scroll
 - waitForAnimationToEnd
 
-# --- 8. Trigger the report Alert and confirm ------------------------------
+# --- 9. Trigger the report Alert and confirm ------------------------------
 - tapOn:
     id: "dog-profile-report"
 - waitForAnimationToEnd:

--- a/apps/mobile/src/components/MatchActionBar/styles.ts
+++ b/apps/mobile/src/components/MatchActionBar/styles.ts
@@ -9,7 +9,14 @@ import thinkingEmoji from "@/assets/images/ThinkingEmoji.webp";
 import { Image } from "@/components/Image";
 import { PressableArea } from "@/components/PressableArea";
 
+// Apple HIG recommends a minimum 44x44pt hit area for tappable targets.
+const MIN_TOUCH_TARGET = 44;
+
 export const Container = styled(Animated.View).attrs({
+  // box-none keeps the bar itself non-blocking so the card below stays
+  // pannable in the gaps, but lifts the bar above the card visually so
+  // each ActionItem reliably wins taps over the card's PersonalInfo
+  // pressable that sits underneath.
   pointerEvents: "box-none",
 })`
   width: 100%;
@@ -22,13 +29,29 @@ export const Container = styled(Animated.View).attrs({
   align-self: center;
   bottom: ${(props) => props.theme.spacing[6]}px;
   padding: 0 ${(props) => props.theme.spacing[2]}px;
+
+  z-index: 10;
+  elevation: 10;
 `;
 
-export const ActionItem = styled(PressableArea).attrs({ accessible: true })`
+export const ActionItem = styled(PressableArea).attrs({
+  accessible: true,
+  // Hit target expansion so taps that land just outside the visible
+  // button still register on the action, never falling through to the
+  // card's PersonalInfo pressable underneath (which would open the
+  // dog profile instead).
+  hitSlop: { top: 12, bottom: 12, left: 12, right: 12 },
+})`
   padding: ${(props) => props.theme.spacing[2.5]}px;
   background-color: ${(props) => Color(props.theme.colors.primary).alpha(0.1).rgb().string()};
 
   border-radius: ${(props) => props.theme.radii.round}px;
+
+  /* Guarantee the Apple HIG minimum even when the emoji shrinks. */
+  min-width: ${MIN_TOUCH_TARGET}px;
+  min-height: ${MIN_TOUCH_TARGET}px;
+  align-items: center;
+  justify-content: center;
 `;
 
 export const ConfusedEmoji = styled(Image).attrs({

--- a/packages/database/maestro-seed.ts
+++ b/packages/database/maestro-seed.ts
@@ -33,6 +33,7 @@
  */
 
 import { createId } from "@paralleldrive/cuid2";
+import { PlanType } from "@prisma/client";
 
 import prisma from ".";
 import { breedData } from "./__mocks__/breed-data";
@@ -241,6 +242,11 @@ async function ensureBellaWithMatch(rexId: string) {
  * swipe service's `notIn` filter would hide MatchMe from the swipe stack).
  */
 async function ensureMatchMeWithPreLike(rexId: string) {
+  // MatchMe's owner is marked PREMIUM so the SuggestionService priority
+  // column evaluates to 1 (premium pre-liker), which forces MatchMe to the
+  // TOP of Rex's swipe stack ahead of the new SwipeDog pool below — both
+  // sets are co-located in SF (~0km) so they otherwise tie on distance,
+  // and Postgres makes no guarantee about tie ordering.
   const matchMeUser = await prisma.user.upsert({
     where: { email: "test+matchme@pegada.app" },
     update: {
@@ -249,6 +255,7 @@ async function ensureMatchMeWithPreLike(rexId: string) {
       country: "USA",
       latitude: SF.lat,
       longitude: SF.lon,
+      plan: PlanType.PREMIUM,
     },
     create: {
       email: "test+matchme@pegada.app",
@@ -257,6 +264,7 @@ async function ensureMatchMeWithPreLike(rexId: string) {
       country: "USA",
       latitude: SF.lat,
       longitude: SF.lon,
+      plan: PlanType.PREMIUM,
     },
     include: { dogs: { where: { deletedAt: null } } },
   });
@@ -328,11 +336,103 @@ async function ensureMatchMeWithPreLike(rexId: string) {
   return { matchMeUser, matchMe, preLike };
 }
 
+/**
+ * SwipeDogN: a small pool of nearby dogs that keep Rex's swipe deck
+ * populated AFTER MatchMe gets consumed by flow #22 (or any like in
+ * flow #21). Without these, the deck would be empty as soon as Rex
+ * swipes MatchMe — the 100 default-seed fake users live in Brazil
+ * (~9000km from SF) and are filtered out by Rex's 50km
+ * preferredMaxDistance.
+ *
+ * These dogs deliberately have NO reciprocal Interest, so swiping
+ * INTERESTED on them never creates a match — flow #21 can exercise
+ * like / dislike / maybe / report on a fresh card every step without
+ * accidentally triggering the new-match modal.
+ *
+ * Stable names (SwipeDog1..SwipeDogN) and email addresses make the
+ * seed idempotent: re-runs upsert the same rows rather than
+ * duplicating.
+ */
+const SWIPE_DOG_COUNT = 6;
+
+async function ensureSwipePoolDogs(rexId: string) {
+  const created: { name: string; id: string }[] = [];
+
+  for (let i = 1; i <= SWIPE_DOG_COUNT; i++) {
+    const email = `test+swipedog${i}@pegada.app`;
+    const name = `SwipeDog${i}`;
+
+    const user = await prisma.user.upsert({
+      where: { email },
+      update: {
+        city: "San Francisco",
+        state: "CA",
+        country: "USA",
+        latitude: SF.lat,
+        longitude: SF.lon,
+      },
+      create: {
+        email,
+        city: "San Francisco",
+        state: "CA",
+        country: "USA",
+        latitude: SF.lat,
+        longitude: SF.lon,
+      },
+      include: { dogs: { where: { deletedAt: null } } },
+    });
+
+    let dog = user.dogs.find((d) => d.name === name);
+    if (!dog) {
+      dog = await prisma.dog.create({
+        data: {
+          userId: user.id,
+          name,
+          // All FEMALE — Rex is MALE and the SuggestionService preference
+          // filter shows ONLY opposite-gender dogs. Mixing in MALEs would
+          // make half the pool invisible to Rex's stack.
+          gender: "FEMALE",
+          color: "GOLDEN",
+          size: "MEDIUM",
+          weight: 15 + i,
+          breedId: GOLDEN_ID,
+          birthDate: yearsAgo(2 + (i % 4)),
+          bio: `${name} — nearby SF dog seeded to keep Rex's swipe stack populated.`,
+          images: {
+            create: {
+              position: 0,
+              status: "APPROVED",
+              url: `https://placedog.net/640/480?id=${100 + i}`,
+            },
+          },
+        },
+      });
+    }
+
+    // Defensive: ensure NO reciprocal Interest exists from prior runs that
+    // might have flipped one of these dogs into a match. Keeps swiping
+    // INTERESTED on them inert (no new-match modal).
+    await prisma.interest.deleteMany({
+      where: {
+        OR: [
+          { requesterId: dog.id, responderId: rexId },
+          { requesterId: rexId, responderId: dog.id },
+        ],
+      },
+    });
+
+    created.push({ name: dog.name, id: dog.id });
+  }
+
+  return created;
+}
+
 async function seedMain() {
   await ensureBreed();
   const { magic, rex } = await ensureMagicUserWithRex();
   const { bella, match } = await ensureBellaWithMatch(rex.id);
   const { matchMe, preLike } = await ensureMatchMeWithPreLike(rex.id);
+  const swipePool = await ensureSwipePoolDogs(rex.id);
 
   // eslint-disable-next-line no-console
   console.log(
@@ -344,6 +444,7 @@ async function seedMain() {
         bellaMatch: { id: match.id },
         matchMe: { id: matchMe.id, name: matchMe.name },
         matchMePreLike: { id: preLike.id, swipeType: preLike.swipeType },
+        swipePool,
         messageCount: await prisma.message.count({
           where: { matchId: match.id, deletedAt: null },
         }),


### PR DESCRIPTION
## Summary

Three related swipe-stack issues surfaced by Maestro validation of flows
**21** (swipe journey) and **22** (new-match journey). All caused
flow-21 to fail in different ways depending on which step they hit;
fixed together because they all live in the same swipe-UX surface.

### Bug 1 — Like button hit target too small

**Root cause.** `ActionItem` shipped with only `padding: 10px` and no
`hitSlop`. The card's `PersonalInfo` `PressableArea` sits directly
underneath the bar with a huge `padding-bottom: 112px` tap zone. When
the user tapped just outside the visible button (or Maestro's
`tapOn id` resolved to a coordinate near the edge), the tap fell
through to the card and opened the dog profile instead of triggering
the like.

**Fix** — `apps/mobile/src/components/MatchActionBar/styles.ts`:
- Each `ActionItem` declares `hitSlop: 12` on all sides.
- Each `ActionItem` guarantees the Apple HIG 44x44pt minimum
  (`min-width`, `min-height`, centered content).
- `Container` adds `z-index: 10` + `elevation: 10` so the bar
  reliably sits above the card on iOS and Android.
- The `pointerEvents: box-none` on the bar Container is preserved
  on purpose — it keeps the gaps between buttons pannable so
  the card's swipe gesture still works.

### Bug 2 — Close button on dog profile didn't return to deck

**Root cause.** `DogProfile.GoBack` renders as a top-RIGHT
glassmorphism button (`align-self: flex-end`), but flows 10 and 21
used `utils/back.yaml`, which taps the standard top-LEFT chevron
coordinate (10%, 9%). The tap landed on the dog's photo / nothing,
so the close handler never fired and the deck stayed behind the
profile screen. The handler itself (`router.back()`) was correct.

**Fix** — `apps/mobile/.maestro/10-dog-profile.yaml` and
`apps/mobile/.maestro/21-swipe-journey.yaml`: tap by the existing
`dog-profile-close` testID instead of the chevron coordinate. Stable
across screen sizes, safe-area insets, and locale.

### Bug 3 — Deck empty after first like + first like was always a match

**Root cause.** Maestro seed only created MatchMe nearby; the 100
faker users live in Brazil (~9000km, outside Rex's 50km preference).
After Rex liked MatchMe the deck was empty, so flow 21 had no card
to dislike/maybe/report. Worse: because MatchMe carries a
pre-existing reciprocal Interest, the FIRST like always opened the
new-match modal, derailing flow 21.

**Fix** — `packages/database/maestro-seed.ts`:
- New `ensureSwipePoolDogs` provisions `SwipeDog1..SwipeDog6` in SF
  with NO reciprocal interest, so swiping INTERESTED on them is
  inert (no match modal) and the deck stays populated.
- MatchMe's owner is promoted to PREMIUM so the
  `SuggestionService` priority column deterministically pins her at
  the top of Rex's stack ahead of the new pool (both groups
  otherwise tie on distance and Postgres makes no tie-break
  guarantee, which would have made flow 22 flaky).
- All SwipeDogs are FEMALE — Rex is MALE and the preference filter
  shows only opposite-gender dogs.
- Idempotent: re-runs upsert the same email/name combos.

**Flow 21 update.** First action is now a DISLIKE on MatchMe to clear
the pre-liked card without firing the modal, then like/dislike/maybe
run against the SwipeDog pool. Flow 22 is unchanged — MatchMe is
still the first card and liking her still creates the match.

## Test plan

- [ ] `pnpm -F @pegada/database maestro:seed` populates
      MatchMe (PREMIUM) + SwipeDog1..SwipeDog6 in SF.
- [ ] Build Release sim app and run flow 22 — MatchMe is the top
      card, swipe-like opens the new-match modal, chat works.
- [ ] Run flow 21 — DISLIKE clears MatchMe without a modal; like /
      dislike / maybe each advance the deck to a fresh SwipeDogN
      card; dog-profile-close returns to the deck with the next
      card visible; report on a SwipeDogN dismisses without
      breaking the deck.
- [ ] Manually tap the like / dislike / maybe buttons just off-center
      and confirm the dog profile no longer opens by mistake.