### PR TITLE
ci(mobile): fix release submit jobs — install deps, pin iOS ascAppId

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -399,6 +399,21 @@ jobs:
           name: ${{ needs.build-ios.outputs.ipa-artifact }}
           path: artifact
 
+      # `eas submit` evaluates apps/mobile/app.config.ts, which imports the
+      # `expo` package -- without an install it dies with "Cannot find
+      # package 'expo'" before ever talking to the store.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.9
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Setup EAS CLI
         uses: expo/expo-github-action@v9
         with:
@@ -428,6 +443,20 @@ jobs:
         with:
           name: ${{ needs.build-android.outputs.aab-artifact }}
           path: artifact
+
+      # Same as submit-ios: `eas submit` needs node_modules to evaluate the
+      # Expo config before it can talk to the store.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.9
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Setup EAS CLI
         uses: expo/expo-github-action@v9

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -26,6 +26,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6450865592"
+      }
+    }
   }
 }


### PR DESCRIPTION
The submit jobs in release-mobile.yml checked out the repo but never installed dependencies, so `eas submit` failed evaluating `app.config.ts` before ever reaching the store:

```
Cannot find package 'expo' imported from apps/mobile/app.config.js
```

Caught live on the first real 1.4.0 release dispatch (run 28814636709): iOS build succeeded, submit job died on this. Android's submit job would hit the same wall.

Changes:
- Add pnpm/node setup + `pnpm install --frozen-lockfile` to both submit jobs
- Add `ascAppId: 6450865592` to the eas.json production submit profile — non-interactive iOS submit refuses to run without it (verified against the live artifact; the id matches `appStoreUrl` in app.config.ts)

Testing: the ascAppId path was exercised by submitting the built .ipa locally with the same command the workflow runs.

https://claude.ai/code/session_01DiAd7HvAMJn9KZtGEex4qr