### PR TITLE
fix(mobile): Hermes import.meta transform (unblocks EAS builds)

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -2,7 +2,7 @@ module.exports = (api) => {
   api.cache(true);
 
   return {
-    presets: ["babel-preset-expo"],
+    presets: [["babel-preset-expo", { unstable_transformImportMeta: true }]],
     plugins: [
       "babel-plugin-styled-components",
       "react-native-reanimated/plugin", // NOTE: this plugin MUST be last


### PR DESCRIPTION
## Why

Fix for the `import.meta` build breaker reported against SDK-55 production builds (Hermes doesn't support `import.meta`, and Metro hard-fails bundling if it hits one). One-line babel-preset-expo option turns on the transform so Hermes never sees the raw syntax.

I could not reproduce the failure locally. `npx expo export --platform android` bundles clean both with and without this change (3605 modules, no `import.meta` error), and I couldn't find a literal `import.meta` anywhere in `react-native-magic-modal@7.0.2`'s shipped dist or its resolved peer deps (worklets, reanimated, gesture-handler) in this repo's lockfile. The failure may be EAS/iOS-specific, or tied to a different bundling path than `expo export` exercises locally.

## Testing steps

1. Kick off a production build for the app.
2. Confirm the build gets past the JS bundling step without an `import.meta` error.

https://claude.ai/code/session_01DiAd7HvAMJn9KZtGEex4qr