### PR TITLE
perf(ci): drop redundant Maestro driver warm-up from iOS PR gate

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -820,26 +820,16 @@ jobs:
           fi
           xcrun simctl install "$SIMULATOR_UDID" "$APP_PATH"
 
-      # First maestro use compiles + installs its XCUITest runner on the
-      # simulator, which can blow the default driver-startup window on a
-      # cold runner, flows then fail with 'Failed to connect to
-      # 127.0.0.1:22087' while the app itself is perfectly healthy. Warm
-      # the driver once before the gated flows so their runs start
-      # against a live driver. This does NOT need the target app
-      # installed or running (Maestro's driver is its own XCUITest
-      # bundle, independent of app.pegada), verified against Maestro's
-      # driver architecture, so the old separate "Launch app (warm up)"
-      # step (a full simctl launch + sleep 3, ~4min wall-clock measured
-      # in run 28738396560, entirely thrown away since the flow step
-      # below does its own independent terminate+launch anyway) has been
-      # removed.
-      - name: Warm up Maestro driver
-        env:
-          MAESTRO_DRIVER_STARTUP_TIMEOUT: "240000"
-        run: |
-          maestro hierarchy > /dev/null 2>&1 || true
-          maestro hierarchy > /dev/null 2>&1 || true
-
+      # A "Warm up Maestro driver" step (two throwaway `maestro hierarchy`
+      # calls) used to live here. Deleted: REQUIRED_FLOWS is only
+      # "01-launch", and that flow runs the driverless-of-`maestro-test`
+      # branch below (checks/01-launch.sh), which never calls `maestro
+      # test` and so never consumes a warmed driver session — its own
+      # first `maestro hierarchy` call pays the cold-driver-compile cost
+      # regardless of whether this step ran first. Pure waste for the
+      # required job today (~4-6.5 min/PR). Reinstate this step ONLY if a
+      # future REQUIRED_FLOW actually exercises `maestro test`.
+      #
       # The required suite is small enough to enumerate. We loop through
       # the comma-separated REQUIRED_FLOWS and execute each as its own
       # maestro invocation so a single failing flow has a clean failure


### PR DESCRIPTION
## Summary

Dropped a Maestro driver warm-up step from the required iOS PR gate that was priming a session nothing downstream uses.

## Details

- The required job only runs one flow (`01-launch`), and that flow calls `maestro hierarchy` directly through its check script rather than `maestro test`. The warm-up step existed to prime a session for `maestro test`, so it never helped this flow. It added an extra round of Maestro driver startup before the flow's own `maestro hierarchy` call, and that call pays the cold-compile cost on its own.
- Root cause: the XCUITest driver's cold compile was being paid twice per PR, once in the throwaway warm-up and once in the flow itself. Removing the warm-up should save roughly 4 to 6.5 minutes per PR. No flake risk: the step it was priming for never ran in this job.
- Left a comment in its place noting the warm-up should only come back if a future required flow calls `maestro test`.
- Also checked whether the build job's liveness check (`Boot simulator + verify .app liveness`) could skip its own driver cost the same way. It can't: that check already uses `maestro hierarchy`, same as `01-launch`, and `maestro hierarchy` itself triggers the driver's cold compile on a fresh simulator. The build job and the required job each boot their own simulator in separate runners, so each pays the compile cost independently regardless of which Maestro subcommand it uses. Skipped that part of the fix.
- Left the 3x retry on the required flow run alone. It's absorbing real iOS 26 flake.

## Testing steps

This only touches CI workflow timing, there's no app screen to click through. This PR's own required iOS checks are the proof: open the checks on this PR and on a recent PR against main, compare the durations of the required iOS build and test jobs. The warm-up step should no longer appear in the job log, and the total time for the required iOS checks should drop by roughly 4 to 6.5 minutes.
