### PR TITLE
deps: force brace-expansion 5.0.8, patch minimatch to match

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,15 +48,15 @@
     "patchedDependencies": {
       "react-native-draggable-grid@2.2.1": "patches/react-native-draggable-grid@2.2.1.patch",
       "styled-components@6.1.11": "patches/styled-components@6.1.11.patch",
-      "redux-saga@1.3.0": "patches/redux-saga@1.3.0.patch"
+      "redux-saga@1.3.0": "patches/redux-saga@1.3.0.patch",
+      "minimatch@3.1.5": "patches/minimatch@3.1.5.patch",
+      "minimatch@9.0.9": "patches/minimatch@9.0.9.patch"
     },
     "overrides": {
       "@react-native-async-storage/async-storage": "2.2.0",
       "react-native-svg": "15.15.3",
       "@xmldom/xmldom": "^0.8.13",
-      "brace-expansion@1": "^1.1.16",
-      "brace-expansion@2": "^2.1.2",
-      "brace-expansion@5": "^5.0.7",
+      "brace-expansion": "^5.0.8",
       "braces": "^3.0.3",
       "diff@4": "^4.0.4",
       "esbuild": "^0.28.1",

--- a/patches/README.md
+++ b/patches/README.md
@@ -5,3 +5,11 @@ Makes it work on monorepos
 # Draggable Grid Patch
 
 Fixes typescript errors
+
+# Minimatch Patches (3.1.5 and 9.0.9)
+
+brace-expansion <= 5.0.7 is CVE-2026-14257, and the fix only exists on 5.x.
+Both of these minimatch lines are EOL on brace-expansion 1.x/2.x, so the root
+override forces 5.0.8 everywhere and these patches teach them to read the named
+`expand` export 5.x switched to. Drop them if either minimatch ever ships a
+release that depends on brace-expansion 5.

--- a/patches/minimatch@3.1.5.patch
+++ b/patches/minimatch@3.1.5.patch
@@ -1,0 +1,19 @@
+diff --git a/minimatch.js b/minimatch.js
+index 2e4a058a130dceebf83a7bd435f5d22b765ac836..d78c32b3a5254fcdeda07713e2481bf7e7804c2b 100644
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -7,7 +7,13 @@ var path = (function () { try { return require('path') } catch (e) {}}()) || {
+ minimatch.sep = path.sep
+ 
+ var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
+-var expand = require('brace-expansion')
++// brace-expansion 1.x/2.x are affected by CVE-2026-14257 (unbounded expansion
++// length -> uncatchable OOM) and upstream shipped the fix on 5.x only. The root
++// package.json pins brace-expansion to ^5.0.8 everywhere; 5.x moved from
++// `module.exports = expand` to a named `expand` export, so unwrap it here. The
++// fallback keeps this working if the resolved copy is ever a 1.x/2.x again.
++var braceExpansion = require('brace-expansion')
++var expand = braceExpansion.expand || braceExpansion
+ 
+ var plTypes = {
+   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},

--- a/patches/minimatch@9.0.9.patch
+++ b/patches/minimatch@9.0.9.patch
@@ -1,0 +1,34 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index c12dc5e6476874f9dbba429a19e445a4a688e1df..1dd661b7ce2e87e5c495bd0eab2960ce58819348 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -4,7 +4,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
+ };
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.unescape = exports.escape = exports.AST = exports.Minimatch = exports.match = exports.makeRe = exports.braceExpand = exports.defaults = exports.filter = exports.GLOBSTAR = exports.sep = exports.minimatch = void 0;
+-const brace_expansion_1 = __importDefault(require("brace-expansion"));
++// brace-expansion 1.x/2.x are affected by CVE-2026-14257 (unbounded expansion
++// length -> uncatchable OOM) and upstream shipped the fix on 5.x only. The root
++// package.json pins brace-expansion to ^5.0.8 everywhere; 5.x dropped the
++// default export in favour of a named `expand`, so normalise both shapes here.
++const brace_expansion_mod_1 = require("brace-expansion");
++const brace_expansion_1 = {
++    default: brace_expansion_mod_1.expand || __importDefault(brace_expansion_mod_1).default,
++};
+ const assert_valid_pattern_js_1 = require("./assert-valid-pattern.js");
+ const ast_js_1 = require("./ast.js");
+ const escape_js_1 = require("./escape.js");
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 737c8095415235e69e4717b505d0ee4ea3c0b6fa..de36008709e804b4e8cc2c3f23e70bc2fea009b1 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -1,4 +1,8 @@
+-import expand from 'brace-expansion';
++// brace-expansion 1.x/2.x are affected by CVE-2026-14257 (unbounded expansion
++// length -> uncatchable OOM) and upstream shipped the fix on 5.x only. The root
++// package.json pins brace-expansion to ^5.0.8 everywhere; 5.x dropped the
++// default export in favour of a named `expand`, so import the named one.
++import { expand } from 'brace-expansion';
+ import { assertValidPattern } from './assert-valid-pattern.js';
+ import { AST } from './ast.js';
+ import { escape } from './escape.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,7 @@ overrides:
   '@react-native-async-storage/async-storage': 2.2.0
   react-native-svg: 15.15.3
   '@xmldom/xmldom': ^0.8.13
-  brace-expansion@1: ^1.1.16
-  brace-expansion@2: ^2.1.2
-  brace-expansion@5: ^5.0.7
+  brace-expansion: ^5.0.8
   braces: ^3.0.3
   diff@4: ^4.0.4
   esbuild: ^0.28.1
@@ -33,6 +31,12 @@ overrides:
   ws@8: ^8.21.0
 
 patchedDependencies:
+  minimatch@3.1.5:
+    hash: anzpumbibnypkm6xefxwimexay
+    path: patches/minimatch@3.1.5.patch
+  minimatch@9.0.9:
+    hash: keuwdskl3w6bv76exewvpi5lxe
+    path: patches/minimatch@9.0.9.patch
   react-native-draggable-grid@2.2.1:
     hash: v6ayathkzbndn3dcqvsojpmote
     path: patches/react-native-draggable-grid@2.2.1.patch
@@ -3651,9 +3655,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3706,12 +3707,6 @@ packages:
   bplist-parser@0.3.2:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
-
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -3952,9 +3947,6 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
@@ -11140,8 +11132,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base-64@0.1.0: {}
@@ -11184,15 +11174,6 @@ snapshots:
   bplist-parser@0.3.2:
     dependencies:
       big-integer: 1.6.52
-
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
     dependencies:
@@ -11448,8 +11429,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  concat-map@0.0.1: {}
 
   connect@3.7.0:
     dependencies:
@@ -12385,7 +12364,7 @@ snapshots:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 3.4.3
-      minimatch: 9.0.9
+      minimatch: 9.0.9(patch_hash=keuwdskl3w6bv76exewvpi5lxe)
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -12401,7 +12380,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=anzpumbibnypkm6xefxwimexay)
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -13990,13 +13969,13 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.8
 
-  minimatch@3.1.5:
+  minimatch@3.1.5(patch_hash=anzpumbibnypkm6xefxwimexay):
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
-  minimatch@9.0.9:
+  minimatch@9.0.9(patch_hash=keuwdskl3w6bv76exewvpi5lxe):
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -15292,7 +15271,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=anzpumbibnypkm6xefxwimexay)
 
   thenify-all@1.6.0:
     dependencies:


### PR DESCRIPTION
Last open high-severity Dependabot alert (#374 uuid and #319 fast-xml-parser stay open, both medium, both documented in #91). `brace-expansion` <= 5.0.7 (CVE-2026-14257, high) is a DoS: `expand()` caps the *number* of results but not their *length*, so `'{a,b}'.repeat(1500)` builds 100k long strings and kills the process with an OOM that `try/catch` can't catch.

#91 left this one open on the read that only 1.x/2.x were in the tree and that forcing v5 breaks minimatch. Half right. All three were in there:

- `brace-expansion@1.1.16` via `minimatch@3.1.5` (glob@7, so jest, RN codegen, rimraf, test-exclude)
- `brace-expansion@2.1.2` via `minimatch@9.0.9` (glob@10, so sucrase and @bacons/apple-targets)
- `brace-expansion@5.0.8` via `minimatch@10.2.5`, already fine

The advisory range is a flat `<= 5.0.7` with no per-major carve-out, and 1.1.16 / 2.1.2 are the newest on their lines, so no backport is coming. Both do abort on the PoC, so this isn't a range-matching artifact:

```
$ node --max-old-space-size=300 -e "require('brace-expansion')('{a,b}'.repeat(1500))"   # 1.1.16
<--- Last few GCs --->
[1651:0x9a080c000]  927 ms: Mark-Compact 310.0 (323.6) -> 310.0 (323.6) MB ... allocation failure
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

## Changes

`brace-expansion` is now overridden to `^5.0.8` flat, no major split, plus patches to `minimatch@3.1.5` and `minimatch@9.0.9` so they can consume it. 5.x moved from `module.exports = expand` to a named `expand` export, which is exactly the breakage #91 was pointing at. The patches unwrap the named export and fall back to the old shape if the resolved copy is ever not 5.x.

Bumping the parents instead doesn't work: 3.1.5 and 9.0.9 are the last of their lines, and forcing minimatch 10 into glob@7 breaks it outright since v10's CJS entry isn't callable.

## Verification

Swapping the expander under jest and Metro is the actual risk here. Same input into 1.1.16, 2.1.2 and 5.0.8:

- 27 hand-picked cases: sequences (`{1..10..3}`, `{a..e}`, `{-01..5}`), nesting, escapes, empty sets, malformed input
- 20,000 randomly generated strings over the brace alphabet

Zero differences. Then through the patched copies:

```
mm3.braceExpand('a/{b,c}.js')                 ['a/b.js', 'a/c.js']
mm3('src/x/y.ts', '**/*.{ts,tsx}')            true
mm9.braceExpand('a/{b,c}.js')                 ['a/b.js', 'a/c.js']   (cjs and esm builds)
glob@7.sync('packages/*/{package.json,tsconfig.json}')    6 hits
glob@10.globSync(same pattern)                            6 hits
```

And the PoC through minimatch, which used to take the process down:

```
mm3.braceExpand('{a,b}'.repeat(1500))   2666 results in 279ms
be9('{a,b}'.repeat(1500))               2666 results in 264ms
```

Repo checks, from an empty `node_modules`:

```
pnpm install --frozen-lockfile   exit 0
pnpm dedupe --check              exit 0
pnpm run typecheck               Tasks: 5 successful, 5 total
pnpm run format                  All matched files use the correct format (449 files)
oxlint                           452 warnings, 0 errors (same as main)
pnpm -F @pegada/mobile test      2 passed
```

`@pegada/api`'s suite is missing from that list. It brings up `postgis/postgis`, which publishes no arm64 image, and no workflow runs `pnpm test` either, so there is no test coverage on the API side for this change. Nothing in the diff reaches API code, so I'm not holding it for that.

The lockfile also gets smaller (`balanced-match@1.0.2` and `concat-map` drop out entirely, one `brace-expansion` left instead of three), and 5.x declares `node: 20 || >=22`, which `.nvmrc` at 20.16 and CI at 20.x both satisfy.


