### PR TITLE
fix(test): logout flow typo + remove broken .verify shims for logout/delete

### DIFF
--- a/apps/mobile/.maestro/26-logout-journey.yaml
+++ b/apps/mobile/.maestro/26-logout-journey.yaml
@@ -48,10 +48,14 @@ tags:
     id: "profile-logout"
 - waitForAnimationToEnd
 - takeScreenshot: 26-logout-confirm-dialog
-# Native iOS Alert: title "Log out", destructive "Log out" button on the
-# right, "Cancel" on the left. i18n key profile.logout = "Log out".
+# Native iOS Alert presented by Alert.alert in services/handleLogout.tsx.
+# Buttons: destructive "Logout" (right), "Cancel" (left). i18n key
+# profile.logout = "Logout" (one word — see packages/shared/i18n/locales/
+# en/translation.json). Maestro's tapOn:text matches the visible label
+# rendered by the native iOS dialog, which is included in the XCUITest
+# accessibility tree even when the underlying RN view tree is not.
 - tapOn:
-    text: "Log out"
+    text: "Logout"
 - waitForAnimationToEnd:
     timeout: 8000
 - takeScreenshot: 26-after-logout


### PR DESCRIPTION
## Root cause

Maestro validator marked flows **26 (logout)** and **27 (delete-account)** as FAIL. A read-only diagnoser determined neither failure was app code — both were test-harness defects (full diagnosis: `~/Desktop/pegada-e2e-videos/LOGOUT_DELETE_DIAGNOSIS.md`). Two compounding defects:

1. **Primary cause (both flows):** the validator did **not** run the canonical YAML in `.maestro/`. It ran broken `.verify/` shims (`apps/mobile/.maestro/.verify/{26,27}-*.yaml`) that strip `assertVisible:` and replace text/id selectors with hard-coded coordinate taps, built on a wrong premise that the confirm dialogs were custom RN Modals. They are **native `Alert.alert(...)` calls** (`handleLogout.tsx`, `deleteAccount.tsx`, both already on `main` since 158039e) whose buttons are in the XCUITest accessibility tree on iOS 26.

2. **Latent typo in canonical flow 26:** the YAML tapped `text: "Log out"` (two words, with a space). The i18n value `profile.logout` resolves to `"Logout"` (one word — `packages/shared/i18n/locales/en/translation.json:270`). Maestro `tapOn: text:` is an exact-regex match, so the destructive button was never tapped, the dialog stayed open, and `assertVisible: signin-submit` failed.

3. Canonical flow **27** was already correct (taps `text: "Delete"` which matches `profile.delete = "Delete"`).

## Changes

- `apps/mobile/.maestro/26-logout-journey.yaml` (lines 51-54) — `text: "Log out"` → `text: "Logout"`, plus rewritten comments pointing at the i18n source of truth.
- `apps/mobile/.maestro/.verify/{26,27}-*.yaml` — deleted from disk. They were untracked (no PR diff impact) but they were overriding the canonical flows in the validator's harness. Their entire premise (custom RN Modal needing coordinate taps) is wrong.

**No app code changes** — `Alert.alert` was already correct. `handleLogout.tsx` and `deleteAccount.tsx` are untouched.

## Verification

Sim verification was attempted on iPhone 17 Pro Max (iOS 26.4, sim UDID `6351098E-…`, build app.pegada 1.3.1). Locale pinned to en-US, DB re-seeded (`pnpm -F @pegada/database maestro:seed` confirms `delete-me@pegada.app` is present).

**Result: blocked by an unrelated pre-existing utility bug in `apps/mobile/.maestro/utils/login-returning.yaml`.** The `tapOn: point: "50%, 84%"` (introduced in d807d1c "Maestro login email tap coord 65% -> 84%") lands inside the iOS keyboard region on this resolution — it types a `v` into the focused email field, so `inputText: "test@pegada.app"` produces `vtest@pegada.app`. The OTP screen then shows the wrong email, magic-code auth fails silently, the test never reaches the Profile screen, and `scrollUntilVisible id: profile-logout` errors out.

Evidence: `/Users/gabrieltaveira/.maestro/tests/2026-05-20_110307/screenshot-…1779285837598-(26-logout-journey.yaml).png` shows `vtest@pegada.app` on the OTP screen with empty OTP cells, captured after `runFlow: utils/login-returning.yaml` reported COMPLETED (the sub-flow does not actually verify login success).

This is a separate defect in another flow's utility, not in 26 or 27. Per the hard rule "If sim verification reveals additional bugs, file as separate issue, do NOT bundle into this PR" — leaving this fix scoped to the test correctness changes the diagnoser identified with HIGH confidence.

**Direct evidence the typo fix is correct** — diagnoser's smoking-gun screenshot `~/.maestro/tests/2026-05-19_203407/screenshot-…1779233706913-(26-logout-journey.yaml).png` (captured by a prior canonical-flow run that *did* reach the dialog) shows the iOS Alert with `Cancel | Logout` buttons in English. The "Logout" label is what `tapOn: text: "Logout"` will now match.

## DB verification (preflight)

```
$ PGPASSWORD=hawk psql -h localhost -p 3356 -U tony -d pegada -c \
    'SELECT id, email, "deletedAt" FROM "User" WHERE email IN (...)'
            id             |        email         | deletedAt
---------------------------+----------------------+-----------
 cmpd50h2s0000tfxk2oaxqj0c | test@pegada.app      |
 cmpd9wemb0001i38n5zfzyjtw | delete-me@pegada.app |
(2 rows)
```

Seed is wired correctly and `delete-me@pegada.app` is present pre-test. The post-test hard-delete assertion (`SELECT … WHERE email = 'delete-me@pegada.app'` returns 0 rows) couldn't be exercised because the test never reached the delete confirmation due to the upstream login-utility bug.

## Test plan

- [ ] Once `utils/login-returning.yaml` keyboard-tap bug is fixed (separate issue/PR), re-run `maestro test apps/mobile/.maestro/26-logout-journey.yaml` against a clean en-US sim — expect PASS.
- [ ] Same for `27-delete-account-journey.yaml` with the seed wrapper.
- [ ] After flow 27 PASS, verify `SELECT … WHERE email = 'delete-me@pegada.app'` returns 0 rows.
- [ ] CI green on `e2e-mobile.yml` once the login utility is fixed.