### PR TITLE
fix(vercel): register queue triggers from repo-root vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "src/app/api/queues/mail/route.ts": {
+    "apps/nextjs/src/app/api/queues/mail/route.ts": {
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",
@@ -10,7 +10,7 @@
         }
       ]
     },
-    "src/app/api/queues/process-image/route.ts": {
+    "apps/nextjs/src/app/api/queues/process-image/route.ts": {
       "maxDuration": 120,
       "experimentalTriggers": [
         {
@@ -20,7 +20,7 @@
         }
       ]
     },
-    "src/app/api/queues/send-push/route.ts": {
+    "apps/nextjs/src/app/api/queues/send-push/route.ts": {
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",
@@ -29,7 +29,7 @@
         }
       ]
     },
-    "src/app/api/queues/check-push-receipts/route.ts": {
+    "apps/nextjs/src/app/api/queues/check-push-receipts/route.ts": {
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",


### PR DESCRIPTION
## Summary
- Vercel Queues consumer triggers (`experimentalTriggers`) for the 4 queue routes (mail, process-image, send-push, check-push-receipts) were defined in `apps/nextjs/vercel.json`, but the Vercel project's Root Directory is the repo root, so that file was never read and triggers never registered (`config.functions` was `null` on the last production deployment).
- Moved the config to a repo-root `vercel.json`, with function path keys prefixed `apps/nextjs/...` to match the actual project root. Deleted `apps/nextjs/vercel.json` so there's a single source of truth.
- No other config (crons/headers/rewrites) existed in the old file, so nothing else needed migrating.

## Test plan
- [x] `vercel.json` is valid JSON
- [x] Confirmed via Vercel API that the current prod deployment has `config.functions: null` (root cause)
- [x] Confirmed no path-filtered CI workflow depends on `apps/nextjs/vercel.json`'s old location
- [ ] After merge: verify the new production deployment registers the triggers (`config.functions` populated) and that a real queue message triggers a consumer invocation

https://claude.ai/code/session_01DiAd7HvAMJn9KZtGEex4qr