### PR TITLE
fix(mobile): sort a copy of the matches cache, triage lint warnings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -60,6 +60,10 @@
     ],
     "typescript/no-explicit-any": "warn",
     "typescript/no-require-imports": "off",
+    "import/no-unassigned-import": "off",
+    "import/no-named-as-default-member": "off",
+    "unicorn/no-array-sort": "off",
+    "unicorn/no-array-reverse": "off",
     "no-restricted-imports": [
       "error",
       {
@@ -88,6 +92,21 @@
       ],
       "rules": {
         "no-console": "off"
+      }
+    },
+    {
+      "files": ["apps/mobile/**"],
+      "rules": {
+        "react-perf/jsx-no-new-object-as-prop": "off",
+        "react-perf/jsx-no-new-array-as-prop": "off",
+        "react-perf/jsx-no-new-function-as-prop": "off",
+        "react-perf/jsx-no-jsx-as-prop": "off"
+      }
+    },
+    {
+      "files": ["packages/api/src/services/**"],
+      "rules": {
+        "typescript/no-extraneous-class": "off"
       }
     }
   ]

--- a/apps/mobile/src/views/(tabs)/Messages/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Messages/index.tsx
@@ -72,8 +72,10 @@ const Messages = () => {
 
     if (!filteredMatches.length) return [];
 
-    // Most recent messages come first
-    const sortedMatches = filteredMatches.sort((a, b) => {
+    // Most recent messages come first. Sort a copy: with no search term
+    // getFiltered hands back the query's own array, and sorting in place
+    // reorders the cached data under everything else reading it.
+    const sortedMatches = [...filteredMatches].sort((a, b) => {
       if (!a.lastMessage) return 1;
       if (!b.lastMessage) return -1;
 


### PR DESCRIPTION
`pnpm lint` reported 454 warnings and 0 errors. It now reports 66.

## The bug

`apps/mobile/src/views/(tabs)/Messages/index.tsx` sorted the matches list in place:

```js
const getFiltered = () => {
  if (!search) return matches;      // the query's own array
  return matches.filter(/* ... */);  // a new one
};

const filteredMatches = getFiltered();
const sortedMatches = filteredMatches.sort(/* ... */);
```

With no search term `getFiltered` returns `matches` itself, so `.sort()` reordered the cached query data that the `syncMatchesWidget(matches)` effect a few lines up also reads. It sorts a copy now.

## Config changes

The other 388 warnings come from rules that don't apply here, so I changed `.oxlintrc.json` rather than adding per-line disables.

`react-perf`, 345 warnings, all in `apps/mobile`. Turned its four rules off for `apps/mobile/**` in an override. `app.config.ts` sets `reactCompiler: true` and `babel-plugin-react-compiler@1.0.0` is installed, so inline objects, arrays and callbacks are already memoized there. The Next.js app doesn't run the compiler, so the rules still apply to it and its 2 warnings are in the 66.

`unicorn/no-array-sort` and `unicorn/no-array-reverse`, 9 warnings. Off repo-wide. Both want `toSorted()` / `toReversed()`, which are ES2023, and `tools/tsconfig/base.json` pins `lib: ["ES2022"]`, so tsc rejects the fix the rule asks for.

`import/no-named-as-default-member`, 15 warnings. Off repo-wide. CJS interop false positives on `Animated.createAnimatedComponent`, `NetInfo.addEventListener` and `i18n.use`.

`import/no-unassigned-import`, 9 warnings. Off repo-wide. Side-effect imports: polyfills, `import "expo-router/entry"`, ambient `.d.ts` files, global CSS.

`typescript/no-extraneous-class`, 10 warnings. Off for `packages/api/src/services/**` only, where the static service classes live. Still applies everywhere else.

## Remaining

66 warnings, mostly `no-shadow` (21) and `no-explicit-any` (16). Each needs a per-site call, so I left them.

Typecheck and format pass. On `pnpm test`, which no workflow runs: `@pegada/mobile` passes (1 suite, 2 tests), `@pegada/api` fails on this branch and on unmodified main alike. Turbo 2 defaults to strict env mode and `turbo.json` declares no `env` or `globalPassThroughEnv`, so `DIRECT_URL` never reaches the Prisma setup step even though `.env.test` defines it. Didn't touch that here.
