### PR TITLE
feat(mobile): chat pushes as iOS communication notifications with the dog's photo

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -13,7 +13,7 @@ const config: ExpoConfig = {
    * That affects eas updates and makes sure the app doesn't
    * break when updating Over The Air
    */
-  version: "1.4.0",
+  version: "1.5.0",
   runtimeVersion: {
     policy: "appVersion",
   },
@@ -161,6 +161,11 @@ const config: ExpoConfig = {
         cameraPermission: "The app allows you to take photos for your doggie's profile.",
       },
     ],
+    // Wires every directory under `targets/` into the Xcode project at
+    // prebuild time. Currently just the notification-service extension that
+    // renders chat pushes as iOS communication notifications (sender dog
+    // avatar + name); see targets/notification-service/.
+    "@bacons/apple-targets",
     // Wires the source-controlled `Pegada.storekit` fixture into the iOS
     // scheme so simulator runs (local + CI) can resolve real product pricing
     // without an App Store sandbox session. Plugin is a no-op when the file
@@ -242,6 +247,13 @@ const config: ExpoConfig = {
       usesNonExemptEncryption: false,
     },
     bundleIdentifier: "app.pegada",
+    entitlements: {
+      // Communication-notification styling for chat pushes (the
+      // notification-service target carries the same entitlement; both need
+      // the capability enabled on their App IDs in the Apple Developer
+      // portal for device builds).
+      "com.apple.developer.usernotifications.communication": true,
+    },
     // associatedDomains: [
     //   'applinks:pegada.app',
     //   'applinks:www.pegada.app',

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,6 +14,7 @@
     "preinstall": "pnpm setup:secret:files"
   },
   "dependencies": {
+    "@bacons/apple-targets": "4.0.7",
     "@expo/config-types": "^55.0.5",
     "@expo/metro-runtime": "~55.0.11",
     "@gorhom/bottom-sheet": "^5.2.14",

--- a/apps/mobile/targets/notification-service/Info.plist
+++ b/apps/mobile/targets/notification-service/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Hand-maintained (apple-targets only generates this file when absent).
+    IntentsSupported/INSendMessageIntent is what marks the extension as
+    capable of upgrading pushes into communication notifications.
+  -->
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionAttributes</key>
+    <dict>
+      <key>IntentsSupported</key>
+      <array>
+        <string>INSendMessageIntent</string>
+      </array>
+    </dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.usernotifications.service</string>
+    <key>NSExtensionPrincipalClass</key>
+    <string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+  </dict>
+</dict>
+</plist>

--- a/apps/mobile/targets/notification-service/NotificationService.swift
+++ b/apps/mobile/targets/notification-service/NotificationService.swift
@@ -1,0 +1,162 @@
+import Intents
+import UserNotifications
+
+/// Upgrades incoming chat pushes into iOS communication notifications
+/// (sender dog avatar + name, iMessage-style) by donating an
+/// `INSendMessageIntent` and rebuilding the notification content from it.
+///
+/// The server marks chat pushes with `mutable-content: 1` and ships
+/// `senderName` / `senderAvatarUrl` / `url` in the Expo push `data` payload
+/// (see packages/api/src/services/MessageService.ts).
+///
+/// NSE contract: no matter what fails (missing fields, avatar download,
+/// intent donation), the original notification content is still delivered.
+/// This class must never swallow a notification or hand back broken content.
+final class NotificationService: UNNotificationServiceExtension {
+  private var contentHandler: ((UNNotificationContent) -> Void)?
+  private var bestAttemptContent: UNMutableNotificationContent?
+  private var avatarTask: URLSessionDataTask?
+
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+  ) {
+    self.contentHandler = contentHandler
+
+    guard let bestAttempt = request.content.mutableCopy() as? UNMutableNotificationContent else {
+      contentHandler(request.content)
+      return
+    }
+    bestAttemptContent = bestAttempt
+
+    let data = Self.expoData(from: request.content.userInfo)
+
+    guard
+      let senderName = data["senderName"] as? String, !senderName.isEmpty,
+      let url = data["url"] as? String, !url.isEmpty
+    else {
+      // Not a payload we know how to upgrade: deliver as-is.
+      contentHandler(bestAttempt)
+      return
+    }
+
+    // Deep-link convention from the server: chat/<matchId>/<senderDogId>.
+    let parts = url.split(separator: "/").map(String.init)
+    let conversationId = parts.count > 1 ? parts[1] : url
+    let senderId = parts.count > 2 ? parts[2] : senderName
+
+    // Group notifications per conversation even if the intent rebuild fails.
+    bestAttempt.threadIdentifier = conversationId
+
+    let avatarUrl = (data["senderAvatarUrl"] as? String).flatMap(URL.init(string:))
+
+    downloadAvatar(from: avatarUrl) { [weak self] avatar in
+      guard let self else { return }
+      let upgraded = Self.communicationContent(
+        from: bestAttempt,
+        senderId: senderId,
+        senderName: senderName,
+        conversationId: conversationId,
+        avatar: avatar
+      )
+      self.deliver(upgraded ?? bestAttempt)
+    }
+  }
+
+  override func serviceExtensionTimeWillExpire() {
+    // Out of time: cancel the avatar download and ship the best we have.
+    avatarTask?.cancel()
+    if let bestAttemptContent {
+      deliver(bestAttemptContent)
+    }
+  }
+
+  private func deliver(_ content: UNNotificationContent) {
+    contentHandler?(content)
+    contentHandler = nil
+  }
+
+  // MARK: - Payload parsing
+
+  /// Expo's push gateway delivers the message's `data` field under the
+  /// top-level `body` key of the APNs payload (dictionary, or JSON string in
+  /// older gateway versions). Handle both shapes defensively.
+  private static func expoData(from userInfo: [AnyHashable: Any]) -> [String: Any] {
+    if let dict = userInfo["body"] as? [String: Any] {
+      return dict
+    }
+    if let string = userInfo["body"] as? String,
+      let data = string.data(using: .utf8),
+      let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    {
+      return dict
+    }
+    return [:]
+  }
+
+  // MARK: - Avatar download
+
+  /// Fetches the sender's avatar. Always calls `completion`, with `nil` on
+  /// any failure so the notification still upgrades (just without a photo).
+  private func downloadAvatar(from url: URL?, completion: @escaping (INImage?) -> Void) {
+    guard let url, url.scheme == "https" else {
+      completion(nil)
+      return
+    }
+
+    // Stay well inside the NSE's ~30s budget so the intent donation and
+    // handoff still happen even on a slow network.
+    let task = URLSession.shared.dataTask(with: url) { data, response, _ in
+      guard
+        let data, !data.isEmpty,
+        let httpResponse = response as? HTTPURLResponse,
+        (200..<300).contains(httpResponse.statusCode)
+      else {
+        completion(nil)
+        return
+      }
+      completion(INImage(imageData: data))
+    }
+    avatarTask = task
+    task.resume()
+  }
+
+  // MARK: - Communication styling
+
+  /// Donates an incoming `INSendMessageIntent` for the sender and rebuilds
+  /// the notification content from it. Returns `nil` on any failure so the
+  /// caller can fall back to the untouched content.
+  private static func communicationContent(
+    from content: UNMutableNotificationContent,
+    senderId: String,
+    senderName: String,
+    conversationId: String,
+    avatar: INImage?
+  ) -> UNNotificationContent? {
+    let sender = INPerson(
+      personHandle: INPersonHandle(value: senderId, type: .unknown),
+      nameComponents: nil,
+      displayName: senderName,
+      image: avatar,
+      contactIdentifier: nil,
+      customIdentifier: senderId
+    )
+
+    let intent = INSendMessageIntent(
+      recipients: nil,
+      outgoingMessageType: .outgoingMessageText,
+      content: content.body,
+      speakableGroupName: nil,
+      conversationIdentifier: conversationId,
+      serviceName: nil,
+      sender: sender,
+      attachments: nil
+    )
+
+    let interaction = INInteraction(intent: intent, response: nil)
+    interaction.direction = .incoming
+    interaction.donate(completion: nil)
+
+    return try? content.updating(from: intent)
+  }
+}

--- a/apps/mobile/targets/notification-service/expo-target.config.js
+++ b/apps/mobile/targets/notification-service/expo-target.config.js
@@ -1,0 +1,26 @@
+// Notification Service Extension (NSE) for chat pushes. Intercepts pushes
+// sent with `mutable-content: 1` (see packages/api MessageService) and
+// restyles them as iOS communication notifications: sender dog avatar +
+// name, iMessage-style. See NotificationService.swift for the actual work.
+//
+// Wired into the Xcode project at prebuild time by @bacons/apple-targets
+// (the `targets/` folder is CNG-safe: nothing under ios/ is committed).
+
+/** @type {import('@bacons/apple-targets/app.plugin').Config} */
+module.exports = {
+  type: "notification-service",
+  name: "PegadaNotificationService",
+  displayName: "Pegada Notification Service",
+  // Appended to the main app's bundle id -> app.pegada.notificationservice
+  bundleIdentifier: ".notificationservice",
+  // INSendMessageIntent + UNNotificationContent.updating(from:) need iOS 15+.
+  deploymentTarget: "15.1",
+  frameworks: ["UserNotifications", "Intents"],
+  entitlements: {
+    // Communication-notification styling. Must also be enabled on the App ID
+    // in the Apple Developer portal for device builds (simulator doesn't
+    // enforce it). The main app carries the same entitlement via
+    // `ios.entitlements` in app.config.ts.
+    "com.apple.developer.usernotifications.communication": true,
+  },
+};

--- a/apps/mobile/targets/notification-service/generated.entitlements
+++ b/apps/mobile/targets/notification-service/generated.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.developer.usernotifications.communication</key>
+    <true/>
+  </dict>
+</plist>

--- a/packages/api/src/services/MessageService.ts
+++ b/packages/api/src/services/MessageService.ts
@@ -1,5 +1,6 @@
 import prisma from "@pegada/database";
 import { Language } from "@pegada/shared/i18n/types/types";
+import { IMAGE_STATUS } from "@pegada/shared/schemas/dogSchema";
 
 import { PushNotificationService } from "./PushNotificationService";
 import { TranslationService } from "./TranslationService";
@@ -64,7 +65,15 @@ class MessageService {
         sender: {
           select: {
             name: true,
-            images: true,
+            // First approved photo only: it rides along in the push payload so
+            // the iOS Notification Service Extension can render the sender's
+            // avatar on communication notifications.
+            images: {
+              orderBy: { position: "asc" },
+              where: { status: IMAGE_STATUS.APPROVED },
+              take: 1,
+              select: { url: true },
+            },
           },
         },
         receiver: {
@@ -93,8 +102,13 @@ class MessageService {
         }),
         channelId: "messages",
         categoryId: "chat-message",
+        // Lets the iOS Notification Service Extension intercept the push and
+        // restyle it as a communication notification (sender avatar + name).
+        mutableContent: true,
         data: {
           url: `chat/${matchId}/${newMessage.senderId}`,
+          senderName: newMessage.sender.name,
+          senderAvatarUrl: newMessage.sender.images[0]?.url,
         },
       });
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4804,12 +4804,6 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.3.15:
-    resolution: {integrity: sha512-0c6RlJt1TICLyvJYIApxb8GsXoai0KUP7AxKKAtsYXdgJR1mGEUa7DgwShbdk1nly0PYoZj01xd4hzbq3fsjpw==}
-    engines: {node: '>=16 || 14 >=14.18'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -5102,10 +5096,6 @@ packages:
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
-
-  jackspeak@2.3.6:
-    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
-    engines: {node: '>=14'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -12528,14 +12518,6 @@ snapshots:
   glob-to-regexp@0.4.1:
     optional: true
 
-  glob@10.3.15:
-    dependencies:
-      foreground-child: 3.1.1
-      jackspeak: 2.3.6
-      minimatch: 9.0.4
-      minipass: 7.1.3
-      path-scurry: 1.11.1
-
   glob@10.5.0:
     dependencies:
       foreground-child: 3.1.1
@@ -12877,12 +12859,6 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  jackspeak@2.3.6:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@3.4.3:
     dependencies:
@@ -15389,7 +15365,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
-      glob: 10.3.15
+      glob: 10.5.0
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@bacons/apple-targets':
+        specifier: 4.0.7
+        version: 4.0.7(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))
       '@expo/config-types':
         specifier: ^55.0.5
         version: 55.0.5
@@ -1199,6 +1202,14 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bacons/apple-targets@4.0.7':
+    resolution: {integrity: sha512-DwD8gbz2vjbmLatR5qlWjrTocG/Ku4d2Kz/rIF4yzREPZtVBHMepVPCH7gEEgZw4PBTtWQe3XMGrPkomNp7QUg==}
+    peerDependencies:
+      expo: '>=52'
+
+  '@bacons/xcode@1.0.0-alpha.32':
+    resolution: {integrity: sha512-OGpH7+yMbWC2cgYZon5B+VVadH9HsB2V/abtEiplA65XnSuV4GAYAVixOCDc5k182WkfoakfdM0zW6U9cbcsbw==}
+
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
@@ -1489,6 +1500,9 @@ packages:
 
   '@expo/package-manager@1.10.5':
     resolution: {integrity: sha512-nCP9Mebfl3jvOr0/P6VAuyah6PAtun+aihIL2zAtuE8uSe94JWkVZ7051i0MUVO+y3gFpBqnr8IIH5ch+VJjHA==}
+
+  '@expo/plist@0.0.18':
+    resolution: {integrity: sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==}
 
   '@expo/plist@0.5.3':
     resolution: {integrity: sha512-jz5oPcPDd3fygwVxwSwmO6wodTwm0Qa14NUyPy0ka7H8sFmCtNZUI2+DzVe/EXjOhq1FbEjrwl89gdlWYOnVjQ==}
@@ -2671,6 +2685,9 @@ packages:
   '@react-native/normalize-colors@0.74.85':
     resolution: {integrity: sha512-pcE4i0X7y3hsAE0SpIl7t6dUc0B0NZLd1yv7ssm4FrLhWG+CGyIq4eFDXpmPU1XHmL5PPySxTAjEMiwv6tAmOw==}
 
+  '@react-native/normalize-colors@0.79.7':
+    resolution: {integrity: sha512-RrvewhdanEWhlyrHNWGXGZCc6MY0JGpNgRzA8y6OomDz0JmlnlIsbBHbNpPnIrt9Jh2KaV10KTscD1Ry8xU9gQ==}
+
   '@react-native/normalize-colors@0.83.6':
     resolution: {integrity: sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw==}
 
@@ -3409,6 +3426,11 @@ packages:
 
   '@webgpu/types@0.1.38':
     resolution: {integrity: sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==}
+
+  '@xmldom/xmldom@0.7.13':
+    resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
+    engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -4788,6 +4810,11 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -5079,6 +5106,9 @@ packages:
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -6061,6 +6091,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -7323,6 +7356,11 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -7506,6 +7544,10 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlbuilder@14.0.0:
+    resolution: {integrity: sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==}
+    engines: {node: '>=8.0'}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
@@ -8443,6 +8485,24 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bacons/apple-targets@4.0.7(expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5))':
+    dependencies:
+      '@bacons/xcode': 1.0.0-alpha.32
+      '@react-native/normalize-colors': 0.79.7
+      debug: 4.4.3
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(@expo/metro-runtime@55.0.11)(expo-router@55.0.14)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.4.5)
+      glob: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@bacons/xcode@1.0.0-alpha.32':
+    dependencies:
+      '@expo/plist': 0.0.18
+      debug: 4.4.3
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -8828,6 +8888,12 @@ snapshots:
       npm-package-arg: 11.0.3
       ora: 3.4.0
       resolve-workspace-root: 2.0.1
+
+  '@expo/plist@0.0.18':
+    dependencies:
+      '@xmldom/xmldom': 0.7.13
+      base64-js: 1.5.1
+      xmlbuilder: 14.0.0
 
   '@expo/plist@0.5.3':
     dependencies:
@@ -10149,6 +10215,8 @@ snapshots:
 
   '@react-native/normalize-colors@0.74.85': {}
 
+  '@react-native/normalize-colors@0.79.7': {}
+
   '@react-native/normalize-colors@0.83.6': {}
 
   '@react-native/virtualized-lists@0.83.6(@types/react@19.2.14)(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
@@ -10960,6 +11028,8 @@ snapshots:
     optional: true
 
   '@webgpu/types@0.1.38': {}
+
+  '@xmldom/xmldom@0.7.13': {}
 
   '@xmldom/xmldom@0.8.10': {}
 
@@ -12466,6 +12536,15 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 1.11.1
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.4
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -12800,6 +12879,12 @@ snapshots:
       istanbul-lib-report: 3.0.1
 
   jackspeak@2.3.6:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
@@ -14354,6 +14439,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -15661,6 +15748,8 @@ snapshots:
 
   uuid@7.0.3: {}
 
+  uuid@8.3.2: {}
+
   v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.2.0:
@@ -15847,6 +15936,8 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlbuilder@14.0.0: {}
 
   xmlbuilder@15.1.1: {}
 


### PR DESCRIPTION
## Summary

Chat pushes on iOS now render iMessage-style, with the sender dog's photo and name, and group per conversation.

Stacked on #75 (base branch is the reply-action one; merge that first).

## Details

- Real Swift Notification Service Extension (via @bacons/apple-targets): intercepts the chat push, downloads the sender's avatar, donates the messaging intent and re-renders the notification as a communication notification.
- Fallback contract respected everywhere: missing fields, failed avatar download, intent errors or the extension time budget expiring all deliver the original notification untouched. A broken extension can never eat a message.
- Notifications group per conversation via the match id thread.
- Server now sends `mutableContent`, `senderName` and `senderAvatarUrl` on chat pushes, using only the first APPROVED photo (which also stops unapproved sender images from leaking in that payload).
- Communication entitlement wired on both the app and the extension.
- Release heads-up: the entitlement must be enabled on the provisioning profile in the Apple Developer portal before device/store builds sign.

## Testing steps

Needs a build with real push credentials (won't show in simulator).

1. From a second test account with a dog photo, send yourself a chat message with the app closed or in background.
2. The notification should show the sender dog's round photo and name, looking like an iMessage/WhatsApp notification instead of a plain one.
3. Send several messages from two different matches: notifications should stack grouped by conversation.
4. Reply from the notification (feature from the base PR): should still work exactly as before.
5. Remove the sender dog's photos (or use a dog with no approved photo) and send again: the notification should still arrive, just without the avatar.