### PR TITLE
feat(mobile): haptic feedback on swipe, match and purchase

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -13,7 +13,7 @@ const config: ExpoConfig = {
    * That affects eas updates and makes sure the app doesn't
    * break when updating Over The Air
    */
-  version: "1.4.0",
+  version: "1.5.0",
   runtimeVersion: {
     policy: "appVersion",
   },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -44,6 +44,7 @@
     "expo-device": "~55.0.18",
     "expo-file-system": "~55.0.23",
     "expo-font": "~55.0.7",
+    "expo-haptics": "~55.0.15",
     "expo-image": "~55.0.10",
     "expo-image-manipulator": "^55.0.16",
     "expo-image-picker": "~55.0.20",

--- a/apps/mobile/src/services/haptics.ts
+++ b/apps/mobile/src/services/haptics.ts
@@ -1,0 +1,64 @@
+import { Platform } from "react-native";
+import * as Haptics from "expo-haptics";
+
+import { sendError } from "@/services/errorTracking";
+
+// Every call is wrapped so a haptics failure (unsupported device, simulator,
+// etc.) never throws into calling code — it's purely a "nice to have".
+const safely = (perform: () => Promise<void>) => {
+  perform().catch(sendError);
+};
+
+/** A subtle tick for discrete selection changes, e.g. crossing a swipe threshold. */
+const selection = () => {
+  safely(() => Haptics.selectionAsync());
+};
+
+/**
+ * A light tap for low-weight confirmations (e.g. a swipe action).
+ * Android is routed through `performAndroidHapticsAsync`, which Expo
+ * recommends over `impactAsync` there since it doesn't rely on the
+ * `Vibrator` API or the `VIBRATE` permission.
+ */
+const light = () => {
+  safely(() =>
+    Platform.OS === "android"
+      ? Haptics.performAndroidHapticsAsync(Haptics.AndroidHaptics.Segment_Tick)
+      : Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light),
+  );
+};
+
+/** A medium tap for slightly heavier confirmations (e.g. a like/dislike button press). */
+const medium = () => {
+  safely(() =>
+    Platform.OS === "android"
+      ? Haptics.performAndroidHapticsAsync(Haptics.AndroidHaptics.Confirm)
+      : Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium),
+  );
+};
+
+/** Marks a successful outcome, e.g. a new match or a completed purchase. */
+const success = () => {
+  safely(() =>
+    Platform.OS === "android"
+      ? Haptics.performAndroidHapticsAsync(Haptics.AndroidHaptics.Confirm)
+      : Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success),
+  );
+};
+
+/** Marks a failed outcome, e.g. a purchase error. */
+const error = () => {
+  safely(() =>
+    Platform.OS === "android"
+      ? Haptics.performAndroidHapticsAsync(Haptics.AndroidHaptics.Reject)
+      : Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error),
+  );
+};
+
+export const haptics = {
+  selection,
+  light,
+  medium,
+  success,
+  error,
+};

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeHandler/hooks/useSwipeGesture.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeHandler/hooks/useSwipeGesture.ts
@@ -13,6 +13,7 @@ import {
 } from "react-native-reanimated";
 
 import { ACTION_OFFSET, ACTION_VELOCITY, CARD } from "@/constants";
+import { haptics } from "@/services/haptics";
 
 export interface Translation {
   x: SharedValue<number>;
@@ -99,6 +100,10 @@ export const useSwipeGesture = ({ onSwipeComplete }: UseSwipeGestureProps) => {
     y: useSharedValue(0),
   };
 
+  // Tracks whether we've already fired the threshold-crossing haptic for the
+  // current gesture, so it ticks once per crossing instead of every frame.
+  const hasCrossedThreshold = useSharedValue(false);
+
   // We want to guarantee the animation has finished before enabling
   // the card to be swiped again. Otherwise the dog will be able
   // to 'catch' the card on the middle of the animation.
@@ -112,6 +117,10 @@ export const useSwipeGesture = ({ onSwipeComplete }: UseSwipeGestureProps) => {
     // Avoid concurrency, should gotoDirection only once
     if (!enabled) return;
     runOnJS(setEnabled)(false);
+
+    // Confirms the action itself (button tap or a released swipe past the
+    // threshold) — distinct from the lighter "crossing" tick in `onUpdate`.
+    runOnJS(haptics.light)();
 
     const swipeCoordinates = getDirectionCoordinates(swipeDirection);
     return gotoCoordinate(
@@ -129,10 +138,19 @@ export const useSwipeGesture = ({ onSwipeComplete }: UseSwipeGestureProps) => {
     .onBegin((ctx) => {
       translation.x.value = ctx.translationX;
       translation.y.value = ctx.translationY;
+      hasCrossedThreshold.value = false;
     })
     .onUpdate((event) => {
       translation.x.value = event.translationX;
       translation.y.value = event.translationY;
+
+      // Fire a tick exactly once per crossing of the decision threshold,
+      // reusing the same rule `onEnd` uses to commit to a direction.
+      const crossedNow = !!getSwipeType(event);
+      if (crossedNow && !hasCrossedThreshold.value) {
+        runOnJS(haptics.selection)();
+      }
+      hasCrossedThreshold.value = crossedNow;
     })
     .onEnd((event) => {
       const swipeType = getSwipeType(event);

--- a/apps/mobile/src/views/NewMatch/index.tsx
+++ b/apps/mobile/src/views/NewMatch/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import * as React from "react";
 import { BackHandler, ScrollView, View } from "react-native";
 import { Image } from "expo-image";
@@ -12,6 +13,7 @@ import { Text } from "@/components/Text";
 import { api } from "@/contexts/TRPCProvider";
 import { useForAdRequestTracked } from "@/services/advertisement/interstitial";
 import { analytics } from "@/services/analytics";
+import { haptics } from "@/services/haptics";
 import { SceneName } from "@/types/SceneName";
 import AnimatedCards from "./AnimatedCards";
 import { ConfettiAnimation } from "./ConfettiAnimation";
@@ -78,6 +80,11 @@ const NewMatch: React.FC = () => {
 
     return () => subscription.remove();
   });
+
+  // Pairs with the confetti Lottie — celebrates the match as the screen appears.
+  useEffect(() => {
+    haptics.success();
+  }, []);
 
   return (
     <Container testID="new-match-screen">

--- a/apps/mobile/src/views/UpgradeWall/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/index.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/Button";
 import { useEligibleForTrial } from "@/hooks/usePayments";
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/errorTracking";
+import { haptics } from "@/services/haptics";
 import { payments } from "@/services/payments";
 import Benefits from "@/views/UpgradeWall/components/Benefits";
 import PlanPackages from "@/views/UpgradeWall/components/PlanPackages";
@@ -75,6 +76,8 @@ const UpgradeWall: React.FC = () => {
       });
     },
     onSuccess: () => {
+      haptics.success();
+
       analytics.track({
         event_type: "Upgrade",
         event_properties: {
@@ -101,6 +104,8 @@ const UpgradeWall: React.FC = () => {
 
       // If it's a simulator, an error is expected
       if (!isDevice) return;
+
+      haptics.error();
 
       analytics.track({
         event_type: "Upgrade",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       expo-font:
         specifier: ~55.0.7
         version: 55.0.7(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-haptics:
+        specifier: ~55.0.15
+        version: 55.0.15(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))
       expo-image:
         specifier: ~55.0.10
         version: 55.0.10(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))(react-native-web@0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -4397,6 +4400,11 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-haptics@55.0.15:
+    resolution: {integrity: sha512-RREAflKxOIPAJ5l5M22eHUDU4PGetH2xvQN4ihN4rNEKrzbxrxI2e8yf3MopujCOz5aV5JO1gaGezdJbWEeS9w==}
+    peerDependencies:
+      expo: '*'
 
   expo-image-loader@55.0.0:
     resolution: {integrity: sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==}
@@ -12011,6 +12019,10 @@ snapshots:
       expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5)
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+
+  expo-haptics@55.0.15(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5)):
+    dependencies:
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5)
 
   expo-image-loader@55.0.0(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5)):
     dependencies:


### PR DESCRIPTION
## Summary

We added haptic feedback to the core interactions: the swipe deck, the new match screen and the purchase flow.

## Details

- New small haptics service wrapping expo-haptics. Every call is fail-safe (never throws, no-op where unsupported). Android goes through the newer `performAndroidHapticsAsync` path, iOS uses the standard impact/notification/selection APIs.
- Swipe deck: a light tick exactly when the card crosses the like/nope decision threshold (once per crossing, not every frame), plus a firmer bump when the action commits (released swipe or action bar button, same choke point).
- New match screen: success buzz on mount, paired with the confetti.
- Paywall: success buzz when a purchase completes, error buzz when it fails. Nothing on user cancel, on purpose.
- Version bumped to 1.5.0 (new native module, per the app.config convention).

## Testing steps

Needs a physical device, haptics don't fire on simulators.

1. Slowly drag a card on the swipe screen past the point where it counts as a decision: you should feel a light tick the moment it crosses, once per crossing (drag back and forth over the line, it should tick each time, never buzz continuously).
2. Let the card go past the threshold, or tap the like/dislike buttons: a slightly firmer bump as the card flies off.
3. Get a new match: one success buzz together with the confetti screen.
4. On the upgrade screen, complete a sandbox purchase: success buzz. Make one fail: a sharper error buzz. Cancel the payment sheet: no vibration at all.
5. Nothing else in the app should feel different, only these spots got haptics.