### PR TITLE
feat(mobile): add bidirectional dog profile transitions

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -13,7 +13,7 @@ const config: ExpoConfig = {
    * That affects eas updates and makes sure the app doesn't
    * break when updating Over The Air
    */
-  version: "1.4.0",
+  version: "1.5.0",
   runtimeVersion: {
     policy: "appVersion",
   },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -118,10 +118,5 @@
   },
   "installConfig": {
     "hoistingLimits": "workspaces"
-  },
-  "reanimated": {
-    "staticFeatureFlags": {
-      "ENABLE_SHARED_ELEMENT_TRANSITIONS": true
-    }
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -91,6 +91,7 @@
     "react-native-svg": "^15.15.3",
     "react-native-svg-transformer": "^1.5.0",
     "react-native-web": "~0.21.2",
+    "react-native-worklets": "0.8.3",
     "react-redux": "^9.1.2",
     "reduce-reducers": "^1.0.4",
     "redux": "^5.0.1",
@@ -117,5 +118,10 @@
   },
   "installConfig": {
     "hoistingLimits": "workspaces"
+  },
+  "reanimated": {
+    "staticFeatureFlags": {
+      "ENABLE_SHARED_ELEMENT_TRANSITIONS": true
+    }
   }
 }

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -54,7 +54,19 @@ export default () => {
           animation: "default",
         }}
       />
-      <Stack.Screen name="profile/[id]" />
+      <Stack.Screen
+        name="profile/[id]"
+        options={({ route }) => ({
+          // The photo overlay is the forward transition from Swipe. Running
+          // the stack fade at the same time duplicates the whole card behind
+          // it. The same route-level opt-out lets the shared elements reverse
+          // cleanly on Back without a competing stack animation.
+          animation:
+            (route.params as { heroTransition?: string } | undefined)?.heroTransition === "1"
+              ? "none"
+              : "fade",
+        })}
+      />
       <Stack.Screen
         name="preferences"
         options={{

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -9,6 +9,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { Provider } from "react-redux";
 import styled from "styled-components/native";
 
+import { HeroTransitionOverlay } from "@/components/HeroTransition";
 import { NetworkBoundary } from "@/components/NetworkBoundary";
 import { config } from "@/services/config";
 import { posthog } from "@/services/posthog";
@@ -80,6 +81,9 @@ const App = () => {
           </ThemeProvider>
         </TRPCProvider>
       </PostHogProvider>
+      {/* Above the navigator so the flying photo paints over both screens
+          while they cross-fade during a swipe-card -> profile transition. */}
+      <HeroTransitionOverlay />
     </AppContainer>
   );
 };

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -66,24 +66,25 @@ const App = () => {
       <PostHogProvider client={posthog} autocapture={false}>
         <TRPCProvider>
           <ThemeProvider>
-            <BottomSheetModalProvider>
-              <NetworkBoundary>
-                <Provider store={store}>
-                  <Stack screenOptions={{ headerShown: false }}>
-                    <Stack.Screen name="index" />
-                    <Stack.Screen name="(app)" />
-                    <Stack.Screen name="(auth)" />
-                  </Stack>
-                </Provider>
-                <MagicModalPortal />
-              </NetworkBoundary>
-            </BottomSheetModalProvider>
+            <>
+              <BottomSheetModalProvider>
+                <NetworkBoundary>
+                  <Provider store={store}>
+                    <Stack screenOptions={{ headerShown: false }}>
+                      <Stack.Screen name="index" />
+                      <Stack.Screen name="(app)" />
+                      <Stack.Screen name="(auth)" />
+                    </Stack>
+                  </Provider>
+                  <MagicModalPortal />
+                </NetworkBoundary>
+              </BottomSheetModalProvider>
+              {/* Above the navigator so shared profile elements paint over both screens. */}
+              <HeroTransitionOverlay />
+            </>
           </ThemeProvider>
         </TRPCProvider>
       </PostHogProvider>
-      {/* Above the navigator so the flying photo paints over both screens
-          while they cross-fade during a swipe-card -> profile transition. */}
-      <HeroTransitionOverlay />
     </AppContainer>
   );
 };

--- a/apps/mobile/src/components/HeroTransition/index.tsx
+++ b/apps/mobile/src/components/HeroTransition/index.tsx
@@ -9,12 +9,23 @@ import Animated, {
 } from "react-native-reanimated";
 import { Image as ExpoImage } from "expo-image";
 
-import { endHero, HeroFrame, markHeroOverlayReady, useHeroState } from "./store";
+import { MatchActionBar } from "@/components/MatchActionBar";
+import Distance from "@/components/MainCard/components/Distance";
+import Pagination from "@/components/MainCard/components/Pagination";
+import { UpperPart } from "@/components/MainCard/styles";
+import {
+  abandonHero,
+  areHeroSharedElementsReady,
+  endHero,
+  HeroFrame,
+  markHeroOverlayReady,
+  useHeroState,
+} from "./store";
 
 const AnimatedExpoImage = Animated.createAnimatedComponent(ExpoImage);
 
-// Matches the stack "fade" duration closely so the overlay lands as the new
-// screen finishes fading in. Slightly springy for a livelier morph.
+// Short enough to preserve the direct-manipulation feel while giving the
+// photo and shared controls time to read as one continuous object.
 const MORPH_DURATION = 320;
 
 const frameStyle = (frame: HeroFrame) => ({
@@ -22,12 +33,13 @@ const frameStyle = (frame: HeroFrame) => ({
   y: frame.y,
   width: frame.width,
   height: frame.height,
+  borderRadius: frame.borderRadius,
 });
 
 /**
  * Renders the flying photo during a manual hero transition. Mounted once, high
  * in the tree (above the navigator), so it stays visible while the source and
- * destination screens cross-fade underneath it. Does nothing until a hero is
+ * destination routes swap underneath it. Does nothing until a hero is
  * active. See {@link file://./store.ts} for the why.
  */
 export const HeroTransitionOverlay = () => {
@@ -37,11 +49,18 @@ export const HeroTransitionOverlay = () => {
   const y = useSharedValue(0);
   const width = useSharedValue(0);
   const height = useSharedValue(0);
-  const opacity = useSharedValue(0);
+  const borderRadius = useSharedValue(0);
+  const actionX = useSharedValue(0);
+  const actionY = useSharedValue(0);
+  const actionWidth = useSharedValue(0);
+  const actionHeight = useSharedValue(0);
 
   const from = hero.from;
   const to = hero.to;
   const heroId = hero.id;
+  const actionFrom = hero.actionFrom;
+  const actionTo = hero.actionTo;
+  const sharedElementsReady = areHeroSharedElementsReady(hero);
 
   // Snap to the source frame the instant a hero starts.
   useEffect(() => {
@@ -50,47 +69,65 @@ export const HeroTransitionOverlay = () => {
     cancelAnimation(y);
     cancelAnimation(width);
     cancelAnimation(height);
+    cancelAnimation(borderRadius);
     const f = frameStyle(from);
     x.value = f.x;
     y.value = f.y;
     width.value = f.width;
     height.value = f.height;
-    opacity.value = 1;
+    borderRadius.value = f.borderRadius ?? 0;
+    if (actionFrom) {
+      actionX.value = actionFrom.x;
+      actionY.value = actionFrom.y;
+      actionWidth.value = actionFrom.width;
+      actionHeight.value = actionFrom.height;
+    }
     // Only re-run when a brand new hero begins.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [heroId, from]);
+  }, [heroId, from, actionFrom]);
 
   // Morph to the destination frame once it's measured, then clear.
   useEffect(() => {
-    if (!from || !to) return;
+    if (!from || !to || !sharedElementsReady) return;
     const t = frameStyle(to);
     const config = { duration: MORPH_DURATION };
     x.value = withTiming(t.x, config);
     y.value = withTiming(t.y, config);
     width.value = withTiming(t.width, config);
+    borderRadius.value = withTiming(t.borderRadius ?? 0, config);
+    if (actionFrom && actionTo) {
+      actionX.value = withTiming(actionTo.x, config);
+      actionY.value = withTiming(actionTo.y, config);
+      actionWidth.value = withTiming(actionTo.width, config);
+      actionHeight.value = withTiming(actionTo.height, config);
+    }
     height.value = withTiming(t.height, config, (finished) => {
       "worklet";
       if (finished) {
-        opacity.value = 0;
         runOnJS(endHero)();
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [heroId, to]);
+  }, [heroId, to, actionFrom, actionTo, sharedElementsReady]);
 
   // Safety net: if the destination never reports a frame (e.g. profile failed
   // to mount), don't leave a frozen photo on screen forever.
   useEffect(() => {
-    if (!from || to) return;
-    const timeout = setTimeout(() => endHero(), 700);
+    if (!heroId || !from || sharedElementsReady) return;
+    const timeout = setTimeout(() => abandonHero(heroId), 700);
     return () => clearTimeout(timeout);
-  }, [heroId, from, to]);
+  }, [heroId, from, sharedElementsReady]);
 
   const animatedStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
     transform: [{ translateX: x.value }, { translateY: y.value }],
     width: width.value,
     height: height.value,
+    borderRadius: borderRadius.value,
+  }));
+  const actionStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: actionX.value }, { translateY: actionY.value }],
+    width: actionWidth.value,
+    height: actionHeight.value,
   }));
 
   if (!heroId || !from || !hero.source?.uri) return null;
@@ -108,12 +145,37 @@ export const HeroTransitionOverlay = () => {
         onDisplay={markHeroOverlayReady}
         style={[styles.image, animatedStyle]}
       />
+      {hero.chrome ? (
+        <Animated.View style={[styles.chrome, animatedStyle]}>
+          <UpperPart>
+            <Distance dog={hero.chrome.dog} />
+            <Pagination pages={hero.chrome.pages} currentPage={hero.chrome.currentPage} />
+          </UpperPart>
+        </Animated.View>
+      ) : null}
+      {hero.chrome && actionFrom && actionTo ? (
+        <Animated.View style={[styles.actionBar, actionStyle]}>
+          <MatchActionBar visualOnly onNope={() => {}} onMaybe={() => {}} onYep={() => {}} />
+        </Animated.View>
+      ) : null}
     </Animated.View>
   );
 };
 
 const styles = StyleSheet.create({
   image: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+  },
+  chrome: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    overflow: "hidden",
+    paddingTop: 24,
+  },
+  actionBar: {
     position: "absolute",
     left: 0,
     top: 0,

--- a/apps/mobile/src/components/HeroTransition/index.tsx
+++ b/apps/mobile/src/components/HeroTransition/index.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from "react";
+import { StyleSheet } from "react-native";
+import Animated, {
+  cancelAnimation,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { Image as ExpoImage } from "expo-image";
+
+import { endHero, HeroFrame, useHeroState } from "./store";
+
+const AnimatedExpoImage = Animated.createAnimatedComponent(ExpoImage);
+
+// Matches the stack "fade" duration closely so the overlay lands as the new
+// screen finishes fading in. Slightly springy for a livelier morph.
+const MORPH_DURATION = 320;
+
+const frameStyle = (frame: HeroFrame) => ({
+  x: frame.x,
+  y: frame.y,
+  width: frame.width,
+  height: frame.height,
+});
+
+/**
+ * Renders the flying photo during a manual hero transition. Mounted once, high
+ * in the tree (above the navigator), so it stays visible while the source and
+ * destination screens cross-fade underneath it. Does nothing until a hero is
+ * active. See {@link file://./store.ts} for the why.
+ */
+export const HeroTransitionOverlay = () => {
+  const hero = useHeroState();
+
+  const x = useSharedValue(0);
+  const y = useSharedValue(0);
+  const width = useSharedValue(0);
+  const height = useSharedValue(0);
+  const opacity = useSharedValue(0);
+
+  const from = hero.from;
+  const to = hero.to;
+  const heroId = hero.id;
+
+  // Snap to the source frame the instant a hero starts.
+  useEffect(() => {
+    if (!from) return;
+    cancelAnimation(x);
+    cancelAnimation(y);
+    cancelAnimation(width);
+    cancelAnimation(height);
+    const f = frameStyle(from);
+    x.value = f.x;
+    y.value = f.y;
+    width.value = f.width;
+    height.value = f.height;
+    opacity.value = 1;
+    // Only re-run when a brand new hero begins.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heroId, from]);
+
+  // Morph to the destination frame once it's measured, then clear.
+  useEffect(() => {
+    if (!from || !to) return;
+    const t = frameStyle(to);
+    const config = { duration: MORPH_DURATION };
+    x.value = withTiming(t.x, config);
+    y.value = withTiming(t.y, config);
+    width.value = withTiming(t.width, config);
+    height.value = withTiming(t.height, config, (finished) => {
+      "worklet";
+      if (finished) {
+        opacity.value = 0;
+        runOnJS(endHero)();
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heroId, to]);
+
+  // Safety net: if the destination never reports a frame (e.g. profile failed
+  // to mount), don't leave a frozen photo on screen forever.
+  useEffect(() => {
+    if (!from || to) return;
+    const timeout = setTimeout(() => endHero(), 700);
+    return () => clearTimeout(timeout);
+  }, [heroId, from, to]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateX: x.value }, { translateY: y.value }],
+    width: width.value,
+    height: height.value,
+  }));
+
+  if (!heroId || !from || !hero.source?.uri) return null;
+
+  return (
+    <Animated.View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      <AnimatedExpoImage
+        source={{ uri: hero.source.uri }}
+        placeholder={hero.source.blurhash ? { blurhash: hero.source.blurhash } : undefined}
+        contentFit="cover"
+        cachePolicy="memory-disk"
+        style={[styles.image, animatedStyle]}
+      />
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  image: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+  },
+});

--- a/apps/mobile/src/components/HeroTransition/index.tsx
+++ b/apps/mobile/src/components/HeroTransition/index.tsx
@@ -9,7 +9,7 @@ import Animated, {
 } from "react-native-reanimated";
 import { Image as ExpoImage } from "expo-image";
 
-import { endHero, HeroFrame, useHeroState } from "./store";
+import { endHero, HeroFrame, markHeroOverlayReady, useHeroState } from "./store";
 
 const AnimatedExpoImage = Animated.createAnimatedComponent(ExpoImage);
 
@@ -102,6 +102,10 @@ export const HeroTransitionOverlay = () => {
         placeholder={hero.source.blurhash ? { blurhash: hero.source.blurhash } : undefined}
         contentFit="cover"
         cachePolicy="memory-disk"
+        // The real photos underneath stay visible until the overlay has
+        // painted (see store.ts), otherwise the card blanks for the frames
+        // the image spends decoding.
+        onDisplay={markHeroOverlayReady}
         style={[styles.image, animatedStyle]}
       />
     </Animated.View>

--- a/apps/mobile/src/components/HeroTransition/store.ts
+++ b/apps/mobile/src/components/HeroTransition/store.ts
@@ -1,5 +1,7 @@
 import { useSyncExternalStore } from "react";
 
+import type { SwipeDog } from "@/store/reducers/dogs/swipe";
+
 /**
  * Manual shared-element ("hero") transition for the swipe-card -> DogProfile
  * photo morph.
@@ -12,7 +14,7 @@ import { useSyncExternalStore } from "react";
  * nothing (you just get the plain stack "fade"). Rather than fork the router's
  * screen tree, we drive the morph ourselves: measure the card photo on tap,
  * measure the profile photo when it mounts, and animate an overlay image
- * between the two frames while the screens cross-fade underneath.
+ * between the two frames while navigation swaps the routes underneath.
  *
  * This is a tiny external store (no Redux/context needed) so both ends can
  * publish frames imperatively without re-rendering the whole tree.
@@ -23,6 +25,7 @@ export interface HeroFrame {
   y: number;
   width: number;
   height: number;
+  borderRadius?: number;
 }
 
 export interface HeroSource {
@@ -30,14 +33,25 @@ export interface HeroSource {
   blurhash?: string | null;
 }
 
+export interface HeroChrome {
+  dog: SwipeDog;
+  pages: number;
+  currentPage: number;
+}
+
 export interface HeroState {
   /** dog id the transition belongs to; ties source and destination together. */
   id: string | null;
   source: HeroSource | null;
+  /** Card chrome that is genuinely shared by both ends of the transition. */
+  chrome: HeroChrome | null;
+  phase: "forward" | "reverse" | null;
   /** measured swipe-card photo frame (start of the morph). */
   from: HeroFrame | null;
   /** measured DogProfile photo frame (end of the morph). set once it mounts. */
   to: HeroFrame | null;
+  actionFrom: HeroFrame | null;
+  actionTo: HeroFrame | null;
   /**
    * True once the flying overlay image has actually painted (expo-image
    * `onDisplay`). The real photos underneath only hide from this point on --
@@ -52,13 +66,21 @@ export interface HeroState {
 const initialState: HeroState = {
   id: null,
   source: null,
+  chrome: null,
+  phase: null,
   from: null,
   to: null,
+  actionFrom: null,
+  actionTo: null,
   overlayReady: false,
   version: 0,
 };
 
 let state: HeroState = initialState;
+let settledHero: HeroState | null = null;
+let reverseCompletions: Array<() => void> = [];
+let reverseHandoffPending = false;
+const sourceActionFrames = new Map<string, HeroFrame>();
 
 const listeners = new Set<() => void>();
 
@@ -76,8 +98,57 @@ const setState = (next: Partial<HeroState>) => {
  * to open a profile, with the tapped photo's measured frame and source. The
  * destination frame arrives later via {@link setHeroTarget}.
  */
-export const startHero = (args: { id: string; source: HeroSource; from: HeroFrame }) => {
-  setState({ id: args.id, source: args.source, from: args.from, to: null, overlayReady: false });
+export const startHero = (args: {
+  id: string;
+  source: HeroSource;
+  from: HeroFrame;
+  chrome?: HeroChrome;
+}) => {
+  // A new navigation attempt supersedes every previously completed hero,
+  // including one for the same dog. Until this forward transition itself
+  // lands, there must be nothing reversible: an immediate Back or a timeout
+  // cannot resurrect geometry from an older Swipe/Profile visit.
+  settledHero = null;
+  setState({
+    id: args.id,
+    source: args.source,
+    chrome: args.chrome ?? null,
+    phase: "forward",
+    from: args.from,
+    to: null,
+    // Only Swipe heroes carry card chrome/action controls. A Chat avatar can
+    // share a dog id with an earlier Swipe card, but must never inherit that
+    // process-lifetime action frame and wait for a target it does not render.
+    actionFrom: args.chrome ? (sourceActionFrames.get(args.id) ?? null) : null,
+    actionTo: null,
+    overlayReady: false,
+  });
+};
+
+const MEASURE_WATCHDOG_MS = 250;
+
+/**
+ * Navigation must not depend indefinitely on a native measurement callback:
+ * refs can be null during teardown and native callbacks are not guaranteed to
+ * arrive. The returned function wins exactly once; a valid measurement can
+ * prepare a hero before navigating, otherwise the watchdog takes the normal
+ * non-hero route.
+ */
+export const createHeroNavigationWatchdog = (
+  navigate: (heroTransition?: string) => void,
+): ((prepareHero?: () => void) => void) => {
+  let completed = false;
+
+  const complete = (prepareHero?: () => void) => {
+    if (completed) return;
+    completed = true;
+    clearTimeout(timer);
+    prepareHero?.();
+    navigate(prepareHero ? "1" : undefined);
+  };
+
+  const timer = setTimeout(complete, MEASURE_WATCHDOG_MS);
+  return complete;
 };
 
 /** Called by the overlay image's `onDisplay` -- it has pixels on screen. */
@@ -92,13 +163,139 @@ export const markHeroOverlayReady = () => {
  * hijack the animation.
  */
 export const setHeroTarget = (args: { id: string; to: HeroFrame }) => {
-  if (state.id !== args.id) return;
+  if (state.id !== args.id || state.phase !== "forward") return;
   setState({ to: args.to });
+};
+
+export const registerHeroActionFrame = (args: {
+  id: string;
+  role: "source" | "target";
+  frame: HeroFrame;
+}) => {
+  if (args.role === "source") {
+    sourceActionFrames.set(args.id, args.frame);
+    if (state.id === args.id && state.phase === "forward" && state.chrome) {
+      setState({ actionFrom: args.frame });
+    }
+    return;
+  }
+
+  if (state.id === args.id && state.phase === "forward" && state.chrome) {
+    setState({ actionTo: args.frame });
+  }
+  if (settledHero?.id === args.id && settledHero.chrome) {
+    settledHero = { ...settledHero, actionTo: args.frame };
+  }
+};
+
+export const unregisterHeroSourceActionFrame = (id: string) => {
+  sourceActionFrames.delete(id);
+};
+
+/** Shared-element readiness is deliberately photo-only outside Swipe. */
+export const areHeroSharedElementsReady = (hero: HeroState): boolean =>
+  Boolean(hero.to) && (!hero.chrome || !hero.actionFrom || Boolean(hero.actionTo));
+
+/** Imperative snapshot for deterministic store verification. */
+export const getHeroStateSnapshot = (): HeroState => state;
+
+/**
+ * Generation token for native measurements whose callbacks may arrive after
+ * React cleanup. Both the queued RAF and the native callback must hold the
+ * currently active token before they can publish geometry.
+ */
+export const createHeroMeasurementLifecycle = () => {
+  let nextGeneration = 0;
+  let activeGeneration: number | null = null;
+
+  return {
+    activate: () => {
+      activeGeneration = ++nextGeneration;
+      return activeGeneration;
+    },
+    invalidate: () => {
+      activeGeneration = null;
+      nextGeneration++;
+    },
+    current: () => activeGeneration,
+    isCurrent: (generation: number) => activeGeneration === generation,
+  };
+};
+
+/** Clear an incomplete forward hero without publishing a reverse snapshot. */
+export const abandonHero = (id: string) => {
+  if (state.id !== id || state.phase !== "forward") return;
+  settledHero = null;
+  state = { ...initialState, version: state.version + 1 };
+  emit();
+};
+
+export const startReverseHero = (id: string, onComplete?: () => void): boolean => {
+  if (state.id === id && state.phase === "reverse") {
+    if (onComplete) reverseCompletions.push(onComplete);
+    return true;
+  }
+
+  // Back can arrive before the forward morph has landed and published its
+  // reversible snapshot. Let navigation pop normally, but remove the
+  // unfinished overlay first so it cannot keep flying over the source screen
+  // or later publish stale geometry for a route that is already gone.
+  if (state.id === id && state.phase === "forward") {
+    abandonHero(id);
+    return false;
+  }
+
+  if (!settledHero || settledHero.id !== id || !settledHero.from || !settledHero.to) return false;
+
+  reverseCompletions = onComplete ? [onComplete] : [];
+  const previous = settledHero;
+  setState({
+    id,
+    source: previous.source,
+    chrome: previous.chrome,
+    phase: "reverse",
+    from: previous.to,
+    to: previous.from,
+    actionFrom: previous.actionTo,
+    actionTo: previous.actionFrom,
+    overlayReady: false,
+  });
+  return true;
 };
 
 /** Clear the hero once the morph finishes (or is abandoned). */
 export const endHero = () => {
   if (state.id === null) return;
+  const finished = state;
+
+  if (finished.phase === "reverse") {
+    if (reverseHandoffPending) return;
+    reverseHandoffPending = true;
+
+    const completions = reverseCompletions;
+    reverseCompletions = [];
+    for (const completion of completions) completion();
+
+    // The reverse overlay has landed on the source frame, but the held route
+    // removal has not committed visually yet. Keep that landed overlay alive
+    // while navigation exposes the source and its real shared elements mount;
+    // only then hand visibility back. Clearing before dispatch produced one
+    // blank frame followed by a duplicate profile/source frame.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (state.id === finished.id && state.phase === "reverse") {
+          state = { ...initialState, version: state.version + 1 };
+          emit();
+        }
+        reverseHandoffPending = false;
+      });
+    });
+    return;
+  }
+
+  if (finished.phase === "forward" && finished.to) {
+    settledHero = { ...finished, overlayReady: false };
+  }
   state = { ...initialState, version: state.version + 1 };
   emit();
 };
@@ -122,5 +319,5 @@ export const useHeroState = (): HeroState => useSyncExternalStore(subscribe, get
  */
 export const useIsHeroActive = (id: string | undefined): boolean => {
   const current = useHeroState();
-  return Boolean(id) && current.id === id && current.overlayReady;
+  return Boolean(id) && current.id === id && current.phase !== null && current.overlayReady;
 };

--- a/apps/mobile/src/components/HeroTransition/store.ts
+++ b/apps/mobile/src/components/HeroTransition/store.ts
@@ -38,6 +38,13 @@ export interface HeroState {
   from: HeroFrame | null;
   /** measured DogProfile photo frame (end of the morph). set once it mounts. */
   to: HeroFrame | null;
+  /**
+   * True once the flying overlay image has actually painted (expo-image
+   * `onDisplay`). The real photos underneath only hide from this point on --
+   * hiding them on `startHero` left a 1-2 frame blank flash while the overlay
+   * image decoded.
+   */
+  overlayReady: boolean;
   /** bumped every mutation so subscribers re-read. */
   version: number;
 }
@@ -47,6 +54,7 @@ const initialState: HeroState = {
   source: null,
   from: null,
   to: null,
+  overlayReady: false,
   version: 0,
 };
 
@@ -69,7 +77,13 @@ const setState = (next: Partial<HeroState>) => {
  * destination frame arrives later via {@link setHeroTarget}.
  */
 export const startHero = (args: { id: string; source: HeroSource; from: HeroFrame }) => {
-  setState({ id: args.id, source: args.source, from: args.from, to: null });
+  setState({ id: args.id, source: args.source, from: args.from, to: null, overlayReady: false });
+};
+
+/** Called by the overlay image's `onDisplay` -- it has pixels on screen. */
+export const markHeroOverlayReady = () => {
+  if (state.id === null || state.overlayReady) return;
+  setState({ overlayReady: true });
 };
 
 /**
@@ -100,8 +114,13 @@ const getSnapshot = () => state;
 
 export const useHeroState = (): HeroState => useSyncExternalStore(subscribe, getSnapshot);
 
-/** True while a hero for `id` is active (used to hide the real photos). */
+/**
+ * True while a hero for `id` is active AND its overlay has painted (used to
+ * hide the real photos). Gating on `overlayReady` keeps the originals visible
+ * for the couple of frames the overlay image needs to decode, so the morph
+ * starts without a blank flash.
+ */
 export const useIsHeroActive = (id: string | undefined): boolean => {
   const current = useHeroState();
-  return Boolean(id) && current.id === id;
+  return Boolean(id) && current.id === id && current.overlayReady;
 };

--- a/apps/mobile/src/components/HeroTransition/store.ts
+++ b/apps/mobile/src/components/HeroTransition/store.ts
@@ -1,0 +1,107 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Manual shared-element ("hero") transition for the swipe-card -> DogProfile
+ * photo morph.
+ *
+ * Why not Reanimated's `sharedTransitionTag`? Reanimated 4.3's shared-element
+ * transitions are driven entirely by react-native-screens' native
+ * `onTransitionProgress` event, which is only emitted when screens render
+ * through `ReanimatedScreenProvider`. expo-router never wraps its navigator in
+ * that provider, so the event never reaches Reanimated and the tag does
+ * nothing (you just get the plain stack "fade"). Rather than fork the router's
+ * screen tree, we drive the morph ourselves: measure the card photo on tap,
+ * measure the profile photo when it mounts, and animate an overlay image
+ * between the two frames while the screens cross-fade underneath.
+ *
+ * This is a tiny external store (no Redux/context needed) so both ends can
+ * publish frames imperatively without re-rendering the whole tree.
+ */
+
+export interface HeroFrame {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface HeroSource {
+  uri?: string;
+  blurhash?: string | null;
+}
+
+export interface HeroState {
+  /** dog id the transition belongs to; ties source and destination together. */
+  id: string | null;
+  source: HeroSource | null;
+  /** measured swipe-card photo frame (start of the morph). */
+  from: HeroFrame | null;
+  /** measured DogProfile photo frame (end of the morph). set once it mounts. */
+  to: HeroFrame | null;
+  /** bumped every mutation so subscribers re-read. */
+  version: number;
+}
+
+const initialState: HeroState = {
+  id: null,
+  source: null,
+  from: null,
+  to: null,
+  version: 0,
+};
+
+let state: HeroState = initialState;
+
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  for (const listener of listeners) listener();
+};
+
+const setState = (next: Partial<HeroState>) => {
+  state = { ...state, ...next, version: state.version + 1 };
+  emit();
+};
+
+/**
+ * Begin a hero transition. Called from the swipe card the moment the user taps
+ * to open a profile, with the tapped photo's measured frame and source. The
+ * destination frame arrives later via {@link setHeroTarget}.
+ */
+export const startHero = (args: { id: string; source: HeroSource; from: HeroFrame }) => {
+  setState({ id: args.id, source: args.source, from: args.from, to: null });
+};
+
+/**
+ * Provide the destination frame (the DogProfile photo, once measured). Ignored
+ * if it doesn't match the in-flight hero's dog id, so a stale mount can't
+ * hijack the animation.
+ */
+export const setHeroTarget = (args: { id: string; to: HeroFrame }) => {
+  if (state.id !== args.id) return;
+  setState({ to: args.to });
+};
+
+/** Clear the hero once the morph finishes (or is abandoned). */
+export const endHero = () => {
+  if (state.id === null) return;
+  state = { ...initialState, version: state.version + 1 };
+  emit();
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const getSnapshot = () => state;
+
+export const useHeroState = (): HeroState => useSyncExternalStore(subscribe, getSnapshot);
+
+/** True while a hero for `id` is active (used to hide the real photos). */
+export const useIsHeroActive = (id: string | undefined): boolean => {
+  const current = useHeroState();
+  return Boolean(id) && current.id === id;
+};

--- a/apps/mobile/src/components/MainCard/index.tsx
+++ b/apps/mobile/src/components/MainCard/index.tsx
@@ -95,9 +95,7 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
   return (
     <Container testID="swipe-card" {...props} style={[props.style, transform]}>
       <PhotoAnchor
-        sharedTransitionTag={
-          SHARED_ELEMENT_TRANSITIONS_ENABLED ? `dog-photo-${dog.id}` : undefined
-        }
+        sharedTransitionTag={SHARED_ELEMENT_TRANSITIONS_ENABLED ? `dog-photo-${dog.id}` : undefined}
         sharedTransitionStyle={SHARED_ELEMENT_TRANSITIONS_ENABLED ? dogPhotoTransition : undefined}
       >
         <Picture

--- a/apps/mobile/src/components/MainCard/index.tsx
+++ b/apps/mobile/src/components/MainCard/index.tsx
@@ -10,9 +10,17 @@ import {
 } from "react-native-reanimated";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
+import { useTheme } from "styled-components/native";
 
-import { setHeroTarget, startHero, useIsHeroActive } from "@/components/HeroTransition/store";
+import {
+  createHeroNavigationWatchdog,
+  setHeroTarget,
+  startHero,
+  useHeroState,
+  useIsHeroActive,
+} from "@/components/HeroTransition/store";
 import { PressableArea } from "@/components/PressableArea";
+import { getTrcpContext } from "@/contexts/trcpContext";
 import { SceneName } from "@/types/SceneName";
 import Distance from "./components/Distance";
 import Pagination from "./components/Pagination";
@@ -46,6 +54,7 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
   const { images = [] } = dog;
   const [currentImage, setCurrentImage] = useState(startImageIndex);
   const router = useRouter();
+  const theme = useTheme();
 
   const rotation = useSharedValue(0);
 
@@ -54,29 +63,51 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
   const isHeroDestination = !shouldShowPersonalInfo;
   const photoAnchorRef = useRef<View>(null);
   const heroActive = useIsHeroActive(dog.id);
+  const activeHero = useHeroState();
+  const hideSharedChrome = heroActive && Boolean(activeHero.chrome);
 
   const currentPhoto = images[currentImage];
 
   const openUserProfile = () => {
-    // Kick off the manual hero morph: freeze the tapped photo into a flying
-    // overlay measured at its on-screen frame, then navigate. The destination
-    // card reports its frame on mount (see onDestinationLayout) and the
-    // overlay springs between the two. See @/components/HeroTransition/store.
-    photoAnchorRef.current?.measureInWindow((x, y, width, height) => {
-      if (width > 0 && height > 0 && currentPhoto?.url) {
-        startHero({
-          id: dog.id,
-          source: { uri: currentPhoto.url, blurhash: currentPhoto.blurhash },
-          from: { x, y, width, height },
-        });
-      }
+    // The swipe response already contains the complete DogProfile payload.
+    // Refresh the exact query key at the interaction boundary so an entry
+    // that has aged out of React Query never suspends between the card and
+    // the hero destination.
+    getTrcpContext().dog.get.setData({ id: dog.id }, dog);
+
+    const navigate = (heroTransition?: string) => {
       router.push({
         pathname: `${SceneName.Profile}/[id]`,
         params: {
           id: dog.id,
           currentImageIndex: currentImage,
+          heroTransition,
         },
       });
+    };
+    const finishNavigation = createHeroNavigationWatchdog(navigate);
+
+    // Kick off the manual hero morph: freeze the tapped photo into a flying
+    // overlay measured at its on-screen frame, then navigate. The destination
+    // card reports its frame on mount (see onDestinationLayout) and the
+    // overlay animates between the two. See @/components/HeroTransition/store.
+    photoAnchorRef.current?.measureInWindow((x, y, width, height) => {
+      if (width > 0 && height > 0 && currentPhoto?.url) {
+        finishNavigation(() => {
+          startHero({
+            id: dog.id,
+            source: { uri: currentPhoto.url, blurhash: currentPhoto.blurhash },
+            from: { x, y, width, height, borderRadius: theme.radii.lg },
+            chrome: {
+              dog,
+              pages: images.length,
+              currentPage: currentImage,
+            },
+          });
+        });
+        return;
+      }
+      finishNavigation();
     });
   };
 
@@ -86,7 +117,7 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
     requestAnimationFrame(() => {
       photoAnchorRef.current?.measureInWindow((x, y, width, height) => {
         if (width > 0 && height > 0) {
-          setHeroTarget({ id: dog.id, to: { x, y, width, height } });
+          setHeroTarget({ id: dog.id, to: { x, y, width, height, borderRadius: 0 } });
         }
       });
     });
@@ -149,7 +180,7 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
         }}
         colors={["rgba(0, 0, 0, .5)", "rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0)"]}
       />
-      <UpperPart>
+      <UpperPart style={hideSharedChrome ? { opacity: 0 } : undefined}>
         <Distance dog={dog} />
         <Pagination pages={images.length} currentPage={currentImage} />
         <CarouselContainer>

--- a/apps/mobile/src/components/MainCard/index.tsx
+++ b/apps/mobile/src/components/MainCard/index.tsx
@@ -1,8 +1,8 @@
 import type { SwipeDog } from "@/store/reducers/dogs/swipe";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import * as React from "react";
+import { View } from "react-native";
 import {
-  SharedTransition,
   useAnimatedStyle,
   useSharedValue,
   withSequence,
@@ -11,8 +11,8 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
 
+import { setHeroTarget, startHero, useIsHeroActive } from "@/components/HeroTransition/store";
 import { PressableArea } from "@/components/PressableArea";
-import { SHARED_ELEMENT_TRANSITIONS_ENABLED } from "@/constants";
 import { SceneName } from "@/types/SceneName";
 import Distance from "./components/Distance";
 import Pagination from "./components/Pagination";
@@ -30,10 +30,6 @@ import {
 const springConfig = { mass: 0.2 };
 
 const START_IMAGE_INDEX = 0;
-
-// Custom easing for the swipe-card -> DogProfile shared-element photo
-// transition. Gated by SHARED_ELEMENT_TRANSITIONS_ENABLED (see @/constants).
-const dogPhotoTransition = SharedTransition.duration(350).springify();
 
 export interface VisitingCardProps extends React.ComponentProps<typeof Container> {
   dog: SwipeDog;
@@ -53,15 +49,48 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
 
   const rotation = useSharedValue(0);
 
+  // When rendered inside DogProfile (no personal info), this card is the hero
+  // *destination*; on the swipe deck it's the *source*.
+  const isHeroDestination = !shouldShowPersonalInfo;
+  const photoAnchorRef = useRef<View>(null);
+  const heroActive = useIsHeroActive(dog.id);
+
+  const currentPhoto = images[currentImage];
+
   const openUserProfile = () => {
-    router.push({
-      pathname: `${SceneName.Profile}/[id]`,
-      params: {
-        id: dog.id,
-        currentImageIndex: currentImage,
-      },
+    // Kick off the manual hero morph: freeze the tapped photo into a flying
+    // overlay measured at its on-screen frame, then navigate. The destination
+    // card reports its frame on mount (see onDestinationLayout) and the
+    // overlay springs between the two. See @/components/HeroTransition/store.
+    photoAnchorRef.current?.measureInWindow((x, y, width, height) => {
+      if (width > 0 && height > 0 && currentPhoto?.url) {
+        startHero({
+          id: dog.id,
+          source: { uri: currentPhoto.url, blurhash: currentPhoto.blurhash },
+          from: { x, y, width, height },
+        });
+      }
+      router.push({
+        pathname: `${SceneName.Profile}/[id]`,
+        params: {
+          id: dog.id,
+          currentImageIndex: currentImage,
+        },
+      });
     });
   };
+
+  const onDestinationLayout = useCallback(() => {
+    if (!isHeroDestination) return;
+    // Defer to the next frame so native layout has settled before we measure.
+    requestAnimationFrame(() => {
+      photoAnchorRef.current?.measureInWindow((x, y, width, height) => {
+        if (width > 0 && height > 0) {
+          setHeroTarget({ id: dog.id, to: { x, y, width, height } });
+        }
+      });
+    });
+  }, [dog.id, isHeroDestination]);
 
   const gotoPreviousImage = () => {
     // If there is only one image, open the user profile for now.
@@ -95,15 +124,19 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
   return (
     <Container testID="swipe-card" {...props} style={[props.style, transform]}>
       <PhotoAnchor
-        sharedTransitionTag={SHARED_ELEMENT_TRANSITIONS_ENABLED ? `dog-photo-${dog.id}` : undefined}
-        sharedTransitionStyle={SHARED_ELEMENT_TRANSITIONS_ENABLED ? dogPhotoTransition : undefined}
+        ref={photoAnchorRef}
+        onLayout={onDestinationLayout}
+        // While the hero overlay is flying, hide the real photo so only the
+        // overlay copy is visible (no double image). The overlay clears itself
+        // once the morph lands, revealing this again.
+        style={heroActive ? { opacity: 0 } : undefined}
       >
         <Picture
           source={{
-            uri: images[currentImage]?.url,
-            blurhash: images[currentImage]?.blurhash,
+            uri: currentPhoto?.url,
+            blurhash: currentPhoto?.blurhash,
           }}
-          key={images[currentImage]?.id}
+          key={currentPhoto?.id}
         />
       </PhotoAnchor>
       <LinearGradient

--- a/apps/mobile/src/components/MainCard/index.tsx
+++ b/apps/mobile/src/components/MainCard/index.tsx
@@ -2,6 +2,7 @@ import type { SwipeDog } from "@/store/reducers/dogs/swipe";
 import { useState } from "react";
 import * as React from "react";
 import {
+  SharedTransition,
   useAnimatedStyle,
   useSharedValue,
   withSequence,
@@ -11,6 +12,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
 
 import { PressableArea } from "@/components/PressableArea";
+import { SHARED_ELEMENT_TRANSITIONS_ENABLED } from "@/constants";
 import { SceneName } from "@/types/SceneName";
 import Distance from "./components/Distance";
 import Pagination from "./components/Pagination";
@@ -19,6 +21,7 @@ import {
   CarouselContainer,
   Container,
   NextImage,
+  PhotoAnchor,
   Picture,
   PreviousImage,
   UpperPart,
@@ -27,6 +30,10 @@ import {
 const springConfig = { mass: 0.2 };
 
 const START_IMAGE_INDEX = 0;
+
+// Custom easing for the swipe-card -> DogProfile shared-element photo
+// transition. Gated by SHARED_ELEMENT_TRANSITIONS_ENABLED (see @/constants).
+const dogPhotoTransition = SharedTransition.duration(350).springify();
 
 export interface VisitingCardProps extends React.ComponentProps<typeof Container> {
   dog: SwipeDog;
@@ -87,13 +94,20 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
 
   return (
     <Container testID="swipe-card" {...props} style={[props.style, transform]}>
-      <Picture
-        source={{
-          uri: images[currentImage]?.url,
-          blurhash: images[currentImage]?.blurhash,
-        }}
-        key={images[currentImage]?.id}
-      />
+      <PhotoAnchor
+        sharedTransitionTag={
+          SHARED_ELEMENT_TRANSITIONS_ENABLED ? `dog-photo-${dog.id}` : undefined
+        }
+        sharedTransitionStyle={SHARED_ELEMENT_TRANSITIONS_ENABLED ? dogPhotoTransition : undefined}
+      >
+        <Picture
+          source={{
+            uri: images[currentImage]?.url,
+            blurhash: images[currentImage]?.blurhash,
+          }}
+          key={images[currentImage]?.id}
+        />
+      </PhotoAnchor>
       <LinearGradient
         style={{
           position: "absolute",

--- a/apps/mobile/src/components/MainCard/styles.ts
+++ b/apps/mobile/src/components/MainCard/styles.ts
@@ -22,6 +22,19 @@ export const Picture = styled(Image)`
   ${absoluteFill}
 `;
 
+/**
+ * Stable (never remounted) wrapper carrying the shared-element
+ * `sharedTransitionTag`. `Picture` itself remounts (via its `key`) every time
+ * the visible photo index changes on a card, which would otherwise make
+ * Reanimated treat an in-card photo swipe as a shared-element transition.
+ * Keeping the tag on this outer, always-mounted view means the transition
+ * only fires on the real navigation-driven mount/unmount.
+ */
+export const PhotoAnchor = styled(Animated.View)`
+  flex: 1;
+  ${absoluteFill}
+`;
+
 export const UpperPart = styled.View`
   flex: 1;
 `;

--- a/apps/mobile/src/components/MainCard/styles.ts
+++ b/apps/mobile/src/components/MainCard/styles.ts
@@ -23,12 +23,10 @@ export const Picture = styled(Image)`
 `;
 
 /**
- * Stable (never remounted) wrapper carrying the shared-element
- * `sharedTransitionTag`. `Picture` itself remounts (via its `key`) every time
- * the visible photo index changes on a card, which would otherwise make
- * Reanimated treat an in-card photo swipe as a shared-element transition.
- * Keeping the tag on this outer, always-mounted view means the transition
- * only fires on the real navigation-driven mount/unmount.
+ * Stable (never remounted) wrapper around the photo. `Picture` itself remounts
+ * (via its `key`) whenever the visible photo index changes, so keeping the
+ * measure anchor on this always-mounted outer view gives the manual hero
+ * transition a stable frame to measure (see @/components/HeroTransition).
  */
 export const PhotoAnchor = styled(Animated.View)`
   flex: 1;

--- a/apps/mobile/src/components/MatchActionBar/index.tsx
+++ b/apps/mobile/src/components/MatchActionBar/index.tsx
@@ -1,6 +1,14 @@
+import { useCallback, useEffect, useRef } from "react";
 import * as React from "react";
+import { View } from "react-native";
 import Animated, { FadeInDown, ZoomOutDown } from "react-native-reanimated";
 
+import {
+  createHeroMeasurementLifecycle,
+  registerHeroActionFrame,
+  unregisterHeroSourceActionFrame,
+  useIsHeroActive,
+} from "@/components/HeroTransition/store";
 import { ActionItem, ConfusedEmoji, Container, HeartEyesEmoji, ThinkingEmoji } from "./styles";
 
 interface MatchActionBarProps extends React.ComponentProps<typeof Container> {
@@ -8,6 +16,9 @@ interface MatchActionBarProps extends React.ComponentProps<typeof Container> {
   onYep: () => void;
   onMaybe: () => void;
   animated?: boolean;
+  sharedDogId?: string;
+  sharedRole?: "source" | "target";
+  visualOnly?: boolean;
 }
 
 export const MatchActionBar: React.FC<MatchActionBarProps> = ({
@@ -15,14 +26,72 @@ export const MatchActionBar: React.FC<MatchActionBarProps> = ({
   onYep,
   onMaybe,
   animated,
+  sharedDogId,
+  sharedRole,
+  visualOnly,
   ...props
 }) => {
+  const containerRef = useRef<View>(null);
+  const measurementLifecycle = useRef(createHeroMeasurementLifecycle()).current;
+  const pendingAnimationFrames = useRef(new Set<number>());
+  const heroActive = useIsHeroActive(sharedDogId);
+  const measureSharedFrame = useCallback(() => {
+    if (!sharedDogId || !sharedRole) return;
+    const generation = measurementLifecycle.current();
+    if (generation === null) return;
+
+    const animationFrame = requestAnimationFrame(() => {
+      pendingAnimationFrames.current.delete(animationFrame);
+      if (!measurementLifecycle.isCurrent(generation)) return;
+
+      containerRef.current?.measureInWindow((x, y, width, height) => {
+        if (!measurementLifecycle.isCurrent(generation)) return;
+        if (width > 0 && height > 0) {
+          registerHeroActionFrame({
+            id: sharedDogId,
+            role: sharedRole,
+            frame: { x, y, width, height },
+          });
+        }
+      });
+    });
+    pendingAnimationFrames.current.add(animationFrame);
+  }, [measurementLifecycle, sharedDogId, sharedRole]);
+
+  useEffect(() => {
+    const animationFrames = pendingAnimationFrames.current;
+    measurementLifecycle.activate();
+    measureSharedFrame();
+    return () => {
+      // Invalidate first: even a native callback already beyond the RAF
+      // cannot publish after this component/id stops owning the frame.
+      measurementLifecycle.invalidate();
+      for (const animationFrame of animationFrames) {
+        cancelAnimationFrame(animationFrame);
+      }
+      animationFrames.clear();
+      if (sharedDogId && sharedRole === "source") {
+        unregisterHeroSourceActionFrame(sharedDogId);
+      }
+    };
+  }, [measureSharedFrame, measurementLifecycle, sharedDogId, sharedRole]);
+
   const dislikeAnimation = animated ? FadeInDown.delay(300) : undefined;
   const maybeAnimation = animated ? FadeInDown.delay(350) : undefined;
   const likeAnimation = animated ? FadeInDown.delay(400) : undefined;
+  const hiddenFromAccessibility = Boolean(visualOnly || heroActive);
 
   return (
-    <Container exiting={ZoomOutDown} {...props}>
+    <Container
+      ref={containerRef}
+      exiting={visualOnly ? undefined : ZoomOutDown}
+      $hidden={visualOnly ? false : heroActive}
+      $inline={visualOnly}
+      {...props}
+      accessibilityElementsHidden={hiddenFromAccessibility}
+      importantForAccessibility={hiddenFromAccessibility ? "no-hide-descendants" : "auto"}
+      onLayout={measureSharedFrame}
+    >
       <Animated.View entering={dislikeAnimation}>
         <ActionItem testID="swipe-dislike" onPress={onNope}>
           <ConfusedEmoji />

--- a/apps/mobile/src/components/MatchActionBar/styles.ts
+++ b/apps/mobile/src/components/MatchActionBar/styles.ts
@@ -12,26 +12,32 @@ import { PressableArea } from "@/components/PressableArea";
 // Apple HIG recommends a minimum 44x44pt hit area for tappable targets.
 const MIN_TOUCH_TARGET = 44;
 
-export const Container = styled(Animated.View).attrs({
+interface ContainerProps {
+  $hidden?: boolean;
+  $inline?: boolean;
+}
+
+export const Container = styled(Animated.View).attrs<ContainerProps>((props) => ({
   // box-none keeps the bar itself non-blocking so the card below stays
   // pannable in the gaps, but lifts the bar above the card visually so
   // each ActionItem reliably wins taps over the card's PersonalInfo
   // pressable that sits underneath.
-  pointerEvents: "box-none",
-})`
+  pointerEvents: props.$hidden ? "none" : "box-none",
+}))<ContainerProps>`
   width: 100%;
 
   justify-content: space-around;
   align-items: center;
   flex-direction: row;
 
-  position: absolute;
+  position: ${(props) => (props.$inline ? "relative" : "absolute")};
   align-self: center;
-  bottom: ${(props) => props.theme.spacing[6]}px;
+  bottom: ${(props) => (props.$inline ? 0 : props.theme.spacing[6])}px;
   padding: 0 ${(props) => props.theme.spacing[2]}px;
 
   z-index: 10;
   elevation: 10;
+  opacity: ${(props) => (props.$hidden ? 0 : 1)};
 `;
 
 export const ActionItem = styled(PressableArea).attrs({

--- a/apps/mobile/src/constants.ts
+++ b/apps/mobile/src/constants.ts
@@ -14,3 +14,16 @@ export const ACTION_VELOCITY = 1000;
 export const ACTION_THRESHOLD = 1 / 35;
 
 export const APP_SHARE_LINK_BASE = "https://www.pegada.app";
+
+/**
+ * Enables the Reanimated shared-element transition (`sharedTransitionTag`)
+ * from the swipe card photo to the DogProfile photo.
+ *
+ * This relies on Reanimated's `ENABLE_SHARED_ELEMENT_TRANSITIONS` static
+ * feature flag (see `apps/mobile/package.json`'s `reanimated.staticFeatureFlags`),
+ * which the API docs still call experimental. Flip this to `false` (single
+ * line, no native rebuild needed) to fall back to the plain stack "fade"
+ * animation if the transition ever misbehaves (flicker, wrong geometry,
+ * gesture interference) on a device/OS combination we haven't tested.
+ */
+export const SHARED_ELEMENT_TRANSITIONS_ENABLED = true;

--- a/apps/mobile/src/constants.ts
+++ b/apps/mobile/src/constants.ts
@@ -14,16 +14,3 @@ export const ACTION_VELOCITY = 1000;
 export const ACTION_THRESHOLD = 1 / 35;
 
 export const APP_SHARE_LINK_BASE = "https://www.pegada.app";
-
-/**
- * Enables the Reanimated shared-element transition (`sharedTransitionTag`)
- * from the swipe card photo to the DogProfile photo.
- *
- * This relies on Reanimated's `ENABLE_SHARED_ELEMENT_TRANSITIONS` static
- * feature flag (see `apps/mobile/package.json`'s `reanimated.staticFeatureFlags`),
- * which the API docs still call experimental. Flip this to `false` (single
- * line, no native rebuild needed) to fall back to the plain stack "fade"
- * animation if the transition ever misbehaves (flicker, wrong geometry,
- * gesture interference) on a device/OS combination we haven't tested.
- */
-export const SHARED_ELEMENT_TRANSITIONS_ENABLED = true;

--- a/apps/mobile/src/views/(tabs)/Swipe/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/index.tsx
@@ -33,6 +33,8 @@ const MatchActionBarWrapper = () => {
 
   return (
     <MatchActionBar
+      sharedDogId={currentCard}
+      sharedRole="source"
       onNope={() => swipeHandlerRef.current?.gotoDirection(Swipe.Dislike)}
       onYep={() => swipeHandlerRef.current?.gotoDirection(Swipe.Like)}
       onMaybe={() => swipeHandlerRef.current?.gotoDirection(Swipe.Maybe)}

--- a/apps/mobile/src/views/Chat/components/Header/index.tsx
+++ b/apps/mobile/src/views/Chat/components/Header/index.tsx
@@ -1,33 +1,77 @@
-import { ActivityIndicator } from "react-native";
+import { useRef } from "react";
+import { ActivityIndicator, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/native";
 
 import BackArrow from "@/assets/images/BackArrow.svg";
+import { createHeroNavigationWatchdog, startHero } from "@/components/HeroTransition/store";
 import { NetworkBoundary } from "@/components/NetworkBoundary";
 import { Text } from "@/components/Text";
+import { getTrcpContext } from "@/contexts/trcpContext";
 import { api } from "@/contexts/TRPCProvider";
 import { SceneName } from "@/types/SceneName";
 import * as S from "./styles";
 
 export const HEADER_HEIGHT = 65;
 
-const DogProfileInfo = ({ dogId }: { dogId: string }) => {
+const DogProfileInfo = ({ dogId, matchId }: { dogId: string; matchId: string }) => {
   const [dog] = api.dog.get.useSuspenseQuery({ id: dogId }, { refetchOnMount: false });
+  const router = useRouter();
+  const pictureRef = useRef<View>(null);
+
+  const openDogProfile = () => {
+    // Keep the destination's exact query hot even if this already-rendered
+    // header outlives React Query's cache window.
+    getTrcpContext().dog.get.setData({ id: dogId }, dog);
+
+    const navigate = (heroTransition?: string) => {
+      router.push({
+        pathname: `${SceneName.Profile}/[id]`,
+        params: { matchId, id: dogId, heroTransition },
+      });
+    };
+    const finishNavigation = createHeroNavigationWatchdog(navigate);
+
+    if (!pictureRef.current || !dog.images[0]?.url) {
+      return;
+    }
+
+    pictureRef.current.measureInWindow((x, y, width, height) => {
+      if (width <= 0 || height <= 0) {
+        finishNavigation();
+        return;
+      }
+
+      finishNavigation(() => {
+        startHero({
+          id: dogId,
+          source: {
+            uri: dog.images[0]?.url,
+            blurhash: dog.images[0]?.blurhash,
+          },
+          from: { x, y, width, height, borderRadius: Math.min(width, height) / 2 },
+        });
+      });
+    });
+  };
 
   return (
-    <S.ProfileInfoContainer>
-      <S.Picture
-        source={{
-          uri: dog.images[0]?.url,
-          blurhash: dog.images[0]?.blurhash ?? undefined,
-        }}
-      />
-      <Text numberOfLines={1} fontWeight="bold">
-        {dog.name}
-      </Text>
-    </S.ProfileInfoContainer>
+    <S.PressableAreaFlex onPress={openDogProfile}>
+      <S.ProfileInfoContainer>
+        <S.Picture
+          ref={pictureRef}
+          source={{
+            uri: dog.images[0]?.url,
+            blurhash: dog.images[0]?.blurhash ?? undefined,
+          }}
+        />
+        <Text numberOfLines={1} fontWeight="bold">
+          {dog.name}
+        </Text>
+      </S.ProfileInfoContainer>
+    </S.PressableAreaFlex>
   );
 };
 
@@ -68,21 +112,9 @@ const Header = () => {
       <S.BackTouchArea testID="chat-back" onPress={() => router.back()}>
         <BackArrow height={15} width={15} fill={theme.colors.text} />
       </S.BackTouchArea>
-      <S.PressableAreaFlex
-        onPress={() =>
-          router.push({
-            pathname: `${SceneName.Profile}/[id]`,
-            params: { matchId: matchId ?? "", id: dogId as string },
-          })
-        }
-      >
-        <NetworkBoundary
-          errorFallback={DogProfileError}
-          suspenseFallback={<DogProfileInfoLoading />}
-        >
-          <DogProfileInfo dogId={dogId as string} />
-        </NetworkBoundary>
-      </S.PressableAreaFlex>
+      <NetworkBoundary errorFallback={DogProfileError} suspenseFallback={<DogProfileInfoLoading />}>
+        <DogProfileInfo dogId={dogId as string} matchId={matchId as string} />
+      </NetworkBoundary>
     </S.Header>
   );
 };

--- a/apps/mobile/src/views/DogProfile/index.tsx
+++ b/apps/mobile/src/views/DogProfile/index.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as React from "react";
 import { ActivityIndicator, Alert, Linking, Share, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { router, useLocalSearchParams, useRouter } from "expo-router";
+import { router, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Header, HeaderBackButton } from "@react-navigation/elements";
 import i18n from "i18next";
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useTheme } from "styled-components/native";
 
 import MainCard from "@/components/MainCard";
+import { startReverseHero } from "@/components/HeroTransition/store";
 import { MatchActionBar } from "@/components/MatchActionBar";
 import { NetworkBoundary, UnknownErrorComponent } from "@/components/NetworkBoundary";
 import { Text } from "@/components/Text";
@@ -107,13 +108,17 @@ const useSwipeHandler = (id: string) => {
   const dispatch = useDispatch();
 
   return (swipeType: Swipe) => {
+    const commitSwipe = () => {
+      if (id === currentCardId && swipeHandlerRef.current) {
+        return swipeHandlerRef.current.gotoDirection(swipeType);
+      }
+
+      dispatch(Actions.dogs.swipe.request({ id: id, swipeType }));
+    };
+
+    const reversing = startReverseHero(id, commitSwipe);
     router.back();
-
-    if (id === currentCardId && swipeHandlerRef.current) {
-      return swipeHandlerRef.current.gotoDirection(swipeType);
-    }
-
-    dispatch(Actions.dogs.swipe.request({ id: id, swipeType }));
+    if (!reversing) commitSwipe();
   };
 };
 
@@ -121,10 +126,12 @@ const DogProfile = () => {
   const {
     id,
     currentImageIndex = 0,
+    heroTransition,
     matchId,
   } = useLocalSearchParams<{
     id: string;
     currentImageIndex?: string;
+    heroTransition?: string;
     matchId?: string;
   }>();
 
@@ -134,6 +141,21 @@ const DogProfile = () => {
   const insets = useSafeAreaInsets();
   const topInset = useCustomTopInset();
   const router = useRouter();
+  const navigation = useNavigation();
+  const completingHeroRemoval = React.useRef(false);
+
+  useEffect(() => {
+    if (heroTransition !== "1") return;
+    return navigation.addListener("beforeRemove", (event) => {
+      if (completingHeroRemoval.current) return;
+
+      const reversing = startReverseHero(id, () => {
+        completingHeroRemoval.current = true;
+        navigation.dispatch(event.data.action);
+      });
+      if (reversing) event.preventDefault();
+    });
+  }, [heroTransition, id, navigation]);
 
   const theme = useTheme();
 
@@ -255,6 +277,8 @@ const DogProfile = () => {
         <>
           <S.MatchActionBarGradient style={{ height: matchActionBarHeight + theme.spacing[8] }} />
           <MatchActionBar
+            sharedDogId={id}
+            sharedRole="target"
             style={{ bottom: topInset }}
             onNope={() => swipeHandler(Swipe.Dislike)}
             onYep={() => swipeHandler(Swipe.Like)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       react-native-web:
         specifier: ~0.21.2
         version: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-native-worklets:
+        specifier: 0.8.3
+        version: 0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@13.6.9)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-redux:
         specifier: ^9.1.2
         version: 9.1.2(@types/react@19.2.14)(react@19.2.0)(redux@5.0.1)


### PR DESCRIPTION
## Summary

Opening a dog profile now morphs the selected Swipe photo or Chat avatar into the profile, and Back returns it to its source.

## Details

The transition remains a manual overlay because Reanimated shared-element progress events are not emitted by the Expo Router screen tree. The overlay now has an explicit forward/reverse state machine and route-removal handoff.

- Swipe shares the current photo, corner radius, distance, pagination, and action bar with the profile.
- Chat shares only the dog avatar and profile photo, without inheriting Swipe controls.
- Back returns the same elements to their source. An immediate Back before the forward morph lands clears it before returning to Swipe.
- Seeds the exact dog query before navigation so a cold cache does not flash a loading screen behind the morph.
- Falls back to normal navigation after 250 ms if native measurement never returns.
- Holds route removal until reverse motion lands, then hands visibility back after two animation frames to avoid blank or duplicate frames.
- Guards queued action-bar measurements against unmount and dog changes.
- Transition copies are visual-only and excluded from VoiceOver and TalkBack; the real controls return when the morph finishes.
- Profiles opened through normal navigation keep the existing fade.

## Testing steps

1. From Swipe, page to a non-first photo and open the profile. The current photo, distance, pagination, and action bar should move together into their profile positions.
2. Go back. The same elements should return to the card with no blank or duplicate frame.
3. Open a profile from a Chat header, then go back. Only the avatar/photo should morph.
4. Press Back immediately after opening a profile. It should return to Swipe without the photo continuing to animate.
5. Use an action from the profile. The profile should close first, then the next card should appear without a flash or duplicate.
