### PR TITLE
fix(vercel): drop apps/nextjs prefix from function path keys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
-    "apps/nextjs/src/app/api/queues/mail/route.ts": {
+    "src/app/api/queues/mail/route.ts": {
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",
@@ -10,7 +10,7 @@
         }
       ]
     },
-    "apps/nextjs/src/app/api/queues/process-image/route.ts": {
+    "src/app/api/queues/process-image/route.ts": {
       "maxDuration": 120,
       "experimentalTriggers": [
         {
@@ -20,7 +20,7 @@
         }
       ]
     },
-    "apps/nextjs/src/app/api/queues/send-push/route.ts": {
+    "src/app/api/queues/send-push/route.ts": {
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",
@@ -29,7 +29,7 @@
         }
       ]
     },
-    "apps/nextjs/src/app/api/queues/check-push-receipts/route.ts": {
+    "src/app/api/queues/check-push-receipts/route.ts": {
       "experimentalTriggers": [
         {
           "type": "queue/v2beta",


### PR DESCRIPTION
## Summary
- #60 moved the queue trigger config to a repo-root `vercel.json` but prefixed function path keys with `apps/nextjs/`, assuming the glob resolves relative to the git repo root. It doesn't.
- Prod deployment of #60's merge commit failed immediately: `The pattern "apps/nextjs/src/app/api/queues/mail/route.ts" defined in functions doesn't match any Serverless Functions.` (confirmed via Vercel API on `dpl_AVfKj6TQK2MRqoAk5Tu56aQTqMzh`, error step at build). Vercel never promoted the broken build, so `www.pegada.app` kept serving the previous good deployment throughout — prod was never actually down.
- The `functions` glob is matched against the Next.js app's own source tree as `vercel build` sees it (i.e. relative to `apps/nextjs`), not the git repo root, even though the config file itself must live at repo root for the project to read it (Root Directory is unset/repo root). Dropped the prefix back to the original `src/app/api/queues/...` convention.
- Verified locally: `vercel pull --environment production && vercel build` no longer errors on the function pattern step (it now runs `next build` end to end; it does fail later on missing env vars, which is expected for a partial local env and unrelated to this fix).

## Test plan
- [x] Reproduced the prod build failure via Vercel API/build logs
- [x] Verified locally with `vercel build` that the corrected (unprefixed) paths pass Vercel's function-pattern validation
- [ ] After merge: confirm production deployment reaches READY and `config.functions` / `experimentalTriggers` are populated

https://claude.ai/code/session_01DiAd7HvAMJn9KZtGEex4qr