### PR TITLE
test(api): run the api suite on a single worker

### DIFF
--- a/packages/api/jest.config.ts
+++ b/packages/api/jest.config.ts
@@ -2,4 +2,10 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   testPathIgnorePatterns: ["<rootDir>/dist/"],
+  // Every suite that touches the database truncates the tables it uses in
+  // beforeEach, against the one database from docker-compose.test.yml. In
+  // parallel workers those wipes land in the middle of another suite's test
+  // and it fails on rows that vanished. Drop this only alongside per-worker
+  // database isolation.
+  maxWorkers: 1,
 };


### PR DESCRIPTION
Sets `maxWorkers: 1` in `packages/api/jest.config.ts`.

`packages/api` has two database-backed suites now, and they truncate the same tables in `beforeEach` against the single database from `docker-compose.test.yml`. In parallel workers one suite's wipe lands in the middle of the other's test, and whichever loses the race fails on rows that vanished. It alternated between `SuggestionService` and `MessageService` across runs. The setting holds until the suites get per-worker database isolation.

## Testing

Locally with `.env.test` against the dockerised test database, on `main`: 3 of 5 runs failed, alternating which suite lost. With `maxWorkers: 1`, 3 of 3 runs passed at 49 tests. `pnpm typecheck` and `pnpm format` clean.
