### PR TITLE
feat: reply to chat messages straight from the notification

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -52,12 +52,14 @@ const config: ExpoConfig = {
     tsconfigPaths: true,
   },
   plugins: [
-    // Generates the shared `targets/pegada-widgets` WidgetKit extension
-    // target (home-screen widgets, Live Activities, Control Center controls)
-    // at prebuild time. iOS allows one widget extension per app, so every
-    // widget-family feature registers in PegadaWidgetsBundle.swift instead
-    // of adding a target. Team ID comes from EAS credentials at build time;
-    // local sim builds don't sign.
+    // Wires every directory under `targets/` into the Xcode project at
+    // prebuild time: the shared `pegada-widgets` WidgetKit extension
+    // (home-screen widgets, Live Activities, Control Center controls) and the
+    // `notification-service` extension that restyles chat pushes as iOS
+    // communication notifications. iOS allows one widget extension per app, so
+    // every widget-family feature registers in PegadaWidgetsBundle.swift
+    // instead of adding a target. Team ID comes from EAS credentials at build
+    // time; local sim builds don't sign.
     "@bacons/apple-targets",
     "expo-secure-store",
     "expo-notifications",
@@ -314,10 +316,15 @@ const config: ExpoConfig = {
       usesNonExemptEncryption: false,
     },
     bundleIdentifier: "app.pegada",
-    // Shared storage between the app and the widget extension: the matches
-    // snapshot (UserDefaults) + downloaded avatars (container files).
     entitlements: {
+      // Shared storage between the app and the widget extension: the matches
+      // snapshot (UserDefaults) + downloaded avatars (container files).
       "com.apple.security.application-groups": ["group.app.pegada"],
+      // Communication-notification styling for chat pushes (the
+      // notification-service target carries the same entitlement; both need
+      // the capability enabled on their App IDs in the Apple Developer
+      // portal for device builds).
+      "com.apple.developer.usernotifications.communication": true,
     },
     // associatedDomains: [
     //   'applinks:pegada.app',

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -123,6 +123,11 @@
     "babel-plugin-styled-components": "^2.1.4",
     "jest": "^29.7.0"
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
+    }
+  },
   "installConfig": {
     "hoistingLimits": "workspaces"
   }

--- a/apps/mobile/src/services/getPushNotificationToken.ts
+++ b/apps/mobile/src/services/getPushNotificationToken.ts
@@ -7,6 +7,7 @@ import Color from "color";
 import { LightTheme } from "@pegada/shared/themes/themes";
 
 import { getTrcpContext } from "@/contexts/trcpContext";
+import i18n from "@/i18n";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -22,6 +23,30 @@ export enum NotificationTokenError {
   Denied = "Push notifications denied",
 }
 
+export enum NotificationCategory {
+  ChatMessage = "chat-message",
+}
+
+export enum NotificationAction {
+  Reply = "reply",
+}
+
+// Lets a chat-message push carry a text-input "Reply" action on both
+// platforms, so the user can answer straight from the notification
+// without opening the app. Handled in `services/linking`.
+const registerNotificationCategories = async () => {
+  await Notifications.setNotificationCategoryAsync(NotificationCategory.ChatMessage, [
+    {
+      identifier: NotificationAction.Reply,
+      buttonTitle: i18n.t("chat.replyAction"),
+      textInput: {
+        submitButtonTitle: i18n.t("chat.replyAction"),
+        placeholder: "",
+      },
+    },
+  ]);
+};
+
 export const getPushNotificationToken = async () => {
   if (!Device.isDevice) return;
 
@@ -32,7 +57,18 @@ export const getPushNotificationToken = async () => {
       vibrationPattern: [0, 250, 250, 250],
       lightColor: Color(LightTheme.colors.primary).alpha(0.7).hex(),
     });
+
+    // Dedicated channel for chat-message pushes, matched server-side by
+    // `channelId: "messages"` (see MessageService).
+    await Notifications.setNotificationChannelAsync("messages", {
+      name: i18n.t("chat.notificationChannelName"),
+      importance: Notifications.AndroidImportance.MAX,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: Color(LightTheme.colors.primary).alpha(0.7).hex(),
+    });
   }
+
+  await registerNotificationCategories();
 
   const { status: existingStatus } = await Notifications.getPermissionsAsync();
 

--- a/apps/mobile/src/services/getPushNotificationToken.ts
+++ b/apps/mobile/src/services/getPushNotificationToken.ts
@@ -4,6 +4,11 @@ import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 import Color from "color";
 
+import {
+  NOTIFICATION_ACTION,
+  NOTIFICATION_CATEGORY,
+  NOTIFICATION_CHANNEL,
+} from "@pegada/shared/constants/notifications";
 import { LightTheme } from "@pegada/shared/themes/themes";
 
 import { getTrcpContext } from "@/contexts/trcpContext";
@@ -23,21 +28,13 @@ export enum NotificationTokenError {
   Denied = "Push notifications denied",
 }
 
-export enum NotificationCategory {
-  ChatMessage = "chat-message",
-}
-
-export enum NotificationAction {
-  Reply = "reply",
-}
-
 // Lets a chat-message push carry a text-input "Reply" action on both
 // platforms, so the user can answer straight from the notification
 // without opening the app. Handled in `services/linking`.
 const registerNotificationCategories = async () => {
-  await Notifications.setNotificationCategoryAsync(NotificationCategory.ChatMessage, [
+  await Notifications.setNotificationCategoryAsync(NOTIFICATION_CATEGORY.ChatMessage, [
     {
-      identifier: NotificationAction.Reply,
+      identifier: NOTIFICATION_ACTION.Reply,
       buttonTitle: i18n.t("chat.replyAction"),
       textInput: {
         submitButtonTitle: i18n.t("chat.replyAction"),
@@ -58,9 +55,9 @@ export const getPushNotificationToken = async () => {
       lightColor: Color(LightTheme.colors.primary).alpha(0.7).hex(),
     });
 
-    // Dedicated channel for chat-message pushes, matched server-side by
-    // `channelId: "messages"` (see MessageService).
-    await Notifications.setNotificationChannelAsync("messages", {
+    // Dedicated channel for chat-message pushes, matched server-side by the
+    // same shared id (see MessageService).
+    await Notifications.setNotificationChannelAsync(NOTIFICATION_CHANNEL.ChatMessage, {
       name: i18n.t("chat.notificationChannelName"),
       importance: Notifications.AndroidImportance.MAX,
       vibrationPattern: [0, 250, 250, 250],

--- a/apps/mobile/src/services/linking/handlers/notification.ts
+++ b/apps/mobile/src/services/linking/handlers/notification.ts
@@ -4,7 +4,7 @@ import { router } from "expo-router";
 import { sendError } from "@/services/errorTracking";
 import { SceneName } from "@/types/SceneName";
 
-enum NotificationUrl {
+export enum NotificationUrl {
   Match = "match/",
   Chat = "chat/",
 }

--- a/apps/mobile/src/services/linking/handlers/reply.test.ts
+++ b/apps/mobile/src/services/linking/handlers/reply.test.ts
@@ -1,0 +1,95 @@
+import * as Notifications from "expo-notifications";
+
+import { NOTIFICATION_ACTION, NOTIFICATION_CATEGORY } from "@pegada/shared/constants/notifications";
+
+import { getTrcpContext } from "@/contexts/trcpContext";
+import { sendError } from "@/services/errorTracking";
+import { getMatchIdFromUrl, handleReplyAction, isReplyAction } from "./reply";
+
+jest.mock("expo-notifications", () => ({ scheduleNotificationAsync: jest.fn() }));
+// Pulled in transitively by ./notification, and untransformed by jest.
+jest.mock("expo-router", () => ({ router: { push: jest.fn() } }));
+jest.mock("@/contexts/trcpContext", () => ({ getTrcpContext: jest.fn() }));
+jest.mock("@/services/errorTracking", () => ({ sendError: jest.fn() }));
+jest.mock("@/i18n", () => ({ __esModule: true, default: { t: (key: string) => key } }));
+
+const mutate = jest.fn();
+const scheduleNotificationAsync = Notifications.scheduleNotificationAsync as jest.Mock;
+const sendErrorMock = sendError as jest.Mock;
+
+(getTrcpContext as jest.Mock).mockReturnValue({ client: { message: { send: { mutate } } } });
+
+const response = (overrides: {
+  actionIdentifier?: string;
+  categoryIdentifier?: string;
+  url?: string;
+  userText?: string;
+}) =>
+  ({
+    actionIdentifier: overrides.actionIdentifier ?? NOTIFICATION_ACTION.Reply,
+    userText: overrides.userText,
+    notification: {
+      request: {
+        content: {
+          categoryIdentifier: overrides.categoryIdentifier ?? NOTIFICATION_CATEGORY.ChatMessage,
+          data: { url: overrides.url ?? "chat/match-1/dog-2" },
+        },
+      },
+    },
+  }) as unknown as Notifications.NotificationResponse;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("isReplyAction", () => {
+  test("only claims a reply on the chat-message category", () => {
+    expect(isReplyAction(response({}))).toBe(true);
+    expect(
+      isReplyAction(response({ actionIdentifier: "expo.modules.notifications.actions.DEFAULT" })),
+    ).toBe(false);
+    expect(isReplyAction(response({ categoryIdentifier: "match" }))).toBe(false);
+  });
+});
+
+describe("getMatchIdFromUrl", () => {
+  test.each([
+    ["chat/match-1/dog-2", "match-1"],
+    ["match/match-1/dog-2", undefined],
+    [undefined, undefined],
+  ])("reads %p as %p", (url, expected) => {
+    expect(getMatchIdFromUrl(url)).toBe(expected);
+  });
+});
+
+describe("handleReplyAction", () => {
+  test("sends the typed text to the match the push came from", async () => {
+    await handleReplyAction(response({ userText: "  on my way  " }));
+
+    expect(mutate).toHaveBeenCalledWith({ matchId: "match-1", content: "on my way" });
+    expect(scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["empty text", { userText: "   " }],
+    ["a non-chat url", { userText: "hi", url: "match/match-1/dog-2" }],
+  ])("reports %s instead of sending", async (_label, overrides) => {
+    await handleReplyAction(response(overrides));
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(sendErrorMock).toHaveBeenCalled();
+  });
+
+  test("tells the user when the send fails, since the notification is already gone", async () => {
+    const error = new Error("offline");
+    mutate.mockRejectedValueOnce(error);
+
+    await handleReplyAction(response({ userText: "hi" }));
+
+    expect(sendErrorMock).toHaveBeenCalledWith(error);
+    expect(scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: { title: "chat.replyFailed", sound: false },
+      trigger: null,
+    });
+  });
+});

--- a/apps/mobile/src/services/linking/handlers/reply.ts
+++ b/apps/mobile/src/services/linking/handlers/reply.ts
@@ -1,0 +1,48 @@
+import * as Notifications from "expo-notifications";
+
+import { getTrcpContext } from "@/contexts/trcpContext";
+import { sendError } from "@/services/errorTracking";
+import { NotificationAction, NotificationCategory } from "@/services/getPushNotificationToken";
+import { getNotificationUrl, NotificationUrl } from "./notification";
+
+// Chat-message pushes carry `chat/<matchId>/<dogId>` in `data.url` (see
+// MessageService, server-side). Reused here to know which match the
+// "Reply" text-input action should send to.
+const getMatchIdFromUrl = (url?: string): string | undefined => {
+  if (!url?.startsWith(NotificationUrl.Chat)) return undefined;
+
+  const [matchId] = url.replace(NotificationUrl.Chat, "").split("/");
+  return matchId;
+};
+
+export const isReplyAction = (response: Notifications.NotificationResponse) => {
+  const category = response.notification.request.content.categoryIdentifier;
+
+  return (
+    response.actionIdentifier === NotificationAction.Reply &&
+    category === NotificationCategory.ChatMessage
+  );
+};
+
+/**
+ * Handles the "Reply" text-input action on a chat-message notification by
+ * sending the typed text through the same tRPC mutation the Chat screen
+ * uses, so it works without that screen being mounted.
+ *
+ * Fires for foreground and backgrounded apps. If the app was killed,
+ * `opensAppToForeground` (default true on the action) brings it to the
+ * foreground first so this listener can run - there is no reliable way
+ * with expo-notifications alone to send the reply without doing that.
+ */
+export const handleReplyAction = async (response: Notifications.NotificationResponse) => {
+  const content = response.userText?.trim();
+  const url = getNotificationUrl(response);
+  const matchId = getMatchIdFromUrl(url);
+
+  if (!content || !matchId) {
+    sendError(new Error("Invalid reply notification: missing content or matchId"));
+    return;
+  }
+
+  await getTrcpContext().client.message.send.mutate({ matchId, content });
+};

--- a/apps/mobile/src/services/linking/handlers/reply.ts
+++ b/apps/mobile/src/services/linking/handlers/reply.ts
@@ -1,14 +1,16 @@
 import * as Notifications from "expo-notifications";
 
+import { NOTIFICATION_ACTION, NOTIFICATION_CATEGORY } from "@pegada/shared/constants/notifications";
+
 import { getTrcpContext } from "@/contexts/trcpContext";
+import i18n from "@/i18n";
 import { sendError } from "@/services/errorTracking";
-import { NotificationAction, NotificationCategory } from "@/services/getPushNotificationToken";
 import { getNotificationUrl, NotificationUrl } from "./notification";
 
 // Chat-message pushes carry `chat/<matchId>/<dogId>` in `data.url` (see
 // MessageService, server-side). Reused here to know which match the
 // "Reply" text-input action should send to.
-const getMatchIdFromUrl = (url?: string): string | undefined => {
+export const getMatchIdFromUrl = (url?: string): string | undefined => {
   if (!url?.startsWith(NotificationUrl.Chat)) return undefined;
 
   const [matchId] = url.replace(NotificationUrl.Chat, "").split("/");
@@ -19,20 +21,30 @@ export const isReplyAction = (response: Notifications.NotificationResponse) => {
   const category = response.notification.request.content.categoryIdentifier;
 
   return (
-    response.actionIdentifier === NotificationAction.Reply &&
-    category === NotificationCategory.ChatMessage
+    response.actionIdentifier === NOTIFICATION_ACTION.Reply &&
+    category === NOTIFICATION_CATEGORY.ChatMessage
   );
 };
+
+// Submitting the reply dismisses the notification, so a failed send would
+// otherwise disappear without the user ever knowing. The in-app composer marks
+// the bubble as failed for the same reason; off-screen, a notification is the
+// only channel left.
+const warnReplyFailed = () =>
+  Notifications.scheduleNotificationAsync({
+    content: { title: i18n.t("chat.replyFailed"), sound: false },
+    trigger: null,
+  });
 
 /**
  * Handles the "Reply" text-input action on a chat-message notification by
  * sending the typed text through the same tRPC mutation the Chat screen
  * uses, so it works without that screen being mounted.
  *
- * Fires for foreground and backgrounded apps. If the app was killed,
- * `opensAppToForeground` (default true on the action) brings it to the
- * foreground first so this listener can run - there is no reliable way
- * with expo-notifications alone to send the reply without doing that.
+ * Called from `useGetInitialNotifications` for both a live response and the
+ * cold-launch one. If the app was killed, `opensAppToForeground` (default true
+ * on the action) brings it to the foreground first so this can run; there is no
+ * reliable way with expo-notifications alone to send the reply without that.
  */
 export const handleReplyAction = async (response: Notifications.NotificationResponse) => {
   const content = response.userText?.trim();
@@ -44,5 +56,10 @@ export const handleReplyAction = async (response: Notifications.NotificationResp
     return;
   }
 
-  await getTrcpContext().client.message.send.mutate({ matchId, content });
+  try {
+    await getTrcpContext().client.message.send.mutate({ matchId, content });
+  } catch (error) {
+    sendError(error);
+    await warnReplyFailed();
+  }
 };

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -4,6 +4,7 @@ import * as Notifications from "expo-notifications";
 import { sendError } from "@/services/errorTracking";
 import { initialNotification, setInitialNotification } from "./handlers/initialNotification";
 import { customNotificationHandler, getNotificationUrl } from "./handlers/notification";
+import { handleReplyAction, isReplyAction } from "./handlers/reply";
 
 export const processLinks = () => {
   if (initialNotification) {
@@ -15,6 +16,11 @@ export const processLinks = () => {
   // When the app is already running, and the user clicks on a notification
   const notificationSubscription = Notifications.addNotificationResponseReceivedListener(
     (response) => {
+      // The "Reply" action is already handled by the root listener in
+      // `useGetInitialNotifications` - skip it here so we don't send the
+      // message twice or navigate into the chat the user didn't tap into.
+      if (isReplyAction(response)) return;
+
       const url = getNotificationUrl(response);
       customNotificationHandler(url).catch(sendError);
     },
@@ -38,9 +44,16 @@ export const useGetInitialNotifications = () => {
       })
       .catch(sendError);
 
-    // When the app is already running, and the user clicks on a notification
+    // Registered here (root, mounted for the whole app lifetime) rather
+    // than in `processLinks`, so the "Reply" action on a chat-message push
+    // is handled even if the user never navigates to the Swipe screen.
     const notificationSubscription = Notifications.addNotificationResponseReceivedListener(
       (response) => {
+        if (isReplyAction(response)) {
+          handleReplyAction(response).catch(sendError);
+          return;
+        }
+
         const url = getNotificationUrl(response);
         setInitialNotification(url);
       },

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -39,6 +39,19 @@ export const useGetInitialNotifications = () => {
     Notifications.getLastNotificationResponseAsync()
       .then((response) => {
         if (!response) return;
+
+        // A reply typed on a killed app only ever surfaces here. Native buffers
+        // the launch response and replays it into the module the moment it is
+        // created, which is before any JS listener exists, so the emitted event
+        // goes nowhere and only `lastResponse` survives (see
+        // NotificationCenterManager.pendingResponses on iOS and
+        // NotificationManager's listener replay on Android). Sending from the
+        // listener alone silently dropped the message.
+        if (isReplyAction(response)) {
+          handleReplyAction(response).catch(sendError);
+          return;
+        }
+
         const url = getNotificationUrl(response);
         setInitialNotification(url);
       })

--- a/apps/mobile/targets/notification-service/Info.plist
+++ b/apps/mobile/targets/notification-service/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Hand-maintained (apple-targets only generates this file when absent).
+    IntentsSupported/INSendMessageIntent is what marks the extension as
+    capable of upgrading pushes into communication notifications.
+  -->
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionAttributes</key>
+    <dict>
+      <key>IntentsSupported</key>
+      <array>
+        <string>INSendMessageIntent</string>
+      </array>
+    </dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.usernotifications.service</string>
+    <key>NSExtensionPrincipalClass</key>
+    <string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+  </dict>
+</dict>
+</plist>

--- a/apps/mobile/targets/notification-service/NotificationService.swift
+++ b/apps/mobile/targets/notification-service/NotificationService.swift
@@ -1,0 +1,162 @@
+import Intents
+import UserNotifications
+
+/// Upgrades incoming chat pushes into iOS communication notifications
+/// (sender dog avatar + name, iMessage-style) by donating an
+/// `INSendMessageIntent` and rebuilding the notification content from it.
+///
+/// The server marks chat pushes with `mutable-content: 1` and ships
+/// `senderName` / `senderAvatarUrl` / `url` in the Expo push `data` payload
+/// (see packages/api/src/services/MessageService.ts).
+///
+/// NSE contract: no matter what fails (missing fields, avatar download,
+/// intent donation), the original notification content is still delivered.
+/// This class must never swallow a notification or hand back broken content.
+final class NotificationService: UNNotificationServiceExtension {
+  private var contentHandler: ((UNNotificationContent) -> Void)?
+  private var bestAttemptContent: UNMutableNotificationContent?
+  private var avatarTask: URLSessionDataTask?
+
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+  ) {
+    self.contentHandler = contentHandler
+
+    guard let bestAttempt = request.content.mutableCopy() as? UNMutableNotificationContent else {
+      contentHandler(request.content)
+      return
+    }
+    bestAttemptContent = bestAttempt
+
+    let data = Self.expoData(from: request.content.userInfo)
+
+    guard
+      let senderName = data["senderName"] as? String, !senderName.isEmpty,
+      let url = data["url"] as? String, !url.isEmpty
+    else {
+      // Not a payload we know how to upgrade: deliver as-is.
+      contentHandler(bestAttempt)
+      return
+    }
+
+    // Deep-link convention from the server: chat/<matchId>/<senderDogId>.
+    let parts = url.split(separator: "/").map(String.init)
+    let conversationId = parts.count > 1 ? parts[1] : url
+    let senderId = parts.count > 2 ? parts[2] : senderName
+
+    // Group notifications per conversation even if the intent rebuild fails.
+    bestAttempt.threadIdentifier = conversationId
+
+    let avatarUrl = (data["senderAvatarUrl"] as? String).flatMap(URL.init(string:))
+
+    downloadAvatar(from: avatarUrl) { [weak self] avatar in
+      guard let self else { return }
+      let upgraded = Self.communicationContent(
+        from: bestAttempt,
+        senderId: senderId,
+        senderName: senderName,
+        conversationId: conversationId,
+        avatar: avatar
+      )
+      self.deliver(upgraded ?? bestAttempt)
+    }
+  }
+
+  override func serviceExtensionTimeWillExpire() {
+    // Out of time: cancel the avatar download and ship the best we have.
+    avatarTask?.cancel()
+    if let bestAttemptContent {
+      deliver(bestAttemptContent)
+    }
+  }
+
+  private func deliver(_ content: UNNotificationContent) {
+    contentHandler?(content)
+    contentHandler = nil
+  }
+
+  // MARK: - Payload parsing
+
+  /// Expo's push gateway delivers the message's `data` field under the
+  /// top-level `body` key of the APNs payload (dictionary, or JSON string in
+  /// older gateway versions). Handle both shapes defensively.
+  private static func expoData(from userInfo: [AnyHashable: Any]) -> [String: Any] {
+    if let dict = userInfo["body"] as? [String: Any] {
+      return dict
+    }
+    if let string = userInfo["body"] as? String,
+      let data = string.data(using: .utf8),
+      let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    {
+      return dict
+    }
+    return [:]
+  }
+
+  // MARK: - Avatar download
+
+  /// Fetches the sender's avatar. Always calls `completion`, with `nil` on
+  /// any failure so the notification still upgrades (just without a photo).
+  private func downloadAvatar(from url: URL?, completion: @escaping (INImage?) -> Void) {
+    guard let url, url.scheme == "https" else {
+      completion(nil)
+      return
+    }
+
+    // Stay well inside the NSE's ~30s budget so the intent donation and
+    // handoff still happen even on a slow network.
+    let task = URLSession.shared.dataTask(with: url) { data, response, _ in
+      guard
+        let data, !data.isEmpty,
+        let httpResponse = response as? HTTPURLResponse,
+        (200..<300).contains(httpResponse.statusCode)
+      else {
+        completion(nil)
+        return
+      }
+      completion(INImage(imageData: data))
+    }
+    avatarTask = task
+    task.resume()
+  }
+
+  // MARK: - Communication styling
+
+  /// Donates an incoming `INSendMessageIntent` for the sender and rebuilds
+  /// the notification content from it. Returns `nil` on any failure so the
+  /// caller can fall back to the untouched content.
+  private static func communicationContent(
+    from content: UNMutableNotificationContent,
+    senderId: String,
+    senderName: String,
+    conversationId: String,
+    avatar: INImage?
+  ) -> UNNotificationContent? {
+    let sender = INPerson(
+      personHandle: INPersonHandle(value: senderId, type: .unknown),
+      nameComponents: nil,
+      displayName: senderName,
+      image: avatar,
+      contactIdentifier: nil,
+      customIdentifier: senderId
+    )
+
+    let intent = INSendMessageIntent(
+      recipients: nil,
+      outgoingMessageType: .outgoingMessageText,
+      content: content.body,
+      speakableGroupName: nil,
+      conversationIdentifier: conversationId,
+      serviceName: nil,
+      sender: sender,
+      attachments: nil
+    )
+
+    let interaction = INInteraction(intent: intent, response: nil)
+    interaction.direction = .incoming
+    interaction.donate(completion: nil)
+
+    return try? content.updating(from: intent)
+  }
+}

--- a/apps/mobile/targets/notification-service/expo-target.config.js
+++ b/apps/mobile/targets/notification-service/expo-target.config.js
@@ -1,0 +1,26 @@
+// Notification Service Extension (NSE) for chat pushes. Intercepts pushes
+// sent with `mutable-content: 1` (see packages/api MessageService) and
+// restyles them as iOS communication notifications: sender dog avatar +
+// name, iMessage-style. See NotificationService.swift for the actual work.
+//
+// Wired into the Xcode project at prebuild time by @bacons/apple-targets
+// (the `targets/` folder is CNG-safe: nothing under ios/ is committed).
+
+/** @type {import('@bacons/apple-targets/app.plugin').Config} */
+module.exports = {
+  type: "notification-service",
+  name: "PegadaNotificationService",
+  displayName: "Pegada Notification Service",
+  // Appended to the main app's bundle id -> app.pegada.notificationservice
+  bundleIdentifier: ".notificationservice",
+  // INSendMessageIntent + UNNotificationContent.updating(from:) need iOS 15+.
+  deploymentTarget: "15.1",
+  frameworks: ["UserNotifications", "Intents"],
+  entitlements: {
+    // Communication-notification styling. Must also be enabled on the App ID
+    // in the Apple Developer portal for device builds (simulator doesn't
+    // enforce it). The main app carries the same entitlement via
+    // `ios.entitlements` in app.config.ts.
+    "com.apple.developer.usernotifications.communication": true,
+  },
+};

--- a/apps/mobile/targets/notification-service/generated.entitlements
+++ b/apps/mobile/targets/notification-service/generated.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
+  </dict>
+</plist>

--- a/packages/api/src/services/MessageService.ts
+++ b/packages/api/src/services/MessageService.ts
@@ -1,5 +1,6 @@
 import prisma from "@pegada/database";
 import { Language } from "@pegada/shared/i18n/types/types";
+import { IMAGE_STATUS } from "@pegada/shared/schemas/dogSchema";
 
 import { PushNotificationService } from "./PushNotificationService";
 import { TranslationService } from "./TranslationService";
@@ -64,7 +65,15 @@ class MessageService {
         sender: {
           select: {
             name: true,
-            images: true,
+            // First approved photo only: it rides along in the push payload so
+            // the iOS Notification Service Extension can render the sender's
+            // avatar on communication notifications.
+            images: {
+              orderBy: { position: "asc" },
+              where: { status: IMAGE_STATUS.APPROVED },
+              take: 1,
+              select: { url: true },
+            },
           },
         },
         receiver: {
@@ -93,8 +102,13 @@ class MessageService {
         }),
         channelId: "messages",
         categoryId: "chat-message",
+        // Lets the iOS Notification Service Extension intercept the push and
+        // restyle it as a communication notification (sender avatar + name).
+        mutableContent: true,
         data: {
           url: `chat/${matchId}/${newMessage.senderId}`,
+          senderName: newMessage.sender.name,
+          senderAvatarUrl: newMessage.sender.images[0]?.url,
         },
       });
     }

--- a/packages/api/src/services/MessageService.ts
+++ b/packages/api/src/services/MessageService.ts
@@ -91,6 +91,8 @@ class MessageService {
           lng: this.language,
           replace: { name: newMessage.sender.name },
         }),
+        channelId: "messages",
+        categoryId: "chat-message",
         data: {
           url: `chat/${matchId}/${newMessage.senderId}`,
         },

--- a/packages/api/src/services/MessageService.ts
+++ b/packages/api/src/services/MessageService.ts
@@ -1,4 +1,8 @@
 import prisma from "@pegada/database";
+import {
+  NOTIFICATION_CATEGORY,
+  NOTIFICATION_CHANNEL,
+} from "@pegada/shared/constants/notifications";
 import { Language } from "@pegada/shared/i18n/types/types";
 import { IMAGE_STATUS } from "@pegada/shared/schemas/dogSchema";
 
@@ -100,8 +104,8 @@ class MessageService {
           lng: this.language,
           replace: { name: newMessage.sender.name },
         }),
-        channelId: "messages",
-        categoryId: "chat-message",
+        channelId: NOTIFICATION_CHANNEL.ChatMessage,
+        categoryId: NOTIFICATION_CATEGORY.ChatMessage,
         // Lets the iOS Notification Service Extension intercept the push and
         // restyle it as a communication notification (sender avatar + name).
         mutableContent: true,

--- a/packages/shared/constants/notifications.ts
+++ b/packages/shared/constants/notifications.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared between the push sender (packages/api's MessageService) and the app
+ * that registers them (apps/mobile's getPushNotificationToken). A mismatch
+ * costs the chat push its Reply action and its own Android channel, and
+ * nothing fails loudly, so both sides read the ids from here.
+ */
+export const NOTIFICATION_CHANNEL = {
+  ChatMessage: "messages",
+} as const;
+
+export const NOTIFICATION_CATEGORY = {
+  ChatMessage: "chat-message",
+} as const;
+
+export const NOTIFICATION_ACTION = {
+  Reply: "reply",
+} as const;

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -35,6 +35,8 @@
     "breed": "Breed"
   },
   "chat": {
+    "notificationChannelName": "Messages",
+    "replyAction": "Reply",
     "sendAMessageToStart": "Send a message to start the conversation",
     "today": "Today",
     "yesterday": "Yesterday",

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -37,6 +37,7 @@
   "chat": {
     "notificationChannelName": "Messages",
     "replyAction": "Reply",
+    "replyFailed": "Your reply didn't send. Open the chat to try again.",
     "sendAMessageToStart": "Send a message to start the conversation",
     "today": "Today",
     "yesterday": "Yesterday",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -35,6 +35,8 @@
     "breed": "Raça"
   },
   "chat": {
+    "notificationChannelName": "Mensagens",
+    "replyAction": "Responder",
     "sendAMessageToStart": "Envie uma mensagem para iniciar a conversa",
     "today": "Hoje",
     "yesterday": "Ontem",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -37,6 +37,7 @@
   "chat": {
     "notificationChannelName": "Mensagens",
     "replyAction": "Responder",
+    "replyFailed": "Sua resposta n\u00e3o foi enviada. Abre a conversa pra tentar de novo.",
     "sendAMessageToStart": "Envie uma mensagem para iniciar a conversa",
     "today": "Hoje",
     "yesterday": "Ontem",


### PR DESCRIPTION
## Summary

Chat pushes get a Reply action you can answer without opening the app, land on their own "Messages" channel on Android, and render iMessage-style on iOS with the sender dog's photo.

## Details

### Reply action

- Notification category with a text-input Reply action on both platforms, localised (Reply / Responder). The server tags chat pushes with the matching `categoryId`, which is the real expo-server-sdk field name; the docs' `categoryIdentifier` isn't on the type.
- The reply goes through the same `message.send` mutation the chat screen uses, from a root-level listener, so no chat screen has to be mounted.
- Replying from a killed app used to drop the message on the floor. Native buffers the launch response and replays it into the module the moment it's created, before any JS listener exists, so the emitted event goes nowhere and only `getLastNotificationResponseAsync` still has it. That path parsed the deep link and navigated into the chat without ever sending. Reply responses are handled there too now.
- A failed send raises a local notification. Submitting the reply dismisses the original, so the in-app "failed" bubble has no off-screen equivalent and the message was vanishing with nothing but an error report behind it.
- The swipe screen's separate listener skips reply responses so nothing double-fires.

### Android channel

- Dedicated channel for chat messages with a localised name. Channel, category and action ids live in `@pegada/shared`, so the push sender and the app that registers them read the same values.

### iOS communication notifications (this is #80, merged into this branch)

- Notification Service Extension in Swift, via `@bacons/apple-targets`, that intercepts chat pushes, downloads the sender dog's avatar and donates an `INSendMessageIntent`.
- Falls back to the untouched notification on anything going wrong: missing fields, avatar download, intent donation, the extension's time budget.
- The server marks chat pushes mutable-content and ships `senderName` and `senderAvatarUrl`, using only the first APPROVED photo, which also stops unapproved sender images leaking into the payload.
- Notifications group per conversation on the match id.

## Before this ships

- `com.apple.developer.usernotifications.communication` has to be enabled on both App IDs, the app and the notification service, in the Apple Developer portal. EAS in non-interactive mode can only reuse an existing provisioning profile, so a release build fails to sign until that's done. I'm the only one with portal access, so that's on me.
- Native changed, so this needs a binary. An OTA won't pick it up. `main` is already on 1.5.0 with no 1.5.0 build behind it, so this rides along with whatever ships that version.

## Proof

iPhone 17 Pro Max simulator, iOS 26.5, Release build, with `EXPO_PUBLIC_API_URL` pointed at a local stub that logs every tRPC call.

Chat push arriving with the app backgrounded, and the same notification sitting on the lock screen:

![chat push banner](https://raw.githubusercontent.com/GSTJ/pegada/gstj/pr-assets-dump/pr75/chat-push-banner.png)
![chat push on the lock screen](https://raw.githubusercontent.com/GSTJ/pegada/gstj/pr-assets-dump/pr75/chat-push-lockscreen.png)

The reply itself I drove from a temporary in-app button that hands `handleReplyAction` the response object expo-notifications produces for a text-input action. The simulator's SpringBoard ignores synthesised touches on a banner, so nothing can type into the real Reply field from a script. That covers everything downstream of the handler getting a reply response, including the request leaving the device:

```
[2026-07-26T23:59:43.566Z] POST /api/trpc/message.send?batch=1
  body: {"0":{"json":{"matchId":"match-1","content":"on my way"}}}
```

![reply handler run](https://raw.githubusercontent.com/GSTJ/pegada/gstj/pr-assets-dump/pr75/reply-handler-run.png)

The gesture itself still wants a real device.

## Testing steps

Needs a real device and a fresh install, since Android only registers the new channel on first launch.

1. From a second test account, send yourself a chat message with the app in the background.
2. Expand the notification, type an answer, send it from there. The other account receives it and your phone stays where it was.
3. Force-close the app and reply from the notification again. The app opens briefly, which is an expo-notifications limitation, and the message still goes out.
4. Turn on airplane mode and reply. You should get a "your reply didn't send" notification.
5. Tap the body of a chat notification: the app opens that exact conversation.
6. iOS: the notification shows the sender dog's photo and name, iMessage-style, and several messages from two matches stack per conversation.
7. Android: chat messages appear under their own "Messages" category in the app's notification settings.
