### PR TITLE
fix(mobile): guard Appearance.setColorScheme against null theme (P0 crash on fresh install)

### DIFF
--- a/apps/mobile/src/contexts/ThemeProvider.tsx
+++ b/apps/mobile/src/contexts/ThemeProvider.tsx
@@ -43,7 +43,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactElement }> = ({ chil
   useEffect(() => {
     const fetchThemeFromStorage = async () => {
       const storedTheme = await getData(StorageKeys.Theme);
-      Appearance.setColorScheme(storedTheme as ColorSchemeName);
+      if (storedTheme) Appearance.setColorScheme(storedTheme as ColorSchemeName);
       setActiveTheme(storedTheme);
     };
 
@@ -53,7 +53,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactElement }> = ({ chil
   const theme = themes[(colorScheme as Theme) ?? Theme.Default] ?? themes[Theme.Default];
 
   const handleActiveThemeChange = async (theme: ActiveTheme) => {
-    Appearance.setColorScheme(theme as ColorSchemeName);
+    if (theme) Appearance.setColorScheme(theme as ColorSchemeName);
     setActiveTheme(theme);
 
     if (!theme) return deleteData(StorageKeys.Theme);


### PR DESCRIPTION
## The crash

Every fresh install of the Android/iOS app crashes at cold launch, before the user ever sees a screen:

```
FATAL: NullPointerException: Parameter specified as non-null is null: method com.facebook.react.modules.appearance.AppearanceModule.setColorScheme, parameter style
```

Confirmed on live devices by two independent QA passes. Every new user hits this on first open.

## Root cause

`ThemeProvider.tsx` calls `Appearance.setColorScheme(storedTheme as ColorSchemeName)` on mount, where `storedTheme` comes from AsyncStorage. On a fresh install nobody has picked a theme yet, so `storedTheme` is `null`.

On RN 0.83 with the new architecture, the native `setColorScheme` parameter became non-nullable. Passing `null` throws instead of being treated as "use system default."

This is a regression from the SDK 51 to 55 upgrade. Commit `109cd6e` added `as ColorSchemeName` casts to silence a TypeScript error, but that just told the compiler to trust a value that can actually be `null` at runtime. It papered over the type error instead of fixing it.

## The fix

Guard both call sites so `setColorScheme` is only invoked when there's an actual stored theme:

```ts
if (storedTheme) Appearance.setColorScheme(storedTheme as ColorSchemeName);
```

and the same at the theme-change handler. When no theme is stored, we now just skip the call, which is correct: `useColorScheme()` already falls back to the OS theme in that case, so "no stored theme" naturally means "follow system." Nothing else in the theme logic changes, and `userInterfaceStyle` in app.config.ts is untouched.

Checked the rest of the app for other unguarded `setColorScheme` calls (`grep -rn "setColorScheme" apps/mobile/src`) - these two were the only ones.

## Testing steps (no dev environment needed)

1. Install a fresh build of the app on a device or simulator that has never had it installed before (or fully uninstall + reinstall to clear storage).
2. Open the app cold (first launch).
3. Expected: the app opens normally and lands on the sign-in screen.
4. Before this fix: the app crashes immediately on launch.

Bonus check: go into theme settings, switch between light/dark/system a few times, confirm it still works exactly as before (this fix doesn't change that path, just makes it null-safe).

https://claude.ai/code/session_01AxWfCxSc7oUmoQcnosQzdV