### PR TITLE
ci: run the test suite on branch pushes

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -86,3 +86,52 @@ jobs:
 
       - name: ${{ matrix.emoji }} ${{ matrix.label }}
         run: pnpm run ${{ matrix.task }}
+
+  # Kept out of the checkup matrix: only this job needs a database, and
+  # sharing the matrix would spin up Postgres for typecheck/lint/format too.
+  # No turbo cache step either — `test` is `cache: false` in turbo.json, so
+  # there would be nothing to restore.
+  test:
+    name: 🔬 Test
+    needs: dedupe
+    runs-on: ubuntu-latest
+    services:
+      # PostGIS, not plain Postgres: schema.prisma declares the postgis
+      # extension and the baseline migration creates it. Same image as
+      # packages/database/docker-compose.test.yml, and the credentials,
+      # port and database name have to match the DATABASE_URL committed in
+      # .env.test, which is what `pnpm test` feeds to Prisma.
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_USER: tony
+          POSTGRES_PASSWORD: hawk
+          POSTGRES_DB: pegava
+        ports:
+          - 3355:5432
+        options: >-
+          --health-cmd "pg_isready -U tony -d pegava"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v7
+
+      - name: 🏗 Setup PNPM
+        uses: pnpm/action-setup@v6.0.9
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20.x
+          cache: pnpm
+
+      - name: 📦 Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm test` is `dotenv -e .env.test -- turbo test`, and the api
+      # package's `pretest` runs `prisma migrate deploy` against the service
+      # container above before jest starts.
+      - name: 🔬 Test
+        run: pnpm test

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -26,7 +26,7 @@
     "db:setup": "pnpm db:up && pnpm migrate deploy && pnpm db:seed",
     "db:push": "npx prisma db push",
     "prisma": "npx prisma",
-    "test:db:up": "docker-compose -f docker-compose.test.yml up --build --detach",
+    "test:db:up": "if [ -n \"$CI\" ]; then echo 'CI supplies Postgres as a workflow service container, skipping docker-compose'; else docker-compose -f docker-compose.test.yml up --build --detach; fi",
     "test:db:setup": "pnpm test:db:up && pnpm migrate deploy",
     "migrate": "npx prisma migrate",
     "postinstall": "pnpm run build"

--- a/turbo.json
+++ b/turbo.json
@@ -2,8 +2,18 @@
   "$schema": "https://turborepo.org/schema.json",
   "globalDependencies": ["**/.env", ".env"],
   "tasks": {
+    // The suite runs against a live database, so a cached pass says nothing
+    // about the current state of it. The old `outputs` entry pointed at a
+    // jest cache directory jest never writes, which made turbo warn "no
+    // output files found" on every run.
+    // `passThroughEnv` is what makes `dotenv -e .env.test -- turbo test`
+    // work at all: under strict env mode turbo drops the vars dotenv set
+    // before the task sees them, so `pretest`'s `prisma migrate deploy`
+    // died on a missing DIRECT_URL. Scoped to `test` on purpose — putting
+    // it in `globalPassThroughEnv` would change build/typecheck cache keys.
     "test": {
-      "outputs": ["node_modules/.cache/.testcache"]
+      "cache": false,
+      "passThroughEnv": ["*"]
     },
     "typecheck": {
       "outputs": ["node_modules/.cache/tsbuildinfo.json"]


### PR DESCRIPTION
Adds a `🔬 Test` job to branch-check.yml, and fixes `pnpm test` so it can run there.

No workflow in this repo runs `pnpm test`, so the tests that came with #93, #94 and #96 (a delete that passed its ids in the wrong order, an origin check on image URLs, a scoped image move) guard nothing on a PR.

## turbo.json

The root script is `dotenv -e .env.test -- turbo test`. Turbo 2 drops env vars it wasn't told to pass through before the task starts, so `pretest`'s `prisma migrate deploy` came up without `DIRECT_URL` and failed with P1012. `passThroughEnv: ["*"]` on the `test` task lets dotenv's vars reach it. Scoped to that task instead of `globalPassThroughEnv` so build and typecheck cache keys stay where they are.

`cache: false` on the same task, because the suite reads and writes a live database and a cached pass says nothing about the current state of it. That also drops the old `outputs` entry, which named a jest cache directory jest never writes, so every run ended on a "no output files found" warning.

This only works now because the baseline migration in #97 landed. Before that, `migrate deploy` couldn't produce a usable schema.

## branch-check.yml

`🔬 Test` sits next to the checkup matrix rather than in it. It's the only check that needs a database, and matrix jobs share their steps, so folding it in would make typecheck, lint and format each wait on Postgres for nothing.

- `postgis/postgis:16-3.4` as a service container. `schema.prisma` declares the postgis extension and the baseline migration creates it, so plain postgres won't get through `migrate deploy`. Same image `docker-compose.test.yml` uses, minus the `platform: linux/amd64` that only Apple Silicon needs.
- Credentials, port and database name match the `DATABASE_URL` already committed in `.env.test`, which points at localhost and carries no real secrets.
- No Redis. `.env.test` sets `REDIS_HOST` and the test compose file starts redis and serverless-redis-http, but nothing under `packages/api` imports a redis client, and the suite is green in CI without either container.
- No turbo cache step. `test` is `cache: false`, so there'd be nothing to restore.
- `test:db:up` in `@pegada/database` skips docker-compose when `$CI` is set. The service container already owns port 3355 there, and ubuntu-24.04 runners don't ship the `docker-compose` v1 binary anyway. `pretest` still runs `prisma migrate deploy` against the service container.

## Testing

Locally, `pnpm test` from the root: 53 passed across 6 suites in `packages/api`, 2 in `apps/mobile`, no turbo warnings. Same result with `CI=1` set, which takes the docker-compose skip path.

In CI on this branch: both migrations applied against the service container, then the same 53 + 2. The job took 70s and 88s across the two green runs, finishing 23s and 29s after the slowest of the other three. Whole-workflow wall clock was 2:28 and 2:34, against 2:00 to 2:43 on the last five runs of this workflow before the job existed.

Negative control: I flipped `expect(allows("https://example.com/payload.png")).toBe(false)` to `true` in `imageUrl.test.ts`, the case that guards against an arbitrary external host, and pushed it. 🔬 Test went red on `isAllowedImageUrl › rejects an arbitrary external host` with 1 failed / 52 passed, while Dedupe, Typecheck, Lint and Format all stayed green. Dropped that commit and the branch went back to green on the same SHA.

## Required checks

Main requires 🧹 Dedupe, 🧪 Typecheck, 🧹 Lint and 💅 Format. I'd add 🔬 Test to that list: it's the only check covering the security fixes from tonight, and it adds under 30s to the wait before a merge, since the other jobs run alongside it. It does pull an image from Docker Hub, which the other four don't, so watch that step for flakes. I haven't touched the ruleset.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uj6xe9Bt2zFYmqU6UTTkQ
