### PR TITLE
fix(mobile): stop the first request dying on the apex→www redirect

### DIFF
--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -72,21 +72,14 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
+      # `--environment production` pulls EXPO_PUBLIC_* from the EAS env store
+      # (the same source `eas build` uses), so OTA updates and binaries stay in
+      # lockstep. The old approach fed these from GitHub Actions secrets that
+      # don't exist (only EXPO_TOKEN is set), so every OTA baked empty values —
+      # empty EXPO_PUBLIC_API_URL is what broke the first request on 1.4.0.
       - name: 🚀 Create Update
-        run: eas update --auto --non-interactive
+        run: eas update --auto --non-interactive --environment production
         working-directory: apps/mobile
-        env:
-          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
-          EXPO_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY }}
-          EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY: ${{ secrets.EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY }}
-          EXPO_PUBLIC_IOS_GOOGLE_MAPS_API_KEY: ${{ secrets.EXPO_PUBLIC_IOS_GOOGLE_MAPS_API_KEY }}
-          EXPO_PUBLIC_REVENUE_CAT_IOS_API_KEY: ${{ secrets.EXPO_PUBLIC_REVENUE_CAT_IOS_API_KEY }}
-          EXPO_PUBLIC_REVENUE_CAT_ANDROID_API_KEY: ${{ secrets.EXPO_PUBLIC_REVENUE_CAT_ANDROID_API_KEY }}
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-          GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}
-          EXPO_PUBLIC_ENV: production
-          EXPO_PUBLIC_POSTHOG_API_KEY: ${{ secrets.EXPO_PUBLIC_POSTHOG_API_KEY }}
-          EXPO_PUBLIC_POSTHOG_HOST: ${{ secrets.EXPO_PUBLIC_POSTHOG_HOST }}
 
       # TODO: Bugsnag sourcemap upload removed (dead vendor, replaced by PostHog).
       # PostHog RN doesn't ship an equivalent build-time sourcemap upload CLI today;

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -33,6 +33,21 @@ name: Release Mobile (build + submit)
 # from Gabriel to fix (only he can create one in App Store Connect).
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# WHEN THIS RUNS vs. WHEN OTA RUNS
+# ---------------------------------------------------------------------------
+# Most releases ship over-the-air: deploy-mobile.yml runs `eas update` on every
+# push to main, which is the frequent path and needs no native build or store
+# submission. This workflow is only for the rarer case where NATIVE actually
+# changed (new/updated native dep, config plugin, permissions, version bump)
+# and a fresh binary is required.
+#
+# A new native binary must NOT be auto-submitted to the stores: it needs
+# TestFlight/internal-track testing and a deliberate staged rollout first. So:
+#   - tag push (v*)        -> builds artifacts only, NEVER submits
+#   - manual dispatch      -> submit is an explicit opt-in (defaults to false)
+# `eas submit` is only ever reached when a human sets submit=true on a dispatch.
+# ---------------------------------------------------------------------------
 on:
   workflow_dispatch:
     inputs:
@@ -46,7 +61,7 @@ on:
           - android
         default: all
       submit:
-        description: "Submit the built artifact(s) to the store after a successful build"
+        description: "Submit built artifact(s) to the store (opt-in; a brand-new native version normally ships to TestFlight/internal first, not straight to submit)"
         required: true
         type: boolean
         default: false

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -56,3 +56,6 @@ google-services.json
 
 # Turbo cache
 *.tsbuildinfo
+# EAS-generated local credentials (contains cert passwords) — never commit
+credentials.json
+credentials/

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -39,6 +39,17 @@ const config: ExpoConfig = {
     "expo-notifications",
     "expo-localization",
     "expo-router",
+    // react-native-maps 1.20+ enables Google Maps via its own config plugin.
+    // The deprecated `ios.config.googleMapsApiKey` / `android.config.googleMaps`
+    // fields make Expo prebuild reference a `react-native-google-maps` podspec
+    // that no longer exists in 1.27, which breaks `pod install` on iOS.
+    [
+      "react-native-maps",
+      {
+        iosGoogleMapsApiKey: process.env.EXPO_PUBLIC_IOS_GOOGLE_MAPS_API_KEY,
+        androidGoogleMapsApiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY,
+      },
+    ],
     [
       "expo-build-properties",
       {
@@ -193,11 +204,6 @@ const config: ExpoConfig = {
       backgroundColor: "#FFFFFF",
     },
     package: "app.pegada",
-    config: {
-      googleMaps: {
-        apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY,
-      },
-    },
     // intentFilters: [
     //   {
     //     action: 'VIEW',
@@ -233,7 +239,6 @@ const config: ExpoConfig = {
     },
     googleServicesFile: "./GoogleService-Info.plist",
     config: {
-      googleMapsApiKey: process.env.EXPO_PUBLIC_IOS_GOOGLE_MAPS_API_KEY,
       usesNonExemptEncryption: false,
     },
     bundleIdentifier: "app.pegada",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -11,6 +11,7 @@
     "development": {
       "extends": "fast",
       "node": "20.10.0",
+      "environment": "development",
       "developmentClient": true,
       "distribution": "internal",
       "autoIncrement": true,
@@ -21,6 +22,7 @@
     "production": {
       "extends": "fast",
       "node": "20.10.0",
+      "environment": "production",
       "channel": "main",
       "autoIncrement": true
     }
@@ -29,6 +31,10 @@
     "production": {
       "ios": {
         "ascAppId": "6450865592"
+      },
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft"
       }
     }
   }

--- a/apps/mobile/src/contexts/TRPCProvider.tsx
+++ b/apps/mobile/src/contexts/TRPCProvider.tsx
@@ -55,7 +55,20 @@ export const trpcQueryClient = api.createClient({
       },
       fetch: async (url, options): Promise<Response> => {
         const res = await fetch(url as string, options as RequestInit);
-        const responsesJSON = (await res.json()) as ResponseJSON[];
+
+        // The API base URL must resolve directly to the tRPC handler with NO
+        // redirect. `pegada.app` 308-redirects to `www.pegada.app`, and RN's
+        // fetch surfaces the redirect body ("Redirecting...") instead of
+        // following it transparently — so `res.json()` below would throw on
+        // the very first request and take startup down with it. If the body
+        // isn't JSON (redirect page, HTML 5xx, gateway timeout), degrade to an
+        // empty tRPC batch instead of throwing so the app can recover.
+        let responsesJSON: ResponseJSON[];
+        try {
+          responsesJSON = (await res.json()) as ResponseJSON[];
+        } catch {
+          responsesJSON = [];
+        }
 
         if (res.status === 401) {
           const unauthorized = responsesJSON.some((responseJSON) => {

--- a/apps/mobile/src/services/config.ts
+++ b/apps/mobile/src/services/config.ts
@@ -35,4 +35,19 @@ if (!_config.success) {
   throw new Error("Invalid environment variables.");
 }
 
-export const config = _config.data;
+/**
+ * The prod API lives on `www.pegada.app`; the bare apex `pegada.app`
+ * 308-redirects there, and RN's fetch can't follow that redirect cleanly
+ * (it hands back the "Redirecting..." body), which crashes the first tRPC
+ * call. Normalize the apex to `www` and drop any trailing slash so the base
+ * URL always hits the handler directly, regardless of the built env value.
+ */
+const normalizeApiUrl = (raw: string): string =>
+  raw
+    .replace(/\/+$/, "")
+    .replace(/^(https?:\/\/)pegada\.app(\/|$)/, "$1www.pegada.app$2");
+
+export const config = {
+  ..._config.data,
+  API_URL: normalizeApiUrl(_config.data.API_URL),
+};

--- a/apps/mobile/src/services/config.ts
+++ b/apps/mobile/src/services/config.ts
@@ -43,9 +43,7 @@ if (!_config.success) {
  * URL always hits the handler directly, regardless of the built env value.
  */
 const normalizeApiUrl = (raw: string): string =>
-  raw
-    .replace(/\/+$/, "")
-    .replace(/^(https?:\/\/)pegada\.app(\/|$)/, "$1www.pegada.app$2");
+  raw.replace(/\/+$/, "").replace(/^(https?:\/\/)pegada\.app(\/|$)/, "$1www.pegada.app$2");
 
 export const config = {
   ..._config.data,


### PR DESCRIPTION
Sets up the mobile app to hit the API directly instead of through a redirect, and hardens it so a bad env value or a stray redirect never crashes startup again. Also finishes wiring the Android release so CI can push builds to Play.

## Details

The 1.4.0 TestFlight build failed on its very first request. Three things stacked up, all from the recent infra consolidation:

- `pegada.app` now permanently redirects to `www.pegada.app`. The app makes one call on launch; React Native did not follow that redirect cleanly and the response parser threw on the redirect page, taking startup down with it.
- All the app-facing env values were stored as `secret` in EAS. Expo only reads those during a native build, not during an over-the-air update, so every OTA shipped an empty API URL.
- The build profiles never opted in to the EAS env store, so even native builds could ship an empty API URL.

What changed:

- The app now rewrites the bare domain to `www` and trims trailing slashes, so it always hits the API directly no matter what value it was built with.
- The request layer tolerates a non-JSON response (a redirect page, an HTML error) instead of crashing.
- EAS build profiles now pull from the production env store, and the OTA workflow reads env from EAS instead of GitHub secrets that were never set.
- The Android release now has a submit target (internal track, draft), so the existing build-and-submit workflow can push straight to Play using the keystore and Play service account already stored in EAS.

Server-side, done outside this diff: every app-facing EAS var is now readable by OTA, the API URL points at `www.pegada.app`, and a dead maps var was removed.

## Testing steps

1. Install the newest build on a phone (TestFlight for iOS).
2. Open the app cold. It should land on the sign-in screen normally, no error or blank screen on the first load.
3. Sign in and confirm the swipe/home screen loads dogs. That proves the first API call went through.
4. Open a screen with a map and confirm the map renders.
5. On Android, from the release workflow trigger a build with submit on, then confirm a new draft shows up on the internal track in the Play Console.