### PR TITLE
fix(mobile): remove Trans list-key warnings

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,6 +8,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "eject": "expo eject",
+    "test": "jest --runInBand",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "expo:prebuild": "expo prebuild",
     "setup:secret:files": "[ ! -s ./google-services.json ] && printf '%s' \"$GOOGLE_SERVICES_JSON\" > ./google-services.json || echo \"\" ; [ ! -s ./GoogleService-Info.plist ] && printf '%s' \"$GOOGLE_SERVICE_INFO_PLIST\" > ./GoogleService-Info.plist || echo \"\"",
@@ -115,7 +116,9 @@
     "@types/react-redux": "^7.1.33",
     "@types/react-test-renderer": "^18.3.0",
     "@types/uuid": "^10.0.0",
-    "babel-plugin-styled-components": "^2.1.4"
+    "babel-jest": "^29.7.0",
+    "babel-plugin-styled-components": "^2.1.4",
+    "jest": "^29.7.0"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/apps/mobile/src/components/LikeLimitReached/index.tsx
+++ b/apps/mobile/src/components/LikeLimitReached/index.tsx
@@ -43,7 +43,7 @@ const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({ likeLimitResetAt })
           <Trans
             i18nKey="likeLimit.description"
             components={{
-              b: <Text fontWeight="semibold" />,
+              b: <Text key="b" fontWeight="semibold" />,
             }}
             values={{ count: FREE_DAILY_SWIPE_LIMIT }}
           />

--- a/apps/mobile/src/views/(auth)/SignIn/components/HeroText/index.test.jsx
+++ b/apps/mobile/src/views/(auth)/SignIn/components/HeroText/index.test.jsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { changeLanguage, use } from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import { initI18n } from "@pegada/shared/i18n/i18n";
+
+import HeroText from ".";
+
+jest.mock("./styles", () => ({
+  Container: "div",
+  FlexRowView: "div",
+  Line: "span",
+  RotatedRectangle: "span",
+  Title: "span",
+  UnderlineContainer: "span",
+  WhiteTitle: "span",
+}));
+
+beforeAll(async () => {
+  await initI18n(use(initReactI18next));
+});
+
+test.each(["en-US", "pt-BR"])("renders %s without React key warnings", async (language) => {
+  await changeLanguage(language);
+
+  const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+  try {
+    renderToStaticMarkup(<HeroText />);
+    expect(consoleError).not.toHaveBeenCalled();
+  } finally {
+    consoleError.mockRestore();
+  }
+});

--- a/apps/mobile/src/views/(auth)/SignIn/components/HeroText/index.tsx
+++ b/apps/mobile/src/views/(auth)/SignIn/components/HeroText/index.tsx
@@ -35,9 +35,9 @@ const HeroText: React.FC = () => {
       <Trans
         i18nKey="insertEmail.findDogsNearYou"
         components={{
-          view: <FlexRowView />,
-          title: <Title />,
-          highlight: <RectangleHighLight />,
+          view: <FlexRowView key="view" />,
+          title: <Title key="title" />,
+          highlight: <RectangleHighLight key="highlight" />,
         }}
       />
     </Container>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,9 +339,15 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      babel-jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@babel/core@7.29.0)
       babel-plugin-styled-components:
         specifier: ^2.1.4
         version: 2.1.4(@babel/core@7.29.0)(styled-components@6.1.11(patch_hash=7pi476ptgmafuuvkxpwgjc6kq4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.1.0)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@22.1.0)(typescript@5.4.5))
 
   apps/nextjs:
     dependencies:


### PR DESCRIPTION
## Summary

Adds stable keys to the mobile app's rich-text translation components, removing React 19 list-key warnings from the sign-in hero and daily swipe-limit message.

## Details

- Keeps each `Trans` component template identifiable before react-i18next transforms it.
- Covers the sign-in hero templates and the bold fragment in the daily swipe-limit message.

## Testing steps

1. Sign out and open the sign-in screen.
2. Switch the device between light and dark appearance. Confirm Find Dogs Near You renders without a warning banner.
3. Sign in and swipe until the daily limit is reached. Confirm the limit message renders without a warning banner.
