### PR TITLE
fix(api): validate image URLs against the configured storage origins

### DIFF
--- a/packages/api/src/queue/handlers/processImage.test.ts
+++ b/packages/api/src/queue/handlers/processImage.test.ts
@@ -1,0 +1,44 @@
+jest.mock("../../services/ImageProcessingService", () => ({
+  ImageProcessingService: {
+    checkForProfanity: jest.fn().mockResolvedValue("APPROVED"),
+    createBlurhash: jest.fn().mockResolvedValue("blur"),
+  },
+}));
+
+jest.mock("../../services/ImageService", () => ({
+  ImageService: { updateImage: jest.fn().mockResolvedValue({}) },
+}));
+
+jest.mock("../../errors/errors", () => ({ sendError: jest.fn() }));
+
+import { ImageService } from "../../services/ImageService";
+import { config } from "../../shared/config";
+import { handleProcessImage } from "./processImage";
+
+const BUCKET_URL = `https://${config.AWS_S3_BUCKET_NAME}.s3.${config.AWS_REGION}.amazonaws.com`;
+
+const fetchMock = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchMock.mockResolvedValue({ arrayBuffer: async () => new ArrayBuffer(8) });
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+describe("handleProcessImage", () => {
+  it("downloads an image served from the configured bucket", async () => {
+    await handleProcessImage({ id: "image-id", url: `${BUCKET_URL}/dogs/1712345678` });
+
+    expect(fetchMock).toHaveBeenCalledWith(`${BUCKET_URL}/dogs/1712345678`);
+    expect(ImageService.updateImage).toHaveBeenCalled();
+  });
+
+  it("does not fetch a URL on a host we do not serve images from", async () => {
+    await expect(
+      handleProcessImage({ id: "image-id", url: "http://169.254.169.254/latest/meta-data/" }),
+    ).rejects.toThrow("configured storage origin");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ImageService.updateImage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/queue/handlers/processImage.ts
+++ b/packages/api/src/queue/handlers/processImage.ts
@@ -3,9 +3,16 @@ import { IMAGE_STATUS } from "@pegada/shared/schemas/dogSchema";
 import { sendError } from "../../errors/errors";
 import { ImageProcessingService } from "../../services/ImageProcessingService";
 import { ImageService } from "../../services/ImageService";
+import { assertAllowedImageUrl } from "../../shared/imageUrl";
 import { IProcessImageJobData } from "../topics";
 
 export const handleProcessImage = async (image: IProcessImageJobData) => {
+  // The URL is validated on the way in and rebuilt from our own storage base
+  // before it is persisted, so this should never fire. It is here because the
+  // job is the one place the server makes an outbound request with a URL that
+  // started life in a request body.
+  assertAllowedImageUrl(image.url);
+
   const arrayBuffer = await fetch(image.url).then((res) => res.arrayBuffer());
 
   const status = await ImageProcessingService.checkForProfanity({

--- a/packages/api/src/routes/dog.ts
+++ b/packages/api/src/routes/dog.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 
-import { dogServerSchema } from "@pegada/shared/schemas/dogSchema";
-
 import { DogService } from "../services/DogService";
+import { dogInputSchema } from "../shared/dogInputSchema";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 const getDogSchema = z.object({
@@ -15,7 +14,7 @@ export const dogRouter = createTRPCRouter({
     return dog;
   }),
 
-  create: protectedProcedure.input(dogServerSchema).mutation(async ({ ctx, input }) => {
+  create: protectedProcedure.input(dogInputSchema).mutation(async ({ ctx, input }) => {
     const dog = await DogService.createDog({
       ...input,
       userId: ctx.session.user.id,

--- a/packages/api/src/routes/myDog.ts
+++ b/packages/api/src/routes/myDog.ts
@@ -1,6 +1,5 @@
-import { dogServerSchema } from "@pegada/shared/schemas/dogSchema";
-
 import { DogService } from "../services/DogService";
+import { dogInputSchema } from "../shared/dogInputSchema";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const myDogRouter = createTRPCRouter({
@@ -14,7 +13,7 @@ export const myDogRouter = createTRPCRouter({
     return { ok: true };
   }),
 
-  update: protectedProcedure.input(dogServerSchema.partial()).mutation(async ({ ctx, input }) => {
+  update: protectedProcedure.input(dogInputSchema.partial()).mutation(async ({ ctx, input }) => {
     const dog = await DogService.getDogByUserId(ctx.session.user.id);
     const updatedDog = await DogService.updateDog(dog.id, input);
     return updatedDog;

--- a/packages/api/src/shared/dogInputSchema.test.ts
+++ b/packages/api/src/shared/dogInputSchema.test.ts
@@ -61,6 +61,19 @@ describe("dogInputSchema images", () => {
     expect(result.error?.issues.map((issue) => issue.path)).toEqual([["images", 1, "url"]]);
   });
 
+  it("keeps the check through .partial(), which is what myDog.update accepts", () => {
+    const partial = dogInputSchema.partial();
+
+    expect(
+      partial.safeParse({ images: [{ url: `${BUCKET_URL}/dogs/1`, position: 0 }] }).success,
+    ).toBe(true);
+    expect(
+      partial.safeParse({ images: [{ url: "https://example.com/payload.png", position: 0 }] })
+        .success,
+    ).toBe(false);
+    expect(partial.safeParse({ name: "Rex" }).success).toBe(true);
+  });
+
   it("still applies the schema it extends", () => {
     const result = dogInputSchema.safeParse({
       ...dogWithImage(`${BUCKET_URL}/dogs/1`),

--- a/packages/api/src/shared/dogInputSchema.test.ts
+++ b/packages/api/src/shared/dogInputSchema.test.ts
@@ -1,0 +1,72 @@
+import { config } from "./config";
+import { dogInputSchema } from "./dogInputSchema";
+
+/**
+ * .env.test leaves R2 and AWS_S3_ENDPOINT unset, so the only allowed origin
+ * is the legacy virtual-hosted bucket.
+ */
+const BUCKET_URL = `https://${config.AWS_S3_BUCKET_NAME}.s3.${config.AWS_REGION}.amazonaws.com`;
+
+const dogWithImage = (url: string) => ({
+  name: "Rex",
+  bio: "",
+  gender: "MALE" as const,
+  images: [{ url, position: 0 }],
+});
+
+const parse = (url: string) => dogInputSchema.safeParse(dogWithImage(url));
+
+describe("dogInputSchema images", () => {
+  it("accepts a URL on the configured bucket", () => {
+    expect(parse(`${BUCKET_URL}/dogs-temporary/1712345678`).success).toBe(true);
+  });
+
+  it("rejects an arbitrary external host", () => {
+    const result = parse("https://example.com/payload.png");
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(["images", 0, "url"]);
+  });
+
+  it("rejects loopback and private addresses", () => {
+    expect(parse("http://localhost:9002/pegada-dev/dogs/1").success).toBe(false);
+    expect(parse("http://127.0.0.1:9002/pegada-dev/dogs/1").success).toBe(false);
+    expect(parse("http://10.0.0.5/dogs/1").success).toBe(false);
+    expect(parse("http://169.254.169.254/latest/meta-data/").success).toBe(false);
+  });
+
+  it("rejects a host that only contains the bucket host as a substring", () => {
+    expect(parse(`${BUCKET_URL}.example.com/dogs/1`).success).toBe(false);
+    expect(parse(`https://example.com${BUCKET_URL.replace("https://", "/")}/dogs/1`).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects a different port on the bucket host", () => {
+    expect(parse(`${BUCKET_URL.replace(".com", ".com:8080")}/dogs/1`).success).toBe(false);
+  });
+
+  it("rejects every bad URL in a list that also contains a good one", () => {
+    const result = dogInputSchema.safeParse({
+      name: "Rex",
+      bio: "",
+      gender: "MALE",
+      images: [
+        { url: `${BUCKET_URL}/dogs/1`, position: 0 },
+        { url: "https://example.com/payload.png", position: 1 },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path)).toEqual([["images", 1, "url"]]);
+  });
+
+  it("still applies the schema it extends", () => {
+    const result = dogInputSchema.safeParse({
+      ...dogWithImage(`${BUCKET_URL}/dogs/1`),
+      name: "R",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/api/src/shared/dogInputSchema.ts
+++ b/packages/api/src/shared/dogInputSchema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { dogServerSchema } from "@pegada/shared/schemas/dogSchema";
+
+import { allowedImageOrigins, isAllowedImageUrl } from "./imageUrl";
+
+/**
+ * `dogServerSchema` with every image URL pinned to a configured storage
+ * origin. This is the schema the tRPC dog routes accept, and the only one
+ * that should ever be wired to a mutation.
+ *
+ * The host check can't live in @pegada/shared: that package is bundled into
+ * the mobile app and has no access to server config, while the allowlist is
+ * built from the API's own storage settings.
+ */
+export const dogInputSchema = dogServerSchema.extend({
+  images: dogServerSchema.shape.images.superRefine((images, ctx) => {
+    const origins = allowedImageOrigins();
+
+    images.forEach((image, index) => {
+      if (!image.url || isAllowedImageUrl(image.url, origins)) return;
+
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [index, "url"],
+        message: "Image URL does not point at a configured storage origin",
+      });
+    });
+  }),
+});

--- a/packages/api/src/shared/fileUpload.test.ts
+++ b/packages/api/src/shared/fileUpload.test.ts
@@ -1,0 +1,104 @@
+jest.mock("@aws-sdk/client-s3", () => {
+  const send = jest.fn().mockResolvedValue({});
+
+  return {
+    send,
+    S3Client: jest.fn(() => ({ send })),
+    CopyObjectCommand: jest.fn((input: unknown) => ({ type: "copy", input })),
+    DeleteObjectCommand: jest.fn((input: unknown) => ({ type: "delete", input })),
+  };
+});
+
+import { CopyObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+
+import { config } from "./config";
+import { deleteImageFromS3, moveImageToFolder } from "./fileUpload";
+
+const { send } = jest.requireMock("@aws-sdk/client-s3") as { send: jest.Mock };
+
+/**
+ * .env.test leaves R2 and AWS_S3_ENDPOINT unset, so the only allowed origin
+ * is the legacy virtual-hosted bucket.
+ */
+const BUCKET_URL = `https://${config.AWS_S3_BUCKET_NAME}.s3.${config.AWS_REGION}.amazonaws.com`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  send.mockResolvedValue({});
+});
+
+describe("moveImageToFolder", () => {
+  it("copies the object and deletes the original", async () => {
+    await moveImageToFolder(`${BUCKET_URL}/dogs-temporary/1712345678`, "dogs");
+
+    expect(CopyObjectCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: config.AWS_S3_BUCKET_NAME,
+        CopySource: `${config.AWS_S3_BUCKET_NAME}/${encodeURIComponent("dogs-temporary/1712345678")}`,
+        Key: "dogs/1712345678",
+      }),
+    );
+
+    expect(DeleteObjectCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Bucket: config.AWS_S3_BUCKET_NAME,
+        Key: "dogs-temporary/1712345678",
+      }),
+    );
+  });
+
+  it("returns a URL rebuilt from the storage base", async () => {
+    const url = await moveImageToFolder(`${BUCKET_URL}/dogs-temporary/1712345678`, "dogs");
+
+    expect(url).toBe(`${BUCKET_URL}/dogs/1712345678`);
+  });
+
+  it("refuses a URL on a host we do not serve images from", async () => {
+    await expect(
+      moveImageToFolder("https://example.com/dogs-temporary/1712345678", "dogs"),
+    ).rejects.toThrow("configured storage origin");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a host that only contains the bucket host as a substring", async () => {
+    await expect(
+      moveImageToFolder(
+        `https://${config.AWS_S3_BUCKET_NAME}.s3.${config.AWS_REGION}.amazonaws.com.example.com/dogs-temporary/1`,
+        "dogs",
+      ),
+    ).rejects.toThrow("configured storage origin");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses loopback and link-local addresses", async () => {
+    await expect(moveImageToFolder("http://127.0.0.1:9002/x/y", "dogs")).rejects.toThrow(
+      "configured storage origin",
+    );
+
+    await expect(
+      moveImageToFolder("http://169.254.169.254/latest/meta-data/", "dogs"),
+    ).rejects.toThrow("configured storage origin");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteImageFromS3", () => {
+  it("deletes the full key, folder prefix included", async () => {
+    await deleteImageFromS3(`${BUCKET_URL}/dogs/1712345678`);
+
+    expect(DeleteObjectCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ Key: "dogs/1712345678" }),
+    );
+  });
+
+  it("refuses a URL on a host we do not serve images from", async () => {
+    await expect(deleteImageFromS3("https://example.com/dogs/1712345678")).rejects.toThrow(
+      "configured storage origin",
+    );
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/shared/fileUpload.ts
+++ b/packages/api/src/shared/fileUpload.ts
@@ -1,6 +1,7 @@
 import { CopyObjectCommand, DeleteObjectCommand, S3Client } from "@aws-sdk/client-s3";
 
 import { config } from "../shared/config";
+import { assertAllowedImageUrl } from "./imageUrl";
 
 /**
  * Legacy S3 client (shipped app binaries upload here via `image.signedUrl`).
@@ -46,9 +47,24 @@ export const r2Client = r2UploadsEnabled
     })
   : undefined;
 
+const encodeKey = (key: string) => key.split("/").map(encodeURIComponent).join("/");
+
 /** Build the public URL an R2 object key is served from. */
-export const getPublicUrl = (key: string) =>
-  `${config.PUBLIC_IMAGES_BASE_URL}/${key.split("/").map(encodeURIComponent).join("/")}`;
+export const getPublicUrl = (key: string) => `${config.PUBLIC_IMAGES_BASE_URL}/${encodeKey(key)}`;
+
+/**
+ * Build the URL a legacy S3/MinIO object key is served from. Mirrors what
+ * `getSignedUpload` hands the client on that path: the endpoint override is
+ * path-style (`<endpoint>/<bucket>/<key>`, MinIO in dev/e2e), plain AWS is
+ * virtual-hosted (`<bucket>.s3.<region>.amazonaws.com/<key>`).
+ */
+export const getLegacyUrl = (key: string) => {
+  const base = config.AWS_S3_ENDPOINT
+    ? `${config.AWS_S3_ENDPOINT.replace(/\/+$/, "")}/${config.AWS_S3_BUCKET_NAME}`
+    : `https://${config.AWS_S3_BUCKET_NAME}.s3.${config.AWS_REGION}.amazonaws.com`;
+
+  return `${base}/${encodeKey(key)}`;
+};
 
 const hostOf = (url: string) => new URL(url).host;
 
@@ -66,12 +82,41 @@ const isR2Url = (url: string) => {
   );
 };
 
-/** Pick the storage (client + bucket) an image URL lives in, by host. */
-const storageForUrl = (url: string) =>
-  isR2Url(url)
-    ? // Non-null: isR2Url only returns true when r2UploadsEnabled.
-      { client: r2Client as S3Client, bucket: config.R2_BUCKET_NAME, isR2: true }
-    : { client, bucket: config.AWS_S3_BUCKET_NAME, isR2: false };
+type Storage = {
+  client: S3Client;
+  bucket: string;
+  isR2: boolean;
+  /** Canonical public URL for a key in this storage. */
+  urlForKey: (key: string) => string;
+};
+
+/**
+ * Pick the storage (client + bucket) an image URL lives in, by host.
+ *
+ * Fails closed: the legacy S3 client used to be the fallback for every host
+ * that wasn't R2, which meant a URL pointing anywhere at all still got
+ * operated on. Only the configured storage origins get past this now.
+ */
+const storageForUrl = (url: string): Storage => {
+  assertAllowedImageUrl(url);
+
+  if (isR2Url(url)) {
+    // Non-null: isR2Url only returns true when r2UploadsEnabled.
+    return {
+      client: r2Client as S3Client,
+      bucket: config.R2_BUCKET_NAME,
+      isR2: true,
+      urlForKey: getPublicUrl,
+    };
+  }
+
+  return {
+    client,
+    bucket: config.AWS_S3_BUCKET_NAME,
+    isR2: false,
+    urlForKey: getLegacyUrl,
+  };
+};
 
 /**
  * Extract the object key from an object URL, host-agnostically.
@@ -103,7 +148,7 @@ export const moveImageToFolder = async (url: string, folder: string) => {
   // Routed by URL host: images uploaded through the legacy path live on
   // S3/MinIO, images from the new path live on R2. Copies never cross
   // providers — temp and permanent folders are in the same bucket.
-  const { client: storageClient, bucket, isR2 } = storageForUrl(url);
+  const { client: storageClient, bucket, isR2, urlForKey } = storageForUrl(url);
 
   const oldKey = keyFromUrl(url, bucket);
   const fileName = oldKey.split("/").slice(-1)[0];
@@ -123,5 +168,8 @@ export const moveImageToFolder = async (url: string, folder: string) => {
 
   await deleteImageFromS3(url);
 
-  return url.replace(oldKey, newKey);
+  // Rebuilt from the storage's own base URL rather than patched out of the
+  // caller's string, so nothing about the incoming URL other than the file
+  // name reaches the database.
+  return urlForKey(newKey);
 };

--- a/packages/api/src/shared/imageUrl.test.ts
+++ b/packages/api/src/shared/imageUrl.test.ts
@@ -1,0 +1,103 @@
+import { buildAllowedImageOrigins, isAllowedImageUrl } from "./imageUrl";
+
+const R2_CONFIG = {
+  publicImagesBaseUrl: "https://images.pegada.app",
+  r2Endpoint: "https://account-id.r2.cloudflarestorage.com",
+  awsBucketName: "pegada-dev",
+  awsRegion: "sa-east-1",
+};
+
+const MINIO_CONFIG = {
+  awsS3Endpoint: "http://localhost:9002",
+  awsBucketName: "pegada-dev",
+  awsRegion: "sa-east-1",
+};
+
+const R2_ORIGINS = buildAllowedImageOrigins(R2_CONFIG);
+
+describe("buildAllowedImageOrigins", () => {
+  it("collects the R2, legacy and endpoint origins", () => {
+    expect([...R2_ORIGINS].sort()).toEqual([
+      "https://account-id.r2.cloudflarestorage.com",
+      "https://images.pegada.app",
+      "https://pegada-dev.s3.amazonaws.com",
+      "https://pegada-dev.s3.sa-east-1.amazonaws.com",
+    ]);
+  });
+
+  it("drops the R2 origins when R2 is not configured", () => {
+    expect([...buildAllowedImageOrigins(MINIO_CONFIG)].sort()).toEqual([
+      "http://localhost:9002",
+      "https://pegada-dev.s3.amazonaws.com",
+      "https://pegada-dev.s3.sa-east-1.amazonaws.com",
+    ]);
+  });
+
+  it("ignores config values that are not http(s) URLs", () => {
+    const origins = buildAllowedImageOrigins({
+      ...R2_CONFIG,
+      publicImagesBaseUrl: "images.pegada.app",
+      r2Endpoint: "file:///etc",
+    });
+
+    expect(origins.has("https://images.pegada.app")).toBe(false);
+    expect(origins.size).toBe(2);
+  });
+});
+
+describe("isAllowedImageUrl", () => {
+  const allows = (url: string) => isAllowedImageUrl(url, R2_ORIGINS);
+
+  it("allows the R2 custom domain", () => {
+    expect(allows("https://images.pegada.app/dogs/1712345678")).toBe(true);
+  });
+
+  it("allows the R2 API endpoint", () => {
+    expect(allows("https://account-id.r2.cloudflarestorage.com/pegava/dogs/1712345678")).toBe(true);
+  });
+
+  it("allows the legacy virtual-hosted S3 bucket", () => {
+    expect(allows("https://pegada-dev.s3.sa-east-1.amazonaws.com/dogs/1712345678")).toBe(true);
+  });
+
+  it("allows the MinIO endpoint only when it is configured", () => {
+    const minioUrl = "http://localhost:9002/pegada-dev/dogs/1712345678";
+
+    expect(allows(minioUrl)).toBe(false);
+    expect(isAllowedImageUrl(minioUrl, buildAllowedImageOrigins(MINIO_CONFIG))).toBe(true);
+  });
+
+  it("rejects an arbitrary external host", () => {
+    expect(allows("https://example.com/payload.png")).toBe(false);
+  });
+
+  it("rejects loopback and private addresses", () => {
+    expect(allows("http://localhost/latest/meta-data/")).toBe(false);
+    expect(allows("http://127.0.0.1:8080/")).toBe(false);
+    expect(allows("http://[::1]/")).toBe(false);
+    expect(allows("http://10.0.0.5/")).toBe(false);
+    expect(allows("http://192.168.1.1/")).toBe(false);
+    expect(allows("http://169.254.169.254/latest/meta-data/")).toBe(false);
+  });
+
+  it("rejects a host that only contains an allowed host as a substring", () => {
+    expect(allows("https://images.pegada.app.example.com/x")).toBe(false);
+    expect(allows("https://evil-images.pegada.app/x")).toBe(false);
+    expect(allows("https://example.com/images.pegada.app/x")).toBe(false);
+    expect(allows("https://images.pegada.app.example.com/images.pegada.app")).toBe(false);
+  });
+
+  it("rejects credentials, ports and schemes that differ from the allowed origin", () => {
+    expect(allows("https://images.pegada.app:8080/x")).toBe(false);
+    expect(allows("http://images.pegada.app/x")).toBe(false);
+    expect(allows("https://images.pegada.app@example.com/x")).toBe(false);
+  });
+
+  it("rejects non-http schemes and unparseable values", () => {
+    expect(allows("file:///etc/passwd")).toBe(false);
+    expect(allows("gopher://images.pegada.app/x")).toBe(false);
+    expect(allows("data:image/png;base64,AAAA")).toBe(false);
+    expect(allows("")).toBe(false);
+    expect(allows("not a url")).toBe(false);
+  });
+});

--- a/packages/api/src/shared/imageUrl.ts
+++ b/packages/api/src/shared/imageUrl.ts
@@ -1,0 +1,82 @@
+import { config } from "./config";
+
+/**
+ * The storage origins image URLs are allowed to point at.
+ *
+ * Image URLs arrive from the client (dog create/update) and the server then
+ * copies, deletes and downloads them, so anything not pinned to our own
+ * storage is a request the server makes on a caller's behalf. Everything is
+ * matched on the parsed `URL.origin`: scheme, host and port together, exact
+ * equality. Substring or prefix matching would accept
+ * `https://images.pegada.app.example.com/x`, and a host-only match would
+ * accept an arbitrary port on our own domain.
+ */
+export type ImageStorageConfig = {
+  /** R2 bucket custom domain, e.g. https://images.pegada.app */
+  publicImagesBaseUrl?: string;
+  /** R2 S3 API endpoint, e.g. https://<account>.r2.cloudflarestorage.com */
+  r2Endpoint?: string;
+  /** Legacy S3 endpoint override (MinIO in dev/e2e). Unset in production. */
+  awsS3Endpoint?: string;
+  awsBucketName: string;
+  awsRegion: string;
+};
+
+const originOf = (url: string | undefined) => {
+  if (!url) return undefined;
+
+  try {
+    const { origin, protocol } = new URL(url);
+    if (protocol !== "http:" && protocol !== "https:") return undefined;
+    return origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * The legacy S3 client presigns virtual-hosted-style URLs, so objects are
+ * served from `<bucket>.s3.<region>.amazonaws.com`. The regionless form is
+ * accepted too because buckets created before the regional endpoints existed
+ * still answer there. Both are bucket-scoped, so neither widens the allowlist
+ * past our own bucket.
+ */
+const awsOrigins = (bucket: string, region: string) => [
+  `https://${bucket}.s3.${region}.amazonaws.com`.toLowerCase(),
+  `https://${bucket}.s3.amazonaws.com`.toLowerCase(),
+];
+
+export const buildAllowedImageOrigins = (storage: ImageStorageConfig) => {
+  const origins = [
+    originOf(storage.publicImagesBaseUrl),
+    originOf(storage.r2Endpoint),
+    originOf(storage.awsS3Endpoint),
+    ...awsOrigins(storage.awsBucketName, storage.awsRegion),
+  ];
+
+  return new Set(origins.filter((origin): origin is string => Boolean(origin)));
+};
+
+/**
+ * Built from the running config. R2 values are optional (unset in dev/e2e)
+ * and simply drop out of the set instead of widening it.
+ */
+export const allowedImageOrigins = () =>
+  buildAllowedImageOrigins({
+    publicImagesBaseUrl: config.PUBLIC_IMAGES_BASE_URL,
+    r2Endpoint: config.R2_ENDPOINT,
+    awsS3Endpoint: config.AWS_S3_ENDPOINT,
+    awsBucketName: config.AWS_S3_BUCKET_NAME,
+    awsRegion: config.AWS_REGION,
+  });
+
+export const isAllowedImageUrl = (url: string, origins = allowedImageOrigins()) => {
+  const origin = originOf(url);
+  return Boolean(origin && origins.has(origin));
+};
+
+export const assertAllowedImageUrl = (url: string, origins = allowedImageOrigins()) => {
+  if (isAllowedImageUrl(url, origins)) return;
+
+  throw new Error("Image URL does not point at a configured storage origin");
+};

--- a/packages/shared/schemas/dogSchema.ts
+++ b/packages/shared/schemas/dogSchema.ts
@@ -144,6 +144,13 @@ export const IMAGE_STATUS = {
   PENDING: "PENDING",
 } as const;
 
+/**
+ * Shape only. Image URLs are unconstrained here because this package is
+ * bundled into the mobile app and has no access to server config; the API
+ * layers the storage-origin allowlist on top in
+ * packages/api/src/shared/dogInputSchema.ts, which is what the tRPC routes
+ * accept. Don't wire this schema straight to a mutation.
+ */
 export const dogServerSchema = z.object({
   ...dogSharedSchema,
   images: z


### PR DESCRIPTION
Image URLs arrive from the client on `dog.create` and `myDog.update`, and the server copies, deletes and downloads them afterwards. Nothing checked where they pointed.

## Changes

- New `packages/api/src/shared/imageUrl.ts` builds the set of allowed storage origins from config (`PUBLIC_IMAGES_BASE_URL`, `R2_ENDPOINT`, `AWS_S3_ENDPOINT` and the legacy bucket's virtual-hosted host) and requires an exact match on the parsed `URL.origin` (scheme, host and port together). When R2 is unconfigured its two origins are absent from the set.
- `dogInputSchema` wraps `dogServerSchema` with that check and is what the two dog routes accept now. The check can't live in `@pegada/shared`: that package ships in the mobile bundle and has no access to server config.
- `storageForUrl` fails closed. The legacy S3 client used to be the fallback for every host that wasn't R2.
- `moveImageToFolder` builds the destination URL from the storage base plus the new key. The old `url.replace(oldKey, newKey)` reused the caller's string, host and all.
- `handleProcessImage` checks the URL before fetching it.

## Testing

No workflow in this repo runs `pnpm test`, so I ran it locally. Jest in `packages/api` with `.env.test` loaded, against the dockerised test database: 45 passed (16 existing SuggestionService, 29 new across `imageUrl`, `fileUpload`, `dogInputSchema` and `processImage`). The new cases cover an allowed origin passing, an arbitrary external host, loopback and private addresses, a host that contains an allowed host as a substring, a different port on an allowed host, and non-http schemes. I also stubbed the check out to confirm those tests fail without it.

`pnpm typecheck` and `pnpm format` clean, `oxlint packages/api packages/shared` reports 0 errors.

## Rollout

`signedUrl` and `signedUpload` are the only things that have ever produced an image URL, and both put them on one of these origins. If any row predates the current bucket or region, `myDog.update` will start rejecting it, because the client sends existing image URLs back on update.
