### PR TITLE
fix(database): add the missing Image status and blurhash migration

### DIFF
--- a/packages/database/migrations/20260726033614_add_image_status_and_blurhash/migration.sql
+++ b/packages/database/migrations/20260726033614_add_image_status_and_blurhash/migration.sql
@@ -1,0 +1,22 @@
+-- Brings the migration history back in line with schema.prisma.
+--
+-- Image.status, Image.blurhash and the ImageStatus enum already exist in
+-- production; they were added to schema.prisma without a matching migration,
+-- so the folder has been behind ever since. Production is the source of truth
+-- here, this migration just writes down what is already there.
+--
+-- Everything below is idempotent on purpose. Against a fresh database it
+-- creates the enum and the two columns. Against a database that already has
+-- them (production) it does nothing and does not error, so it is safe whether
+-- it gets applied or resolved.
+
+-- CreateEnum
+-- Postgres has no CREATE TYPE IF NOT EXISTS, hence the guarded block.
+DO $$ BEGIN
+  CREATE TYPE "ImageStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+-- AlterTable
+ALTER TABLE "Image" ADD COLUMN IF NOT EXISTS "status" "ImageStatus" NOT NULL DEFAULT 'PENDING';
+ALTER TABLE "Image" ADD COLUMN IF NOT EXISTS "blurhash" TEXT;


### PR DESCRIPTION
Adds the migration that's been missing for `Image.status`, `Image.blurhash` and the `ImageStatus` enum.

`schema.prisma` has all three. The migrations folder never got them: the only migration on record, `20240310005920`, creates `Image` with `id, url, dogId, createdAt, updatedAt, position`. Production has them: `dogDto.ts` selects `blurhash` and `status` off `Image` on every dog read, and those reads work.

Anyone setting a local database up from scratch hits it right away, `The column status does not exist in the current database`, 19 times across the api suite.

The SQL is idempotent. `ADD COLUMN IF NOT EXISTS` for both columns, and the guarded `DO $$ ... EXCEPTION WHEN duplicate_object` block for the enum since Postgres has no `CREATE TYPE IF NOT EXISTS`. Against a database that already has all three it does nothing and exits clean.

`prisma migrate diff` also wanted 24 renames, 8 primary key constraints and 16 indexes (`Image_pkey` -> `idx_57672_PRIMARY`, `Image_dogId_idx` -> `image_dogid_idx`, and so on). Those are leftovers from the pre-Prisma import that prod already carries under the old names. Left them alone, they're cosmetic, and taking a DDL lock on a live primary key to make a diff quieter isn't a trade I'd take.

## Testing

Fresh database, dropped and recreated, `migrate deploy` from zero:

- both migrations apply
- `Image` comes out with `status "ImageStatus" NOT NULL DEFAULT 'PENDING'` and nullable `blurhash text`
- api suite goes from 19 failed / 34 passed to 53 passed, 0 failed

Production-shaped database, baseline applied and recorded, then the enum and both columns added by hand out of band, plus an `Image` row carrying `status = 'APPROVED'` and a blurhash:

- `migrate deploy` applies the new migration and exits clean
- the `APPROVED` row still reads `APPROVED`
- the enum still has exactly 3 labels

`prisma migrate diff --from-migrations ./migrations --to-schema-datamodel ./schema.prisma` reports zero structural drift now. What's left is the renames above plus a `CREATE EXTENSION IF NOT EXISTS "postgis"` line that the baseline already runs on line 2. Both predate this PR.

## Production

Merging this doesn't touch prod. No workflow runs `prisma migrate deploy`, it only appears in `db:setup` and `test:db:setup` in `packages/database/package.json`.

1. `prisma migrate resolve --applied 20260726033614_add_image_status_and_blurhash` records it without running any SQL.
2. `prisma migrate deploy` runs it and, given the SQL above, no-ops.

I'd use `resolve`. Same end state, no DDL lock on `Image`, and nothing executes against prod. `deploy` works too if you'd rather have the database confirm the three are there than take the dto as evidence.
