### PR TITLE
fix(mobile): forward image props to Expo Image

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -114,6 +114,7 @@
     "@pegada/tsconfig": "workspace:*",
     "@posthog/cli": "^0.8.1",
     "@types/color": "^3.0.6",
+    "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.7",
     "@types/react": "^19.2.14",
     "@types/react-dom": "~19.2.3",

--- a/apps/mobile/src/components/Image.test.tsx
+++ b/apps/mobile/src/components/Image.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { Image as ExpoImage } from "expo-image";
+
+import { Image } from "./Image";
+
+jest.mock("expo-image", () => ({ Image: jest.fn(() => null) }));
+
+const expoImage = ExpoImage as unknown as jest.Mock;
+
+const blurhash = "LEHV6nWB2yk8pyo0adR*.7kCMdnj";
+const uri = "https://images.pegada.app/luna.webp";
+
+beforeEach(() => {
+  expoImage.mockClear();
+});
+
+test("hands every image prop to Expo Image, on a single node", () => {
+  const onDisplay = () => undefined;
+  const onLoad = () => undefined;
+
+  renderToStaticMarkup(
+    <Image
+      source={{ uri, blurhash }}
+      contentFit="contain"
+      contentPosition="top"
+      transition={180}
+      recyclingKey="luna-photo-1"
+      priority="high"
+      onDisplay={onDisplay}
+      onLoad={onLoad}
+    />,
+  );
+
+  expect(expoImage).toHaveBeenCalledTimes(1);
+  expect(expoImage.mock.calls[0]?.[0]).toMatchObject({
+    source: { uri },
+    placeholder: { blurhash },
+    contentFit: "contain",
+    placeholderContentFit: "contain",
+    contentPosition: "top",
+    transition: 180,
+    recyclingKey: "luna-photo-1",
+    priority: "high",
+    cachePolicy: "memory-disk",
+    onDisplay,
+    onLoad,
+  });
+});
+
+test("keeps the style on the image itself instead of a wrapper", () => {
+  const style = { width: 80, height: 100, borderRadius: 12 };
+
+  renderToStaticMarkup(<Image source={{ uri }} style={style} />);
+
+  expect(expoImage.mock.calls[0]?.[0]).toMatchObject({ style });
+});

--- a/apps/mobile/src/components/Image.tsx
+++ b/apps/mobile/src/components/Image.tsx
@@ -1,35 +1,29 @@
-import { forwardRef } from "react";
-import { View } from "react-native";
-import { Image as ExpoImage, ImageProps } from "expo-image";
-import styled from "styled-components/native";
+import { forwardRef, type ComponentRef } from "react";
+import { Image as ExpoImage, type ImageProps } from "expo-image";
 
-interface LocalImageProps extends Omit<ImageProps, "source"> {
-  source?: {
-    blurhash?: string | null | undefined;
-    uri?: string;
-  };
-}
+import { resolveImagePresentationProps } from "./imageProps";
 
-const AbsoluteImage = styled(ExpoImage)`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-`;
+export type LocalImageProps = ImageProps;
 
-const ImageWrapper = styled.View`
-  overflow: hidden;
-`;
+/**
+ * Pegada's cached image with automatic blurhash placeholder support.
+ *
+ * This intentionally renders a single Expo Image. Keeping an outer View here
+ * would require manually separating every current and future Image prop from
+ * View props, which is how options such as contentFit and onDisplay were lost.
+ */
+export const Image = forwardRef<ComponentRef<typeof ExpoImage>, LocalImageProps>(
+  ({ source, placeholder, contentFit, placeholderContentFit, cachePolicy, ...props }, ref) => {
+    const presentationProps = resolveImagePresentationProps({
+      source,
+      placeholder,
+      contentFit,
+      placeholderContentFit,
+      cachePolicy,
+    });
 
-export const Image = forwardRef<View, LocalImageProps>(({ source, ...props }, ref) => {
-  const blurhash = source?.blurhash;
+    return <ExpoImage ref={ref} {...props} {...presentationProps} />;
+  },
+);
 
-  return (
-    <ImageWrapper {...props} ref={ref}>
-      {blurhash ? <AbsoluteImage source={{ blurhash }} /> : null}
-      <AbsoluteImage
-        source={blurhash ? { ...source, blurhash: undefined } : source}
-        cachePolicy="memory-disk"
-      />
-    </ImageWrapper>
-  );
-});
+Image.displayName = "Image";

--- a/apps/mobile/src/components/imageProps.test.ts
+++ b/apps/mobile/src/components/imageProps.test.ts
@@ -1,0 +1,102 @@
+import type { ComponentProps } from "react";
+
+import type { Image } from "./Image";
+import { resolveImagePresentationProps } from "./imageProps";
+
+const blurhash = "LEHV6nWB2yk8pyo0adR*.7kCMdnj";
+const uri = "https://images.pegada.app/luna.webp";
+
+// Compiles only while Image keeps forwarding Expo Image's own props. These are
+// the ones the old layout wrapper silently swallowed.
+const forwardedProps = {
+  source: { uri, blurhash },
+  contentFit: "contain",
+  contentPosition: "top",
+  transition: 180,
+  recyclingKey: "luna-photo-1",
+  onDisplay: () => undefined,
+  onLoad: () => undefined,
+} satisfies ComponentProps<typeof Image>;
+
+test("moves an API blurhash onto the placeholder and keeps the source clean", () => {
+  expect(resolveImagePresentationProps(forwardedProps)).toEqual({
+    source: { uri },
+    placeholder: { blurhash },
+    contentFit: "contain",
+    placeholderContentFit: "contain",
+    cachePolicy: "memory-disk",
+  });
+});
+
+test("defaults the blurhash fit to cover when the caller sets no contentFit", () => {
+  expect(resolveImagePresentationProps({ source: { uri, blurhash } })).toEqual({
+    source: { uri },
+    placeholder: { blurhash },
+    contentFit: undefined,
+    placeholderContentFit: "cover",
+    cachePolicy: "memory-disk",
+  });
+});
+
+test("leaves a caller-provided placeholder and cache policy alone", () => {
+  const placeholder = { uri: "file:///placeholder.webp" };
+
+  expect(
+    resolveImagePresentationProps({
+      source: { uri, blurhash },
+      placeholder,
+      placeholderContentFit: "scale-down",
+      cachePolicy: "disk",
+    }),
+  ).toEqual({
+    source: { uri },
+    placeholder,
+    contentFit: undefined,
+    placeholderContentFit: "scale-down",
+    cachePolicy: "disk",
+  });
+});
+
+test("treats an explicit null placeholder and cache policy as opting out", () => {
+  expect(
+    resolveImagePresentationProps({
+      source: { uri, blurhash },
+      placeholder: null,
+      cachePolicy: null,
+    }),
+  ).toEqual({
+    source: { uri },
+    placeholder: null,
+    contentFit: undefined,
+    placeholderContentFit: undefined,
+    cachePolicy: null,
+  });
+});
+
+test.each([42, "https://images.pegada.app/static.webp", null] as const)(
+  "passes a %p source straight through",
+  (source) => {
+    expect(resolveImagePresentationProps({ source })).toEqual({
+      source,
+      placeholder: undefined,
+      contentFit: undefined,
+      placeholderContentFit: undefined,
+      cachePolicy: "memory-disk",
+    });
+  },
+);
+
+test("passes a responsive source array straight through", () => {
+  const source = [
+    { uri: "https://images.pegada.app/luna-small.webp", width: 320 },
+    { uri: "https://images.pegada.app/luna-large.webp", width: 1280 },
+  ];
+
+  expect(resolveImagePresentationProps({ source })).toEqual({
+    source,
+    placeholder: undefined,
+    contentFit: undefined,
+    placeholderContentFit: undefined,
+    cachePolicy: "memory-disk",
+  });
+});

--- a/apps/mobile/src/components/imageProps.ts
+++ b/apps/mobile/src/components/imageProps.ts
@@ -1,0 +1,52 @@
+import type { ImageProps, ImageSource } from "expo-image";
+
+const DEFAULT_CACHE_POLICY = "memory-disk" as const;
+
+type ImagePresentationProps = Pick<
+  ImageProps,
+  "cachePolicy" | "contentFit" | "placeholder" | "placeholderContentFit" | "source"
+>;
+
+const isBlurhashSource = (
+  source: ImageProps["source"],
+): source is ImageSource & { blurhash: string } =>
+  typeof source === "object" &&
+  source !== null &&
+  !Array.isArray(source) &&
+  "blurhash" in source &&
+  typeof source.blurhash === "string" &&
+  source.blurhash.length > 0;
+
+/**
+ * A source cannot use `uri` and `blurhash` simultaneously in Expo Image.
+ * Treat Pegada's API blurhash as a placeholder and leave the real source clean.
+ */
+export const resolveImagePresentationProps = ({
+  source,
+  placeholder,
+  contentFit,
+  placeholderContentFit,
+  cachePolicy,
+}: ImagePresentationProps): ImagePresentationProps => {
+  if (!isBlurhashSource(source)) {
+    return {
+      source,
+      placeholder,
+      contentFit,
+      placeholderContentFit,
+      cachePolicy: cachePolicy === undefined ? DEFAULT_CACHE_POLICY : cachePolicy,
+    };
+  }
+
+  const { blurhash, ...imageSource } = source;
+  const usesSourceBlurhash = placeholder === undefined;
+
+  return {
+    source: imageSource,
+    placeholder: usesSourceBlurhash ? { blurhash } : placeholder,
+    contentFit,
+    placeholderContentFit:
+      placeholderContentFit ?? (usesSourceBlurhash ? (contentFit ?? "cover") : undefined),
+    cachePolicy: cachePolicy === undefined ? DEFAULT_CACHE_POLICY : cachePolicy,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
       '@types/color':
         specifier: ^3.0.6
         version: 3.0.6
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
       '@types/lodash':
         specifier: ^4.17.7
         version: 4.17.7
@@ -516,7 +519,7 @@ importers:
         version: 11.0.0-rc.477
       '@types/jest':
         specifier: ^29.5.12
-        version: 29.5.12
+        version: 29.5.14
       '@vercel/queue':
         specifier: ^0.3.1
         version: 0.3.1
@@ -3265,8 +3268,8 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
-  '@types/jest@29.5.12':
-    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -10693,7 +10696,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
-  '@types/jest@29.5.12':
+  '@types/jest@29.5.14':
     dependencies:
       expect: 29.7.0
       pretty-format: 29.7.0


### PR DESCRIPTION
## Summary

Image options and callbacks were landing on the layout wrapper instead of the native image, so `contentFit`, `contentPosition`, `transition`, `recyclingKey` and the load callbacks were dropped at every call site. Rendering one Expo Image fixes it.

## Details

- Renders a single Expo Image, so whatever a caller passes reaches the component that owns it. Keeping the wrapper would mean hand-separating every current and future Image prop from View props, which is how these got lost in the first place.
- The API's blurhash moves onto `placeholder`, where expo-image expects it: one source can't carry both `uri` and `blurhash`. Caller-provided placeholders, `placeholderContentFit` and cache policies still win, and memory-and-disk stays the default.
- The blurhash placeholder inherits the image's own `contentFit` so it doesn't crop differently from the photo that replaces it.
- Every call site is a `styled(Image)` with width, height and border-radius, all of which expo-image applies itself, so the `overflow: hidden` wrapper wasn't buying anything.
- Rebased onto `main`. The old branch also had a `verify:image-props` tsx script that ran nowhere in CI; that's now three jest suites, which `pnpm test` picks up on every branch push.

## Proof

720x240 image in a 150x150 box on an iPhone 17 Pro Max simulator, Release build. `contain` keeps all four colour bands, `cover` crops to the middle two. Top row is `main` with `contentFit="contain"` then `"cover"`, identical because both were dropped. Middle row is this branch, same two props, honoured. Bottom row is `contentPosition` left then right.

![contentFit old vs new](https://raw.githubusercontent.com/GSTJ/pegada/gstj/pr-assets-dump/pr86/contentfit-old-vs-new.png)

## Testing steps

1. `pnpm --filter @pegada/mobile test` (12 tests). `Image.test.tsx` renders the component with `expo-image` mocked and asserts the props arrive on it; drop the `{...props}` spread and both of its cases fail.
2. Open the swipe screen, Messages, a chat, Profile and Edit profile, and confirm every dog photo renders with the expected crop and rounded corners.
3. Switch between light and dark mode and confirm the photos stay visible.
