### PR TITLE
fix(mobile): stop the age-range slider triggering back navigation on iOS

### DIFF
--- a/apps/mobile/src/components/Slider/index.tsx
+++ b/apps/mobile/src/components/Slider/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Platform, View } from "react-native";
+import { View } from "react-native";
 import MultiSlider, { LabelProps, MultiSliderProps } from "@ptomasroos/react-native-multi-slider";
 import { useTheme } from "styled-components/native";
 
@@ -58,11 +58,11 @@ const CustomMarker = () => <Marker hitSlop={markerHitSlop} />;
 export const Root = (props: MultiSliderProps) => {
   const theme = useTheme();
 
-  // On android, if the slider is close to the edge of the screen,
-  // the swipe gesture will be triggered instead of the slider
-  // making the user go back to the previous screen. This is a
-  // workaround to prevent that.
-  const safePadding = Platform.OS === "android" ? theme.spacing[7] : 0;
+  // When the slider reaches the edge of the screen, a horizontal drag there
+  // gets claimed by the OS navigation gesture (iOS interactive pop / Android
+  // system back) instead of the slider, sending the user back a screen. Inset
+  // the track on both platforms so no marker sits in that edge gesture zone.
+  const safePadding = theme.spacing[7];
 
   const sliderLength = (props?.sliderLength ?? 0) - safePadding * 2;
 


### PR DESCRIPTION
The age-range ("faixa etária") slider triggered a swipe-back instead of moving when you dragged it toward the edge on iOS.

## Details

The slider track ran all the way to the screen edges, where iOS claims horizontal drags for its interactive back gesture. The Slider component already had an inset to avoid this, but it only applied on Android. iOS has the same problem (its edge swipe-back is on by default), so the inset now applies on both platforms. The track just centers and shortens slightly, no other layout change.

## Testing steps

1. Open the app, go to Match Preferences.
2. Drag the age-range slider handles left and right, including all the way to each end.
3. Confirm the handles move normally and the screen never swipes back while dragging.
4. Same check on the distance slider below it.