### PR TITLE
fix(api): scope the image move to the temporary upload folder

### DIFF
--- a/packages/api/src/services/ImageService.ts
+++ b/packages/api/src/services/ImageService.ts
@@ -7,7 +7,7 @@ import { DogServerSchema } from "@pegada/shared/schemas/dogSchema";
 
 import { config } from "../shared/config";
 import * as FileUpload from "../shared/fileUpload";
-import { getPublicUrl, moveImageToFolder } from "../shared/fileUpload";
+import { TEMPORARY_UPLOAD_PREFIX, getPublicUrl, moveImageToFolder } from "../shared/fileUpload";
 
 const PERMANENT_STORAGE_FOLDER = "dogs";
 
@@ -36,7 +36,7 @@ export class ImageService {
    * MIN_APP_VERSION is past the release that switched to `signedUpload`.
    */
   static async getSignedUrl() {
-    const key = "dogs-temporary/" + Date.now().toString();
+    const key = `${TEMPORARY_UPLOAD_PREFIX}/${Date.now().toString()}`;
 
     const command = new PutObjectCommand({
       Bucket: config.AWS_S3_BUCKET_NAME,
@@ -58,7 +58,7 @@ export class ImageService {
    * just builds its own descriptor here.
    */
   static async getSignedUpload(): Promise<SignedUpload> {
-    const key = "dogs-temporary/" + Date.now().toString();
+    const key = `${TEMPORARY_UPLOAD_PREFIX}/${Date.now().toString()}`;
 
     if (FileUpload.r2UploadsEnabled) {
       const command = new PutObjectCommand({

--- a/packages/api/src/shared/fileUpload.test.ts
+++ b/packages/api/src/shared/fileUpload.test.ts
@@ -83,6 +83,54 @@ describe("moveImageToFolder", () => {
 
     expect(send).not.toHaveBeenCalled();
   });
+
+  /**
+   * The URL comes off the dog payload, so the caller picks the key. Only a
+   * pending upload is a valid thing to move.
+   */
+  it("refuses a key already under the permanent folder", async () => {
+    await expect(moveImageToFolder(`${BUCKET_URL}/dogs/1712345678`, "dogs")).rejects.toThrow(
+      "temporary upload",
+    );
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a key under any other prefix", async () => {
+    await expect(moveImageToFolder(`${BUCKET_URL}/backups/1712345678`, "dogs")).rejects.toThrow(
+      "temporary upload",
+    );
+
+    await expect(moveImageToFolder(`${BUCKET_URL}/1712345678`, "dogs")).rejects.toThrow(
+      "temporary upload",
+    );
+
+    await expect(
+      moveImageToFolder(`${BUCKET_URL}/dogs-temporary-other/1712345678`, "dogs"),
+    ).rejects.toThrow("temporary upload");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("refuses a key nested deeper than one segment under the temporary folder", async () => {
+    await expect(
+      moveImageToFolder(`${BUCKET_URL}/dogs-temporary/nested/1712345678`, "dogs"),
+    ).rejects.toThrow("temporary upload");
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("does not delete the original when the copy fails", async () => {
+    send.mockRejectedValueOnce(new Error("copy blew up"));
+
+    await expect(
+      moveImageToFolder(`${BUCKET_URL}/dogs-temporary/1712345678`, "dogs"),
+    ).rejects.toThrow("copy blew up");
+
+    expect(CopyObjectCommand).toHaveBeenCalled();
+    expect(DeleteObjectCommand).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("deleteImageFromS3", () => {

--- a/packages/api/src/shared/fileUpload.ts
+++ b/packages/api/src/shared/fileUpload.ts
@@ -130,6 +130,28 @@ const keyFromUrl = (url: string, bucket: string) => {
   return decodeURIComponent(withoutBucket.join("/"));
 };
 
+/**
+ * Where every fresh upload lands. Both upload routes (`image.signedUpload` and
+ * the legacy `image.signedUrl`) presign exactly one key shape,
+ * `dogs-temporary/<timestamp>`, so a freshly uploaded object is always here
+ * and never anywhere else.
+ */
+export const TEMPORARY_UPLOAD_PREFIX = "dogs-temporary";
+
+/**
+ * The move acts on a key the caller names: the URL comes straight off the dog
+ * create/update payload. An allowed origin only tells us the key is somewhere
+ * in our storage, and the move is meant for one thing, a pending upload. So it
+ * accepts a key directly under the temporary prefix, one segment, nothing else.
+ */
+const assertTemporaryUploadKey = (key: string) => {
+  const [prefix, name, ...rest] = key.split("/");
+
+  if (prefix !== TEMPORARY_UPLOAD_PREFIX || !name || rest.length > 0) {
+    throw new Error("Image URL does not point at a temporary upload");
+  }
+};
+
 export const deleteImageFromS3 = async (url: string) => {
   const { client: storageClient, bucket } = storageForUrl(url);
 
@@ -151,6 +173,10 @@ export const moveImageToFolder = async (url: string, folder: string) => {
   const { client: storageClient, bucket, isR2, urlForKey } = storageForUrl(url);
 
   const oldKey = keyFromUrl(url, bucket);
+
+  // Ahead of the copy and the delete below, both of which act on this key.
+  assertTemporaryUploadKey(oldKey);
+
   const fileName = oldKey.split("/").slice(-1)[0];
   const newKey = `${folder}/${fileName}`;
 
@@ -164,6 +190,9 @@ export const moveImageToFolder = async (url: string, folder: string) => {
     ...(isR2 ? {} : { ACL: "public-read" as const }),
   });
 
+  // Sequential on purpose: a failed copy rejects here and the original stays
+  // put. Losing the object because only half the move ran is worse than the
+  // move failing.
   await storageClient.send(command);
 
   await deleteImageFromS3(url);

--- a/packages/database/docker-compose.test.yml
+++ b/packages/database/docker-compose.test.yml
@@ -6,6 +6,10 @@ services:
   postgres:
     container_name: pegada-postgres-test
     image: postgis/postgis
+    # postgis/postgis publishes no arm64 manifest, so an Apple Silicon Mac
+    # cannot pull it at all without being told to take the amd64 image and
+    # run it emulated. No-op on amd64 hosts.
+    platform: linux/amd64
     shm_size: 128mb
     restart: always
     environment:

--- a/packages/database/docker-compose.yml
+++ b/packages/database/docker-compose.yml
@@ -6,6 +6,8 @@ services:
   postgres:
     container_name: pegada-postgres
     image: postgis/postgis
+    # Same as the test compose: no arm64 manifest for postgis/postgis.
+    platform: linux/amd64
     shm_size: 128mb
     restart: always
     environment:


### PR DESCRIPTION
`moveImageToFolder` copies whatever key the caller's image URL names into the permanent folder, then deletes the original. #94 pinned those URLs to our own storage origins. The key inside that storage is still unscoped: any object in the bucket is a valid target. The only key this operation ever needs to reach is a pending upload.

Both upload routes, `image.signedUpload` and the legacy `image.signedUrl`, presign exactly one key shape: `dogs-temporary/<timestamp>`. The move now takes a key directly under `dogs-temporary/`, one segment, and rejects anything else before it issues a copy or a delete. `TEMPORARY_UPLOAD_PREFIX` lives next to the check, and `ImageService` builds both presigned keys from it.

`deleteImageFromS3` has one other caller, `DogService.updateDog`. There the URLs come out of the dog's own image rows, already scoped by ownership. It keeps deleting the full key it's given.

The copy is awaited before the delete already. A copy that throws leaves the original alone. Added a test for it.

## Changes

- `assertTemporaryUploadKey` in `packages/api/src/shared/fileUpload.ts`, called from `moveImageToFolder` before the copy.
- `ImageService.getSignedUrl` and `getSignedUpload` key off the exported `TEMPORARY_UPLOAD_PREFIX`.
- Four new cases in `fileUpload.test.ts`: a key under the permanent folder, a key with the wrong folder or none at all, a key nested deeper than one segment, and no delete when the copy rejects.
- `platform: linux/amd64` on the postgres service in both database compose files. `postgis/postgis` has no arm64 manifest, so `db:up` and `test:db:up` fail outright on an M-series Mac without it. amd64 hosts resolve to the same image they do today.

## Testing

No workflow in this repo runs `pnpm test`, so I ran it locally. Jest in `packages/api` with `.env.test` loaded, against the dockerised test database: 53 passed across 6 suites. I also stubbed the check out to confirm the three rejection cases fail without it.

`pnpm typecheck` and `pnpm format` clean, `pnpm lint` reports 0 errors.

For the compose change I removed the local postgres container, ran `test:db:up` on an arm64 Mac and got a container created by compose, running x86_64 under emulation, accepting `psql` connections.

## Rollout

Behaviour is unchanged for a normal create or update: the client uploads to a presigned URL and sends back the `dogs-temporary/` URL it was given. A dog payload carrying a permanent image URL that isn't already on the dog will now be rejected instead of moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uj6xe9Bt2zFYmqU6UTTkQ
