### PR TITLE
fix(mobile): size language/theme picker sheets to their content

### DIFF
--- a/apps/mobile/src/components/Picker/index.tsx
+++ b/apps/mobile/src/components/Picker/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import * as React from "react";
-import { ListRenderItemInfo, Pressable } from "react-native";
+import { ListRenderItemInfo, Pressable, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BottomSheetFlatList, BottomSheetModal } from "@gorhom/bottom-sheet";
 import { BottomSheetFlatListProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetScrollable/types";
@@ -102,11 +102,19 @@ const UnForwardedPickerSheet = <T extends Item>(
     onChange,
     optional: _optional,
     searchable,
-    snapPoints = ["70%", "93%"],
+    snapPoints,
     itemTestIDPrefix,
     testID: _testID,
     ...flatlistProps
   } = props;
+
+  // When no snapPoints are given, let the sheet size to its content (v5
+  // dynamic sizing) so short lists like language/theme aren't clipped by a
+  // fixed fraction of the screen. Searchable/long lists still pass explicit
+  // snapPoints for a tall scrollable sheet. Cap dynamic height so a big list
+  // can't grow past the screen.
+  const enableDynamicSizing = !snapPoints;
+  const { height: screenHeight } = useWindowDimensions();
 
   const data = filter
     ? props.data.filter((item) => item.name.toLowerCase().includes(filter.toLowerCase()))
@@ -145,6 +153,8 @@ const UnForwardedPickerSheet = <T extends Item>(
       android_keyboardInputMode="adjustResize" // Fixes the keyboard extra padding on Android
       ref={pickerSheetRef}
       snapPoints={snapPoints}
+      enableDynamicSizing={enableDynamicSizing}
+      maxDynamicContentSize={screenHeight * 0.9}
       enableDismissOnClose
       keyboardBehavior="interactive"
       backgroundStyle={backgroundStyle}
@@ -208,7 +218,9 @@ export const InputPicker = <T extends Item>(props: InputPickerProps<T>) => {
           optional={props.optional}
         />
       </Pressable>
-      <PickerSheet {...props} ref={pickerSheetRef} />
+      {/* Long/searchable lists (breeds, sizes, colors) keep a tall fixed sheet;
+          direct PickerSheet users without snapPoints get content-fit sizing. */}
+      <PickerSheet snapPoints={["70%", "93%"]} {...props} ref={pickerSheetRef} />
     </Container>
   );
 };

--- a/apps/mobile/src/views/(tabs)/Profile/components/LanguageConfig.tsx
+++ b/apps/mobile/src/views/(tabs)/Profile/components/LanguageConfig.tsx
@@ -52,7 +52,6 @@ export const LanguageConfig = () => {
         placeholder={t("profile.language")}
         value={value}
         data={languagesPickerData}
-        snapPoints={["40%"]}
         itemTestIDPrefix="language-item-"
         onChange={(item) => {
           i18n.changeLanguage(item.id as keyof typeof LANGUAGES).catch(sendError);

--- a/apps/mobile/src/views/(tabs)/Profile/components/ThemeConfig.tsx
+++ b/apps/mobile/src/views/(tabs)/Profile/components/ThemeConfig.tsx
@@ -50,7 +50,6 @@ export const ThemeConfig = () => {
         placeholder={t("profile.theme")}
         value={value}
         data={data}
-        snapPoints={["40%"]}
         itemTestIDPrefix="theme-item-"
         onChange={(item) => {
           setActiveTheme(item.id as ActiveTheme).catch(sendError);


### PR DESCRIPTION
The language and theme pickers opened too small and cut off their content because they were pinned to a fixed 40% of the screen height.

## Details

Those two pickers now size to their content instead of a fixed fraction (bottom-sheet v5 dynamic sizing, capped at 90% of the screen), so nothing gets clipped regardless of device size. The longer, searchable pickers (breeds, sizes, colors) keep their tall fixed sheet unchanged.

## Testing steps

1. Open the app, go to Profile.
2. Tap Language. Confirm the sheet opens at a height that fits both options fully, nothing cut off at the bottom.
3. Tap Theme. Same check with its three options.
4. Open a breed/size/color picker elsewhere (e.g. Match Preferences or Edit Profile) and confirm it still opens as a tall, scrollable, searchable sheet like before.