### PR TITLE
fix(test): Maestro login utility taps keyboard region on iPhone 17 Pro Max iOS 26

### DIFF
--- a/apps/mobile/.maestro/utils/login-delete-me.yaml
+++ b/apps/mobile/.maestro/utils/login-delete-me.yaml
@@ -28,13 +28,29 @@ tags:
     optional: true
 # Email screen: tap the email field, type, then tap Continue (above keyboard).
 # pressKey:Enter does not advance to OTP on iOS 26 + RN Fabric.
-# Continue button sits at ~59% Y when keyboard is open.
+#
+# Calibration (issue #40): with the autoFocus keyboard open on iPhone 17
+# Pro Max iOS 26 the keyboard takes the bottom ~29% of the viewport
+# (Y ≥ 71%). The OLD coord `50%, 84%` landed on the `v` key inside the
+# keyboard, prepending a stray `v` to the typed email. Pixel-measured
+# coords from a 1320×2868 keyboard-up screenshot:
+#   - email TextInput vertical center ≈ 53% Y
+#   - Continue button vertical center ≈ 62% Y
+#   - keyboard top edge ≈ 71% Y
 - tapOn:
-    point: "50%, 84%"
+    point: "50%, 53%"
+- waitForAnimationToEnd
+# Defense-in-depth for issue #40: if a future calibration drift puts the
+# focus tap inside the keyboard region, that tap types a stray character
+# into the field. Erase 50 chars (well above any sane manual prefix) so
+# the field is empty before we input the real email — otherwise a stray
+# `v` would yield `vdelete-me@pegada.app` which is NOT in
+# APPLE_MAGIC_EMAIL and the downstream 424242 submit is rejected.
+- eraseText: 50
 - waitForAnimationToEnd
 - inputText: "delete-me@pegada.app"
 - tapOn:
-    point: "50%, 59%"
+    point: "50%, 62%"
 - waitForAnimationToEnd:
     timeout: 8000
 # ATT dialog fires asynchronously after email submit — dismiss before OTP.
@@ -45,6 +61,15 @@ tags:
     text: "Don.t Allow"
     optional: true
 - waitForAnimationToEnd
+# Regression guard for issue #40: if the email tap lands in the keyboard
+# (as the OLD 84% coord did with the v-key), inputText prepends junk to
+# the email, the magic-email check rejects it, and the flow gets stuck on
+# the email screen with a QWERTY keyboard. The OTP screen swaps in iOS's
+# system number-pad which exposes a "Next" accessory button that XCUITest
+# CAN see even though app-rendered RN text cannot. Assert it here so a
+# coord regression fails LOUDLY at the utility level instead of cascading
+# into "OTP cells never filled" timeouts in every dependent flow.
+- assertVisible: "Next"
 # OTP: first cell does not auto-focus on iOS 26 — tap center of OTP row
 # then enter digits. Same pattern as utils/login-returning.yaml.
 - tapOn:

--- a/apps/mobile/.maestro/utils/login-fresh.yaml
+++ b/apps/mobile/.maestro/utils/login-fresh.yaml
@@ -22,17 +22,34 @@ tags:
 # Caller MUST have launchApp'd already with `clearState: true` and
 # `clearKeychain: true`.
 #
-# Coordinates calibrated on iPhone 17 Pro Max (440x956 logical) — see
-# utils/login.yaml for the rationale on point-based taps + per-digit OTP entry.
+# Coordinates calibrated on iPhone 17 Pro Max (440x956 logical, 1320x2868 px)
+# — see utils/login.yaml for the rationale on point-based taps + per-digit
+# OTP entry.
+#
 # Email screen: tap field (point fallback for RN Fabric/iOS 26 hierarchy gap).
+# Calibration (issue #40): with the autoFocus keyboard open the keyboard
+# occupies the bottom ~29% (Y ≥ 71%). The OLD coord `50%, 84%` was inside
+# the keyboard's `v` key, prepending a stray `v` to the typed email and
+# poisoning the magic-email check downstream. Pixel-measured coords from
+# a keyboard-up screenshot:
+#   - email TextInput vertical center ≈ 53% Y
+#   - Continue button vertical center ≈ 62% Y
 - tapOn:
-    point: "50%, 84%"
+    point: "50%, 53%"
+- waitForAnimationToEnd
+# Defense-in-depth for issue #40: if a future calibration drift puts the
+# focus tap inside the keyboard region, that tap types a stray character
+# into the field. Erase 50 chars (well above any sane manual prefix) so
+# the field is empty before we input the real email — otherwise a stray
+# `v` would yield `vmaestro-fresh@pegada.app` which falls OUTSIDE the
+# APPLE_MAGIC_EMAIL_REGEX bypass and the OTP submit gets rejected.
+- eraseText: 50
 - waitForAnimationToEnd
 - inputText: "maestro-fresh@pegada.app"
 # iOS 26: pressKey: Enter does NOT advance from email → OTP screen.
-# Tap the "Continue" button that sits above the keyboard (~59% Y).
+# Tap the "Continue" button that sits above the keyboard.
 - tapOn:
-    point: "50%, 59%"
+    point: "50%, 62%"
 - waitForAnimationToEnd:
     timeout: 8000
 # ATT dialog fires asynchronously after email submit and can block the OTP
@@ -44,6 +61,15 @@ tags:
     text: "Don.t Allow"
     optional: true
 - waitForAnimationToEnd
+# Regression guard for issue #40: if the email tap lands in the keyboard
+# (as the OLD 84% coord did with the v-key), inputText prepends junk to
+# the email, the magic-email regex rejects it, and the flow gets stuck on
+# the email screen with a QWERTY keyboard. The OTP screen swaps in iOS's
+# system number-pad which exposes a "Next" accessory button that XCUITest
+# CAN see even though app-rendered RN text cannot. Assert it here so a
+# coord regression fails LOUDLY at the utility level instead of cascading
+# into "OTP cells never filled" timeouts in every dependent flow.
+- assertVisible: "Next"
 # iOS 26: first OTP cell does not auto-focus. Tap center of OTP row first.
 - tapOn:
     point: "50%, 43%"

--- a/apps/mobile/.maestro/utils/login-returning.yaml
+++ b/apps/mobile/.maestro/utils/login-returning.yaml
@@ -26,14 +26,32 @@ tags:
     optional: true
 # Email screen: tap email field, type, then tap Continue (above keyboard).
 # pressKey:Enter is NOT used — on iOS 26 it does not dismiss the keyboard
-# or advance to OTP. The Continue button sits at ~59% Y when keyboard is
-# open (keyboard occupies the bottom ~40% of the viewport).
+# or advance to OTP.
+#
+# Calibration (issue #40): with the autoFocus keyboard open on iPhone 17
+# Pro Max iOS 26 the keyboard occupies the bottom ~29% of the viewport
+# (Y ≥ 71%). Tapping the OLD coord `50%, 84%` landed on the `v` key in
+# the keyboard's `c v b n m` row, prepending a stray `v` to the typed
+# email and breaking the magic-email check downstream. Pixel-measured
+# from a 1320×2868 screenshot with the keyboard up:
+#   - email TextInput vertical center ≈ Y 1540 / 2868 = 53%
+#   - Continue button vertical center ≈ Y 1770 / 2868 = 62%
+#   - keyboard top edge ≈ Y 2040 / 2868 = 71%
 - tapOn:
-    point: "50%, 84%"
+    point: "50%, 53%"
+- waitForAnimationToEnd
+# Defense-in-depth for issue #40: if a future calibration drift puts the
+# focus tap inside the keyboard region, that tap types a stray character
+# into the field (e.g. the original bug typed `v`, producing
+# `vtest@pegada.app` which is NOT a magic email — code rotates and the
+# downstream 424242 OTP submit is rejected). Erase 50 chars (well above
+# any sane manual prefix) so the field is empty before we input the real
+# email.
+- eraseText: 50
 - waitForAnimationToEnd
 - inputText: "test@pegada.app"
 - tapOn:
-    point: "50%, 59%"
+    point: "50%, 62%"
 - waitForAnimationToEnd:
     timeout: 8000
 # ATT dialog fires asynchronously during OTP screen load — dismiss it
@@ -45,6 +63,15 @@ tags:
     text: "Don.t Allow"
     optional: true
 - waitForAnimationToEnd
+# Regression guard for issue #40: if the email tap lands in the keyboard
+# (as the OLD 84% coord did with the v-key), inputText prepends junk to
+# the email, the magic-email check rejects it, and the flow gets stuck on
+# the email screen with a QWERTY keyboard. The OTP screen swaps in iOS's
+# system number-pad which exposes a "Next" accessory button that XCUITest
+# CAN see even though app-rendered RN text cannot. Assert it here so a
+# coord regression fails LOUDLY at the utility level instead of cascading
+# into "OTP cells never filled" timeouts in every dependent flow.
+- assertVisible: "Next"
 # OTP: on iOS 26 + RN Fabric the first OTP cell does NOT receive focus
 # automatically after screen transition. Tap center of OTP row (~50%,43%)
 # then enter all 6 digits as a single string.

--- a/apps/mobile/.maestro/utils/login.yaml
+++ b/apps/mobile/.maestro/utils/login.yaml
@@ -20,15 +20,42 @@ tags:
 - tapOn:
     text: "Don.t Allow"
     optional: true
-# Email screen: tap email field, type address, submit with Enter.
-# The Continue button cannot be hit reliably via point taps on this build;
-# the email TextInput has returnKeyType=Done|next so Enter submits the form.
+# Email screen: tap email field, type address, then tap Continue.
+#
+# Calibration (issue #40): with the autoFocus keyboard open on iPhone 17
+# Pro Max iOS 26 the keyboard occupies the bottom ~29% of the viewport
+# (Y ≥ 71%). The OLD coord `50%, 84%` landed inside the keyboard's `v`
+# key, prepending a stray `v` to the typed email. Pixel-measured coords
+# from a 1320×2868 keyboard-up screenshot:
+#   - email TextInput vertical center ≈ 53% Y
+#   - Continue button vertical center ≈ 62% Y
+#
+# pressKey:Enter was previously used here because the Continue tap was
+# (mis-)calibrated to the keyboard region; with the correct Continue
+# coord the explicit tap is reliable across iOS 26 + RN Fabric where
+# pressKey:Enter does not always advance.
 - tapOn:
-    point: "50%, 84%"
+    point: "50%, 53%"
+- waitForAnimationToEnd
+# Defense-in-depth for issue #40: if a future calibration drift puts the
+# focus tap inside the keyboard region, that tap types a stray character
+# into the field. Erase 50 chars (well above any sane manual prefix) so
+# the field is empty before we input the real email.
+- eraseText: 50
 - waitForAnimationToEnd
 - inputText: "test@pegada.app"
-- pressKey: Enter
+- tapOn:
+    point: "50%, 62%"
 - waitForAnimationToEnd
+# Regression guard for issue #40: if the email tap lands in the keyboard
+# (as the OLD 84% coord did with the v-key), inputText prepends junk to
+# the email, the magic-email check rejects it, and the flow gets stuck on
+# the email screen with a QWERTY keyboard. The OTP screen swaps in iOS's
+# system number-pad which exposes a "Next" accessory button that XCUITest
+# CAN see even though app-rendered RN text cannot. Assert it here so a
+# coord regression fails LOUDLY at the utility level instead of cascading
+# into "OTP cells never filled" timeouts in every dependent flow.
+- assertVisible: "Next"
 # OTP screen: first digit cell autoFocuses (isFirst=true).
 # Each cell is a separate TextInput with maxLength=6, so OtpInput.handleChange
 # concatenates into shared `value` state and advances focus as digits accumulate.


### PR DESCRIPTION
## Summary

Fixes #40.

The login utilities tapped `50%, 84%` to focus the email field. With autoFocus + the iOS 26 keyboard up, that coord lands inside the keyboard's `v` key — `inputText` then prepended `v` to the typed email, producing `vtest@pegada.app`. That address is not a magic email, so the API rotated a fresh OTP and rejected `424242`, leaving every downstream flow stuck on the OTP screen.

## Root cause

Pixel-measured the email screen with the keyboard up on iPhone 17 Pro Max iOS 26.4 (1320×2868):

| element | coord |
|---|---|
| email TextInput center | 53% Y |
| Continue button center | 62% Y |
| keyboard top edge | 71% Y |
| `v` key (where the old 84% landed) | 84% Y |

## Fix choice — Option B (calibrated coords) + defense

Per the issue's three options:

- **Option A (testID)** — REJECTED. Empirically re-verified on sim: `tapOn: { id: "signin-email" }` still returns `Element not found` on iOS 26 + RN Fabric. The same applies to `assertVisible: text` against app-rendered RN elements — the RN view tree remains invisible to XCUITest's accessibility snapshot for this app build. (This forecloses the broader testID strategy for now; coord-based interaction stays as the only option.)
- **Option B (calibrated coords)** — CHOSEN. Pixel-measured the field + button positions and updated all four login utilities.
- **Option C (hideKeyboard)** — feasible but adds keyboard-bounce visual noise. Kept the autoFocus keyboard up and just re-aimed the taps above it.

## Defense-in-depth

Two regression guards were added inside each utility so a future drift fails LOUDLY at the utility level instead of cascading into "OTP cells never filled" timeouts in every dependent flow:

1. **`eraseText: 50`** immediately after the focus tap — clears any junk a future mis-calibrated tap might inject before the real email is typed. Verified on sim: even when the BUG coord `50%, 84%` is re-introduced, the email field still ends up exactly `test@pegada.app` (no leading `v`) after `eraseText`.
2. **`assertVisible: "Next"`** after the email submit — the iOS system numeric keypad on the OTP screen exposes a "Next" accessory button that XCUITest CAN see, unlike RN-rendered text. If a future regression keeps us on the email screen (QWERTY keyboard), the assertion fails immediately at the utility boundary.

## Diff scope

- `apps/mobile/.maestro/utils/login.yaml`
- `apps/mobile/.maestro/utils/login-returning.yaml`
- `apps/mobile/.maestro/utils/login-fresh.yaml`
- `apps/mobile/.maestro/utils/login-delete-me.yaml`

No other flows or app code were modified.

## Sim verification

- Device: iPhone 17 Pro Max — iOS 26.4 simulator
- Locale: pinned to `en-US`
- Build: existing Release `app.pegada` installed
- Seed: `DATABASE_URL='postgresql://tony:hawk@localhost:3356/pegada' pnpm -F @pegada/database maestro:seed`
- Probe ran the patched `login-returning.yaml`. Result:
  ```
  Tap on point (50%, 53%)... COMPLETED
  Erase 50 characters... COMPLETED
  Input text test@pegada.app... COMPLETED
  Tap on point (50%, 62%)... COMPLETED
  Assert that "Next" is visible... COMPLETED
  ```
- OTP screen showed `Insert the verification code we sent to: test@pegada.app` (NOT `vtest@pegada.app`) — confirmed via screenshot.
- After 6 digits, app routed to the swipe tabs with the seeded "MatchMe" dog visible.
- Video: `~/Desktop/pegada-e2e-videos/login-util-FIXED.mp4`

## Test plan

- [ ] CI runs the full suite (every login-using flow) and the `assertVisible: "Next"` guard passes on each.
- [ ] If maestro upgrades or RN/Fabric exposes the view tree in a future iOS, revisit Option A (testID-based) for an even more robust fix.