### PR TITLE
chore: gitignore local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,15 @@ build/**
 
 .env.dev
 .env.prod
+.env.production
+
+# Claude Code local state (worktrees, local settings)
+.claude/worktrees/
+.claude/settings.local.json
+
+# Maestro run artifacts (screenshots land in the CWD of the run)
+/*.png
+apps/mobile/.maestro/.verify/
 
 dist/
 build/


### PR DESCRIPTION
Stops local-only files from ever showing up in diffs:

- `.env.production` (real keys, was untracked and one `git add -A` away from leaking)
- root `/*.png` Maestro run screenshots
- `apps/mobile/.maestro/.verify/` scratch flows
- `.claude/worktrees/` + local settings

Also removed (untracked, so no diff): a stray root `ios/` prebuild + `app.json` that came from running `expo prebuild` at the workspace root, ~90 root screenshots, and two orphaned experiment files (`apps/mobile/shims/node-module.js`, `packages/database/magic-seed.ts`).

https://claude.ai/code/session_01HqEcc4pgUbJHoym9kiPd8Y