### PR TITLE
feat(mobile): home-screen quick actions

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -13,7 +13,7 @@ const config: ExpoConfig = {
    * That affects eas updates and makes sure the app doesn't
    * break when updating Over The Air
    */
-  version: "1.4.0",
+  version: "1.5.0",
   runtimeVersion: {
     policy: "appVersion",
   },
@@ -39,6 +39,7 @@ const config: ExpoConfig = {
     "expo-notifications",
     "expo-localization",
     "expo-router",
+    "expo-quick-actions",
     // react-native-maps 1.20+ enables Google Maps via its own config plugin.
     // The deprecated `ios.config.googleMapsApiKey` / `android.config.googleMaps`
     // fields make Expo prebuild reference a `react-native-google-maps` podspec

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -53,6 +53,7 @@
     "expo-localization": "~55.0.16",
     "expo-location": "~55.1.10",
     "expo-notifications": "^55.0.23",
+    "expo-quick-actions": "^6.0.2",
     "expo-router": "^55.0.14",
     "expo-secure-store": "^55.0.14",
     "expo-splash-screen": "~55.0.21",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -18,6 +18,7 @@ import { useProtectedRoute } from "@/hooks/useProtectedRoute";
 import { useTrackScreens } from "@/hooks/useTrackScreens";
 import { sendError } from "@/services/errorTracking";
 import { useGetInitialNotifications } from "@/services/linking";
+import { useQuickActions } from "@/services/quickActions";
 import { store } from "@/store";
 
 // Wait for the assets to load before hiding the SplashScreen
@@ -39,6 +40,7 @@ const App = () => {
 
   useTrackScreens();
   useGetInitialNotifications();
+  useQuickActions();
 
   // MAESTRO_E2E only: render magic modals inside the main window instead
   // of RNScreens' FullWindowOverlay. The overlay is a separate native

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -19,6 +19,7 @@ import { useTrackScreens } from "@/hooks/useTrackScreens";
 import { sendError } from "@/services/errorTracking";
 import { useGetInitialNotifications } from "@/services/linking";
 import { useQuickActions } from "@/services/quickActions";
+import { SceneName } from "@/types/SceneName";
 import { store } from "@/store";
 
 // Wait for the assets to load before hiding the SplashScreen
@@ -40,7 +41,10 @@ const App = () => {
 
   useTrackScreens();
   useGetInitialNotifications();
-  useQuickActions();
+  // Quick actions can be triggered from this unauthenticated-safe root
+  // mount, so navigation is gated on having resolved to the fully
+  // authenticated, onboarded route -- see `useQuickActions`'s docblock.
+  useQuickActions(initialRouteName === SceneName.Swipe);
 
   // MAESTRO_E2E only: render magic modals inside the main window instead
   // of RNScreens' FullWindowOverlay. The overlay is a separate native

--- a/apps/mobile/src/services/quickActions/handlers/action.ts
+++ b/apps/mobile/src/services/quickActions/handlers/action.ts
@@ -1,0 +1,28 @@
+import * as QuickActions from "expo-quick-actions";
+import { router } from "expo-router";
+
+import { sendError } from "@/services/errorTracking";
+import { SceneName } from "@/types/SceneName";
+
+export enum QuickActionId {
+  Matches = "matches",
+  EditProfile = "editProfile",
+}
+
+const handleUnknownQuickAction = (id: string) => {
+  sendError(new Error(`Unknown quick action: ${id}`));
+};
+
+export const customQuickActionHandler = (action?: QuickActions.Action | null) => {
+  if (!action) return;
+
+  if (action.id === QuickActionId.Matches) {
+    return router.push(SceneName.Messages);
+  }
+
+  if (action.id === QuickActionId.EditProfile) {
+    return router.push(SceneName.EditProfile);
+  }
+
+  handleUnknownQuickAction(action.id);
+};

--- a/apps/mobile/src/services/quickActions/handlers/action.ts
+++ b/apps/mobile/src/services/quickActions/handlers/action.ts
@@ -9,6 +9,16 @@ export enum QuickActionId {
   EditProfile = "editProfile",
 }
 
+// Holds a quick action tapped before we know whether the user is
+// authenticated and fully onboarded (mirrors `initialNotification` in
+// `services/linking/handlers/initialNotification.ts`). Cleared once
+// consumed so it doesn't replay on a later, unrelated auth resolution.
+let pendingQuickAction: QuickActions.Action | undefined;
+
+export const setPendingQuickAction = (action?: QuickActions.Action | null) => {
+  pendingQuickAction = action ?? undefined;
+};
+
 const handleUnknownQuickAction = (id: string) => {
   sendError(new Error(`Unknown quick action: ${id}`));
 };
@@ -25,4 +35,15 @@ export const customQuickActionHandler = (action?: QuickActions.Action | null) =>
   }
 
   handleUnknownQuickAction(action.id);
+};
+
+// Only called once the app has resolved to the fully authenticated,
+// onboarded route (`SceneName.Swipe`) -- see `useQuickActions`. This is
+// the same "navigate only from an authenticated mount point" guarantee
+// `services/linking`'s `processLinks` gets from only being called inside
+// the Swipe screen.
+export const flushPendingQuickAction = () => {
+  const action = pendingQuickAction;
+  pendingQuickAction = undefined;
+  customQuickActionHandler(action);
 };

--- a/apps/mobile/src/services/quickActions/handlers/icons.ts
+++ b/apps/mobile/src/services/quickActions/handlers/icons.ts
@@ -1,0 +1,10 @@
+import { Platform } from "react-native";
+
+// expo-quick-actions icons are iOS-only (SF Symbols / built-in system
+// icons, see the library's README). Android has no built-in named icons --
+// only custom drawables via its config plugin -- so we pass `undefined`
+// there and let the shortcut fall back to the app's own icon, which keeps
+// this simple without shipping extra icon assets.
+export const matchesIcon = Platform.select({ ios: "symbol:message.fill", default: undefined });
+
+export const editProfileIcon = Platform.select({ ios: "symbol:person.fill", default: undefined });

--- a/apps/mobile/src/services/quickActions/index.ts
+++ b/apps/mobile/src/services/quickActions/index.ts
@@ -3,25 +3,54 @@ import * as QuickActions from "expo-quick-actions";
 import { useTranslation } from "react-i18next";
 
 import { sendError } from "@/services/errorTracking";
-import { customQuickActionHandler, QuickActionId } from "./handlers/action";
+import {
+  customQuickActionHandler,
+  flushPendingQuickAction,
+  QuickActionId,
+  setPendingQuickAction,
+} from "./handlers/action";
 import { editProfileIcon, matchesIcon } from "./handlers/icons";
 
-export const useQuickActions = () => {
+/**
+ * `enabled` must only be `true` once the app has resolved to the fully
+ * authenticated, onboarded route (`initialRouteName === SceneName.Swipe`
+ * in `app/_layout.tsx`). Quick actions are reachable from the
+ * unauthenticated root mount, so -- like `services/linking`'s
+ * `processLinks`, which only runs inside the authenticated Swipe screen --
+ * we must not navigate before that resolves. A tap that arrives earlier
+ * (cold start, or a warm tap while still signed out/onboarding) is held
+ * and replayed once `enabled` flips to `true`, instead of being dropped
+ * or racing the auth redirect.
+ */
+export const useQuickActions = (enabled: boolean) => {
   const { t, i18n } = useTranslation();
 
   useEffect(() => {
     // When the app is not already running, and the user taps a quick action
-    customQuickActionHandler(QuickActions.initial);
+    setPendingQuickAction(QuickActions.initial);
   }, []);
 
   useEffect(() => {
     // When the app is already running, and the user taps a quick action
-    const subscription = QuickActions.addListener(customQuickActionHandler);
+    const subscription = QuickActions.addListener((action) => {
+      if (enabled) {
+        customQuickActionHandler(action);
+        return;
+      }
+
+      setPendingQuickAction(action);
+    });
 
     return () => {
       subscription.remove();
     };
-  }, []);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    flushPendingQuickAction();
+  }, [enabled]);
 
   useEffect(() => {
     // Titles come from the runtime API (not the static config plugin) so

--- a/apps/mobile/src/services/quickActions/index.ts
+++ b/apps/mobile/src/services/quickActions/index.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import * as QuickActions from "expo-quick-actions";
+import { useTranslation } from "react-i18next";
+
+import { sendError } from "@/services/errorTracking";
+import { customQuickActionHandler, QuickActionId } from "./handlers/action";
+import { editProfileIcon, matchesIcon } from "./handlers/icons";
+
+export const useQuickActions = () => {
+  const { t, i18n } = useTranslation();
+
+  useEffect(() => {
+    // When the app is not already running, and the user taps a quick action
+    customQuickActionHandler(QuickActions.initial);
+  }, []);
+
+  useEffect(() => {
+    // When the app is already running, and the user taps a quick action
+    const subscription = QuickActions.addListener(customQuickActionHandler);
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    // Titles come from the runtime API (not the static config plugin) so
+    // they follow the user's in-app language choice, not just the device
+    // locale. Re-run whenever it changes so an in-app language switch
+    // updates the shortcuts without needing an app restart.
+    const setLocalizedItems = () => {
+      QuickActions.setItems([
+        {
+          id: QuickActionId.Matches,
+          title: t("quickActions.matches"),
+          icon: matchesIcon,
+        },
+        {
+          id: QuickActionId.EditProfile,
+          title: t("quickActions.editProfile"),
+          icon: editProfileIcon,
+        },
+      ]).catch(sendError);
+    };
+
+    setLocalizedItems();
+    i18n.on("languageChanged", setLocalizedItems);
+
+    return () => {
+      i18n.off("languageChanged", setLocalizedItems);
+    };
+  }, [t, i18n]);
+};

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -216,6 +216,10 @@
     "updateError": "An error occurred while updating your preferences.",
     "years": "0-{{maxYears}}+ years"
   },
+  "quickActions": {
+    "matches": "Matches",
+    "editProfile": "Edit profile"
+  },
   "plans": {
     "FREE": "Free",
     "PREMIUM": "Premium",
@@ -327,9 +331,5 @@
     "automatic": "Automatic",
     "dark": "Dark",
     "light": "Light"
-  },
-  "quickActions": {
-    "matches": "Matches",
-    "editProfile": "Edit profile"
   }
 }

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -327,5 +327,9 @@
     "automatic": "Automatic",
     "dark": "Dark",
     "light": "Light"
+  },
+  "quickActions": {
+    "matches": "Matches",
+    "editProfile": "Edit profile"
   }
 }

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -327,5 +327,9 @@
     "automatic": "Automático",
     "dark": "Escuro",
     "light": "Claro"
+  },
+  "quickActions": {
+    "matches": "Matches",
+    "editProfile": "Editar perfil"
   }
 }

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -216,6 +216,10 @@
     "updateError": "Ocorreu um erro ao atualizar suas preferências.",
     "years": "0-{{maxYears}}+ anos"
   },
+  "quickActions": {
+    "matches": "Matches",
+    "editProfile": "Editar perfil"
+  },
   "links": {
     "termsOfUse": "https://www.pegada.app/pt-br/terms-of-use",
     "privacyPolicy": "https://www.pegada.app/pt-br/privacy-policy"
@@ -327,9 +331,5 @@
     "automatic": "Automático",
     "dark": "Escuro",
     "light": "Claro"
-  },
-  "quickActions": {
-    "matches": "Matches",
-    "editProfile": "Editar perfil"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       expo-notifications:
         specifier: ^55.0.23
         version: 55.0.23(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5)
+      expo-quick-actions:
+        specifier: ^6.0.2
+        version: 6.0.2(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))(typescript@5.4.5)
       expo-router:
         specifier: ^55.0.14
         version: 55.0.14(b25pycznjzzxkiz5hz77uvfcyi)
@@ -3461,13 +3464,29 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
       ajv: ^6.9.1
 
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -4488,6 +4507,11 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-quick-actions@6.0.2:
+    resolution: {integrity: sha512-IVoTMCx55MjSnPqUEb5jhePpOAUdOTonifY3QXM/DBFxc6qMzBy5iJWEkfDZcFAzFzahK1ZW9tFaNv4pi2AAvQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-router@55.0.14:
     resolution: {integrity: sha512-rOn/wosp2hAPM+O2o41hnarbP5Zqv9UkHWa31KoSoiOme1tpmZd2yc93XtRAtzP0P5E5xzqq7a2rbEAarpP5XA==}
     peerDependencies:
@@ -4633,6 +4657,9 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -5253,6 +5280,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -6642,6 +6672,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
@@ -6720,6 +6754,10 @@ packages:
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
+    engines: {node: '>= 10.13.0'}
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
   seedrandom@3.0.5:
@@ -10721,8 +10759,7 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
-  '@types/json-schema@7.0.15':
-    optional: true
+  '@types/json-schema@7.0.15': {}
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
@@ -11002,10 +11039,19 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
     optional: true
+
+  ajv-keywords@5.1.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+      fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
     dependencies:
@@ -11014,6 +11060,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     optional: true
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   anser@1.4.10: {}
 
@@ -12114,6 +12167,16 @@ snapshots:
       - supports-color
       - typescript
 
+  expo-quick-actions@6.0.2(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))(typescript@5.4.5):
+    dependencies:
+      '@expo/image-utils': 0.8.14(typescript@5.4.5)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5)
+      schema-utils: 4.3.3
+      sf-symbols-typescript: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   expo-router@55.0.14(b25pycznjzzxkiz5hz77uvfcyi):
     dependencies:
       '@expo/log-box': 55.0.12(3k66tzb5xj5hun3h6f7mdupxsy)
@@ -12312,6 +12375,8 @@ snapshots:
       micromatch: 4.0.5
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.3: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -13158,6 +13223,8 @@ snapshots:
 
   json-schema-traverse@0.4.1:
     optional: true
+
+  json-schema-traverse@1.0.0: {}
 
   json5@1.0.2:
     dependencies:
@@ -14974,6 +15041,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-main-filename@2.0.0:
     optional: true
 
@@ -15045,6 +15114,13 @@ snapshots:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
     optional: true
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   seedrandom@3.0.5: {}
 


### PR DESCRIPTION
## Summary

Long-pressing the app icon now shows two shortcuts, Matches and Edit profile, in the user's language.

## Details

- expo-quick-actions@6.0.2 using the runtime JS API instead of static config, so titles follow the in-app locale and update live when the user switches language.
- Cold start (app killed) and warm resume both handled, navigating with expo-router to the messages tab and the edit-profile screen.
- iOS gets SF Symbol icons (message bubble, person). Android shows the actions without custom icons on purpose: custom Android icons need shipped image assets via the config plugin, skipped to keep this small.
- Heads up for review: this lib has an open SDK 55 compat thread (expo-quick-actions#56, mixed reports). Prebuild passes clean on both platforms here, but the first device run of this branch is the real proof, so worth testing this one with extra care.
- Version bumped to 1.5.0 (new native module).

## Testing steps

1. Install the build, then long-press the Pegada icon on the home screen: you should see "Matches" and "Edit profile" (or "Editar perfil" with the phone/app in Portuguese).
2. Force-quit the app, long-press the icon and tap Matches: the app launches straight into the messages tab.
3. With the app in the background, long-press and tap Edit profile: the app comes back already on the edit screen, no reload.
4. In the app, switch the language in the profile settings, background it and long-press the icon again: the shortcut titles are in the new language without restarting.