### PR TITLE
fix(api): pass message delete ids in the right order

### DIFF
--- a/packages/api/src/routes/message.ts
+++ b/packages/api/src/routes/message.ts
@@ -51,7 +51,10 @@ export const messageRouter = createTRPCRouter({
 
     const dog = await DogService.getDogByUserId(ctx.session.user.id);
 
-    const deletedMessage = await MessageService.deleteMessage(dog.id, messageId);
+    const deletedMessage = await MessageService.deleteMessage({
+      messageId,
+      senderId: dog.id,
+    });
 
     return deletedMessage;
   }),

--- a/packages/api/src/services/MessageService.test.ts
+++ b/packages/api/src/services/MessageService.test.ts
@@ -1,0 +1,107 @@
+import prisma from "@pegada/database";
+import { breedData } from "@pegada/database/__mocks__/breed-data";
+import { generateFakeUserWithDog } from "@pegada/database/__mocks__/generate-fake-user-with-dog";
+
+import MessageService from "./MessageService";
+
+jest.mock("../shared/posthog", () => ({
+  posthog: {
+    captureException: jest.fn(),
+    capture: jest.fn(),
+    identify: jest.fn(),
+    isFeatureEnabled: jest.fn(),
+    shutdown: jest.fn(),
+  },
+}));
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeAll(async () => {
+  await prisma.breed.deleteMany();
+  await prisma.breed.createMany({ data: breedData });
+});
+
+beforeEach(async () => {
+  await prisma.message.deleteMany();
+  await prisma.match.deleteMany();
+  await prisma.interest.deleteMany();
+  await prisma.image.deleteMany();
+  await prisma.dog.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+/** Two matched dogs and a message the first one sent to the second. */
+const seedConversation = async () => {
+  const [{ dog: sender }, { dog: receiver }] = await Promise.all([
+    generateFakeUserWithDog(),
+    generateFakeUserWithDog(),
+  ]);
+
+  const match = await prisma.match.create({
+    data: { requesterId: sender.id, responderId: receiver.id },
+  });
+
+  const message = await prisma.message.create({
+    data: {
+      content: "woof",
+      senderId: sender.id,
+      receiverId: receiver.id,
+      matchId: match.id,
+    },
+  });
+
+  return { sender, receiver, match, message };
+};
+
+describe("MessageService.deleteMessage", () => {
+  it("soft-deletes a message its sender owns", async () => {
+    const { sender, message } = await seedConversation();
+
+    await MessageService.deleteMessage({
+      messageId: message.id,
+      senderId: sender.id,
+    });
+
+    const deleted = await prisma.message.findUnique({ where: { id: message.id } });
+
+    expect(deleted?.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it("refuses to delete a message owned by another dog", async () => {
+    const { receiver, message } = await seedConversation();
+
+    await expect(
+      MessageService.deleteMessage({
+        messageId: message.id,
+        senderId: receiver.id,
+      }),
+    ).rejects.toThrow("the sender is not the owner of the message");
+
+    const untouched = await prisma.message.findUnique({ where: { id: message.id } });
+
+    expect(untouched?.deletedAt).toBeNull();
+  });
+
+  it("throws for an unknown message id", async () => {
+    const { sender } = await seedConversation();
+
+    await expect(
+      MessageService.deleteMessage({
+        messageId: "does-not-exist",
+        senderId: sender.id,
+      }),
+    ).rejects.toThrow("Invalid messageId");
+  });
+
+  it("does not delete twice", async () => {
+    const { sender, message } = await seedConversation();
+
+    await MessageService.deleteMessage({ messageId: message.id, senderId: sender.id });
+
+    await expect(
+      MessageService.deleteMessage({ messageId: message.id, senderId: sender.id }),
+    ).rejects.toThrow("Invalid messageId");
+  });
+});

--- a/packages/api/src/services/MessageService.ts
+++ b/packages/api/src/services/MessageService.ts
@@ -100,7 +100,15 @@ class MessageService {
     return newMessage;
   }
 
-  static async deleteMessage(messageId: string, senderId: string) {
+  /**
+   * Soft-deletes a message the sender owns.
+   *
+   * `senderId` is a Dog id, not a User id — Message.senderId is a relation to
+   * Dog (see schema.prisma), and `sendMessage` stores the sender's dog id.
+   * Both ids are strings, so the arguments used to be trivially swappable at
+   * the call site; taking a named object makes that a compile error.
+   */
+  static async deleteMessage({ messageId, senderId }: { messageId: string; senderId: string }) {
     const message = await prisma.message.findUnique({
       where: { id: messageId, deletedAt: null },
     });


### PR DESCRIPTION
`message.delete` calls `MessageService.deleteMessage(dog.id, messageId)`, but the signature is `deleteMessage(messageId, senderId)`. Both parameters are strings so the swap type-checks, and deleting a message never works: the lookup runs against a dog id, finds nothing, and the route throws.

`deleteMessage` now takes `{ messageId, senderId }` so the two ids can't be swapped by position again, and the route passes them by name.

`senderId` is a Dog id. `Message.senderId` is a relation to `Dog` in schema.prisma and `sendMessage` writes the sender's dog id there, so the `dog.id` the route resolves from the session is the right value to compare against.

Added `packages/api/src/services/MessageService.test.ts`: the sender deletes their own message, a non-owner is rejected and the row is left untouched, an unknown message id throws, and a second delete on an already-deleted message throws.

## Testing

No workflow in this repo runs `pnpm test`, so I ran it locally. Jest in `packages/api` with `.env.test` loaded, against the dockerised test database: 20 passed (16 existing SuggestionService, 4 new). `pnpm typecheck` and `pnpm format` clean, `oxlint packages/api` reports 0 errors.
