### PR TITLE
chore(mobile): upload source maps to PostHog on release and OTA builds

### DIFF
--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -81,7 +81,13 @@ jobs:
         run: eas update --auto --non-interactive --environment production
         working-directory: apps/mobile
 
-      # TODO: Bugsnag sourcemap upload removed (dead vendor, replaced by PostHog).
-      # PostHog RN doesn't ship an equivalent build-time sourcemap upload CLI today;
-      # its error tracking relies on SDK-side capture (PostHogErrorBoundary / autocapture),
-      # not symbolication of uploaded maps. Revisit if PostHog adds one.
+      # `eas update` publishes the OTA bundle but never uploads sourcemaps
+      # anywhere (that's a separate step per PostHog's docs). `eas env:exec`
+      # pulls POSTHOG_CLI_API_KEY/HOST/PROJECT_ID from the EAS "production"
+      # environment (POSTHOG_CLI_API_KEY is stored there as "sensitive", not
+      # "secret", so it IS readable by the CLI here) and injects them into
+      # the script's shell env; the script itself no-ops if the key is
+      # somehow still missing.
+      - name: 🗺️ Upload PostHog sourcemaps (OTA)
+        run: eas env:exec production 'pnpm run sourcemaps:upload:ota' --non-interactive
+        working-directory: apps/mobile

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -7,6 +7,23 @@ import { ExpoConfig } from "expo/config";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const defaultLocaleNativeStrings = require("@pegada/shared/i18n/locales/en/native.json");
 
+// The posthog-react-native/expo config plugin wires a sourcemap-upload step
+// into the generated Xcode "Bundle React Native code and images" build phase
+// and the Android Gradle release bundle task (see posthog-react-native's
+// tooling/posthog-xcode.sh and tooling/posthog.gradle). The Gradle side
+// already skips debug variants on its own; the Xcode side does not -- it
+// would run (and hard-fail the build) on ANY config, including a Debug
+// build on a real device, if posthog-cli can't authenticate.
+//
+// Only apply the plugin when POSTHOG_CLI_API_KEY is present so a bare local
+// `expo prebuild`/`expo run:ios`/`expo run:android` (no EAS env, no
+// POSTHOG_CLI_* exported) never gets the upload step injected at all -- the
+// generated native project simply doesn't contain it, so there's nothing to
+// fail. CI (release-mobile.yml's `eas build --local`) and EAS-managed builds
+// pull POSTHOG_CLI_API_KEY from the EAS "production" environment, so the
+// plugin activates there automatically.
+const posthogSourcemapsEnabled = Boolean(process.env.POSTHOG_CLI_API_KEY);
+
 const config: ExpoConfig = {
   /**
    * Always update the version when making a native change
@@ -174,6 +191,11 @@ const config: ExpoConfig = {
     // FAILS gradlew bundleRelease -- this is what killed the 2026-07-05
     // overnight EAS cloud build. See withDefaultLocaleStrings.js.
     ["./plugins/withDefaultLocaleStrings", { stringsByKey: defaultLocaleNativeStrings }],
+    // Sourcemap upload for Release native builds only (see
+    // posthogSourcemapsEnabled above) -- omitted entirely from the plugins
+    // list otherwise, so a plain local build never has the upload step in
+    // its generated Xcode/Gradle project.
+    ...(posthogSourcemapsEnabled ? (["posthog-react-native/expo"] as const) : []),
   ],
   androidStatusBar: {
     barStyle: "dark-content",

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,6 +1,7 @@
 // https://github.com/expo/router/blob/main/apps/demo/metro.config.js
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require("expo/metro-config");
+const { getPostHogExpoConfig } = require("posthog-react-native/metro");
 const path = require("path");
 
 // Find the project and workspace directories
@@ -8,7 +9,14 @@ const projectRoot = __dirname;
 
 const workspaceRoot = path.resolve(projectRoot, "../..");
 
-const config = getDefaultConfig(__dirname);
+// Wraps the default config so every JS bundle (Release native builds AND
+// `expo export`/`eas update` OTA bundles) gets a chunk/debug id injected at
+// build time. That id is what lets PostHog match an uploaded sourcemap back
+// to the exact bundle a crash came from. Safe to always apply: it only
+// annotates the bundle, it never uploads anything itself (upload happens
+// separately, see app.config.ts's posthog-react-native/expo plugin and
+// scripts/upload-posthog-sourcemaps-ota.sh for the OTA path).
+const config = getPostHogExpoConfig(__dirname, { getDefaultConfig });
 
 config.watcher = {
   // +73.3

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "expo:prebuild": "expo prebuild",
     "setup:secret:files": "[ ! -s ./google-services.json ] && printf '%s' \"$GOOGLE_SERVICES_JSON\" > ./google-services.json || echo \"\" ; [ ! -s ./GoogleService-Info.plist ] && printf '%s' \"$GOOGLE_SERVICE_INFO_PLIST\" > ./GoogleService-Info.plist || echo \"\"",
-    "preinstall": "pnpm setup:secret:files"
+    "preinstall": "pnpm setup:secret:files",
+    "sourcemaps:upload:ota": "../../scripts/upload-posthog-sourcemaps-ota.sh"
   },
   "dependencies": {
     "@expo/config-types": "^55.0.5",
@@ -106,6 +107,7 @@
     "@babel/core": "^7.29.0",
     "@pegada/api": "workspace:*",
     "@pegada/tsconfig": "workspace:*",
+    "@posthog/cli": "^0.8.1",
     "@types/color": "^3.0.6",
     "@types/lodash": "^4.17.7",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       '@pegada/tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig
+      '@posthog/cli':
+        specifier: ^0.8.1
+        version: 0.8.1
       '@types/color':
         specifier: ^3.0.6
         version: 3.0.6
@@ -2269,6 +2272,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@posthog/cli@0.8.1':
+    resolution: {integrity: sha512-7gCx2rslQtXSN0RfdxHRXumc5E1CY8ldVDxncUGeQ7qTFHprRbryH17W//fcuNMeNhvr6vc8DStj9gGWSS/Zfw==}
+    engines: {node: '>=14.14', npm: '>=6'}
+    hasBin: true
 
   '@posthog/core@1.39.6':
     resolution: {integrity: sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==}
@@ -9540,6 +9548,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@posthog/cli@0.8.1':
+    dependencies:
+      detect-libc: 2.1.2
 
   '@posthog/core@1.39.6':
     dependencies:

--- a/scripts/upload-posthog-sourcemaps-ota.sh
+++ b/scripts/upload-posthog-sourcemaps-ota.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Uploads readable JS sourcemaps to PostHog for an `eas update` OTA bundle.
+#
+# Why this exists: `eas update` (run from .github/workflows/deploy-mobile.yml
+# on every push to main) publishes a Hermes bundle but does NOT itself upload
+# sourcemaps anywhere -- that's a separate, manual step per PostHog's docs
+# (https://posthog.com/docs/error-tracking/upload-source-maps/react-native).
+# Native Release builds get their upload wired automatically via the
+# posthog-react-native/expo config plugin (see apps/mobile/app.config.ts and
+# the Xcode/Gradle build phases it injects); OTA bundles have no build phase
+# to hook into, so this script re-exports the same JS with sourcemaps and
+# uploads them explicitly.
+#
+# Guarded on POSTHOG_CLI_API_KEY so this is a silent no-op for anyone running
+# it without the CI/EAS-provided credentials (matches the native-build guard
+# in app.config.ts) -- never fails a deploy just because sourcemaps aren't
+# configured.
+set -euo pipefail
+
+if [ -z "${POSTHOG_CLI_API_KEY:-}" ]; then
+  echo "POSTHOG_CLI_API_KEY not set; skipping PostHog sourcemap upload."
+  exit 0
+fi
+
+cd "$(dirname "$0")/../apps/mobile"
+
+OUTPUT_DIR="dist"
+# Bundle identifier is stable across OTA updates (only the JS changes), so
+# every OTA upload is tagged under the same release-name as native builds.
+# release-version is left to posthog-cli's own git auto-detection: it
+# derives commit/branch info from the checkout, which ties each OTA upload
+# to the exact commit `eas update` published -- more precise than the app's
+# semver for this path, since many OTAs land between version bumps.
+RELEASE_NAME="app.pegada"
+
+echo "Exporting JS bundle + sourcemaps to $OUTPUT_DIR..."
+npx expo export --dump-sourcemap --output-dir "$OUTPUT_DIR"
+
+# Chunk ids are already injected at bundle time by the posthog-react-native
+# Metro serializer (see metro.config.js's getPostHogExpoConfig); only the
+# upload step is needed here.
+echo "Uploading sourcemaps to PostHog..."
+npx posthog-cli hermes upload \
+  --directory "$OUTPUT_DIR" \
+  --release-name "$RELEASE_NAME"
+
+echo "PostHog sourcemap upload complete."


### PR DESCRIPTION
## Summary

Production JS stack traces in PostHog error tracking become readable: source maps now upload automatically on native release builds and OTA updates.

## Details

- Metro config wraps PostHog's Expo helper so every bundle gets a chunk/debug id injected.
- The `posthog-react-native/expo` config plugin wires the upload into the Xcode bundle phase and the Android Gradle release task, added only when `POSTHOG_CLI_API_KEY` is present, so plain local `expo run:ios` / prebuild stays untouched.
- OTA path: a small script runs `expo export --dump-sourcemap` + `posthog-cli hermes upload`, wired into the deploy workflow via `eas env:exec` (replaces a stale TODO claiming this CLI didn't exist).
- No CI secret changes needed: the key lives in EAS with "sensitive" visibility, readable where the config plugin needs it.
- Verified with real uploads to the PostHog project from both paths (native release sim build and an OTA export), server confirming the upload keys.

## Testing steps

1. Merge and let the next release or OTA update go out normally.
2. In PostHog, open Error tracking and click any new exception from that build: the stack trace should show real file names and lines instead of minified frames.
3. Do a local debug run of the app as usual and confirm nothing new happens at build time (no upload step, no extra output).