### PR TITLE
ci: generate the changelog, tag and GitHub release from conventional commits

### DIFF
--- a/.github/scripts/changelog.py
+++ b/.github/scripts/changelog.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Build release notes from conventional commits.
+
+One generator feeds all three places a release shows up, so they can't
+disagree with each other:
+
+  - CHANGELOG.md          `--all` regenerates the whole file from git history
+  - the annotated tag     `scripts/tag-release.sh` uses `--notes` as the message
+  - the GitHub release    release-mobile.yml passes the same `--notes` output
+
+A breaking change is a `!` before the colon (`feat(api)!: ...`) or a
+`BREAKING CHANGE:` / `BREAKING-CHANGE:` footer, per the conventional commits
+spec. Either one puts the commit under the Breaking changes heading at the top
+of its section, keeps its footer text, and makes `--is-breaking` exit 0, which
+is what marks the release title.
+
+Commits that don't parse as conventional aren't dropped; they land under Other
+so nothing silently disappears from a release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Unit/record separators, not NUL: argv strings can't carry an embedded NUL.
+RECORD = "\x1e"
+FIELD = "\x1f"
+
+# Ordered: this is the order sections appear under a version.
+SECTIONS: list[tuple[str, tuple[str, ...]]] = [
+    ("Features", ("feat",)),
+    ("Fixes", ("fix",)),
+    ("Performance", ("perf",)),
+    ("Reverts", ("revert",)),
+    ("Dependencies", ("deps",)),
+    ("Refactors", ("refactor",)),
+    ("Documentation", ("docs",)),
+    ("Tests", ("test",)),
+    ("Build and CI", ("build", "ci")),
+    ("Chores", ("chore", "style")),
+]
+
+BREAKING_HEADING = "Breaking changes"
+OTHER_HEADING = "Other"
+
+HEADER = re.compile(r"^(?P<type>[a-zA-Z]+)(?:\((?P<scope>[^)]*)\))?(?P<bang>!)?:\s*(?P<subject>.+)$")
+TRAILING_PR = re.compile(r"\s*\(#(?P<number>\d+)\)\s*$")
+
+# Conventional commits footers are `token: value` or `token #value`, where the
+# token is one word. A footer runs until the next one, so a BREAKING CHANGE
+# explanation can span several lines and all of them belong in the changelog.
+FOOTER = re.compile(r"^(?P<token>[A-Za-z][A-Za-z-]*|BREAKING CHANGE)(?::[ \t]|[ ]#)(?P<value>.*)$")
+
+
+def breaking_notes(body: str) -> list[str]:
+    notes: list[list[str]] = []
+    current: list[str] | None = None
+
+    for line in body.splitlines():
+        match = FOOTER.match(line)
+        if match:
+            if match.group("token").upper().replace("-", " ") == "BREAKING CHANGE":
+                current = [match.group("value").strip()]
+                notes.append(current)
+            else:
+                current = None
+            continue
+        if current is not None:
+            current.append(line.strip())
+
+    return [
+        " ".join(part for part in note if part).strip()
+        for note in notes
+        if any(part.strip() for part in note)
+    ]
+
+
+class Commit:
+    def __init__(self, sha: str, subject: str, body: str) -> None:
+        self.sha = sha
+        self.body = body
+
+        subject, self.pr = self._split_pr(subject)
+        match = HEADER.match(subject)
+
+        self.type = (match.group("type").lower() if match else "").strip()
+        self.scope = (match.group("scope") or "").strip() if match else ""
+        self.subject = (match.group("subject") if match else subject).strip()
+        self.breaking_notes = breaking_notes(body)
+        self.breaking = bool(match and match.group("bang")) or bool(self.breaking_notes)
+
+    @staticmethod
+    def _split_pr(subject: str) -> tuple[str, str | None]:
+        """Squash merges end in `(#123)`. Keep the number, drop it from the text."""
+        match = TRAILING_PR.search(subject)
+        if not match:
+            return subject.strip(), None
+        return TRAILING_PR.sub("", subject).strip(), match.group("number")
+
+    @property
+    def heading(self) -> str:
+        for heading, types in SECTIONS:
+            if self.type in types:
+                return heading
+        return OTHER_HEADING
+
+    def render(self, repo: str | None) -> str:
+        scope = f"**{self.scope}:** " if self.scope else ""
+        line = f"- {scope}{self.subject}"
+
+        if self.pr and repo:
+            line += f" ([#{self.pr}](https://github.com/{repo}/pull/{self.pr}))"
+        elif self.pr:
+            line += f" (#{self.pr})"
+
+        if repo:
+            line += f" ([`{self.sha[:7]}`](https://github.com/{repo}/commit/{self.sha}))"
+        else:
+            line += f" (`{self.sha[:7]}`)"
+
+        return line
+
+    def render_breaking(self, repo: str | None) -> str:
+        lines = [self.render(repo)]
+        lines += [f"  {note}" for note in self.breaking_notes]
+        return "\n".join(lines)
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def read_commits(rev_range: str) -> list[Commit]:
+    raw = git("log", "--no-merges", f"--format=%H{FIELD}%s{FIELD}%b{RECORD}", rev_range)
+    commits = []
+    for record in raw.split(RECORD):
+        record = record.strip("\n")
+        if not record.strip():
+            continue
+        sha, subject, body = (record.split(FIELD, 2) + ["", ""])[:3]
+        commits.append(Commit(sha, subject, body))
+    return commits
+
+
+def render_body(commits: list[Commit], repo: str | None) -> str:
+    breaking = [commit for commit in commits if commit.breaking]
+    blocks: list[str] = []
+
+    if breaking:
+        rendered = "\n".join(commit.render_breaking(repo) for commit in breaking)
+        blocks.append(f"### {BREAKING_HEADING}\n\n{rendered}")
+
+    for heading, types in [*SECTIONS, (OTHER_HEADING, ())]:
+        group = [
+            commit
+            for commit in commits
+            if commit.heading == heading and not commit.breaking
+        ]
+        if group:
+            rendered = "\n".join(commit.render(repo) for commit in group)
+            blocks.append(f"### {heading}\n\n{rendered}")
+
+    if not blocks:
+        return "No commits in this release."
+
+    return "\n\n".join(blocks)
+
+
+def tag_date(ref: str) -> str:
+    return git("log", "-1", "--format=%ad", "--date=short", ref)
+
+
+def sorted_tags(pattern: str) -> list[str]:
+    raw = git("tag", "--list", pattern, "--sort=-creatordate")
+    return [tag for tag in raw.splitlines() if tag.strip()]
+
+
+def compare_link(repo: str | None, previous: str | None, current: str) -> str | None:
+    if not repo:
+        return None
+    if previous:
+        return f"[Full diff](https://github.com/{repo}/compare/{previous}...{current})"
+    return f"[Full history](https://github.com/{repo}/commits/{current})"
+
+
+def section(repo: str | None, previous: str | None, current: str, heading_level: int) -> str:
+    rev_range = f"{previous}..{current}" if previous else current
+    body = render_body(read_commits(rev_range), repo)
+    link = compare_link(repo, previous, current)
+
+    heading = "#" * heading_level
+    parts = [f"{heading} {current} ({tag_date(current)})", "", body]
+    if link:
+        parts += ["", link]
+    return "\n".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="owner/name, for commit and PR links")
+    parser.add_argument("--tag-pattern", default="v*", help="which tags count as releases")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--notes", metavar="TAG", help="print one release's notes")
+    mode.add_argument("--all", action="store_true", help="print the whole changelog")
+    mode.add_argument(
+        "--is-breaking",
+        metavar="TAG",
+        help="exit 0 when the release contains a breaking change, 1 when it doesn't",
+    )
+    parser.add_argument("--previous", help="override the tag to diff against")
+    parser.add_argument("--output", type=Path, help="write to this file instead of stdout")
+    args = parser.parse_args()
+
+    tags = sorted_tags(args.tag_pattern)
+
+    def previous_of(tag: str) -> str | None:
+        if args.previous is not None:
+            return args.previous or None
+        if tag not in tags:
+            # Notes for a tag that isn't pushed yet: diff against the newest one.
+            return tags[0] if tags else None
+        index = tags.index(tag)
+        return tags[index + 1] if index + 1 < len(tags) else None
+
+    if args.is_breaking:
+        rev_range = (
+            f"{previous_of(args.is_breaking)}..{args.is_breaking}"
+            if previous_of(args.is_breaking)
+            else args.is_breaking
+        )
+        return 0 if any(commit.breaking for commit in read_commits(rev_range)) else 1
+
+    if args.notes:
+        text = render_body(
+            read_commits(
+                f"{previous_of(args.notes)}..{args.notes}"
+                if previous_of(args.notes)
+                else args.notes
+            ),
+            args.repo,
+        )
+        link = compare_link(args.repo, previous_of(args.notes), args.notes)
+        if link:
+            text += f"\n\n{link}"
+    else:
+        if not tags:
+            print("No tags match the pattern, nothing to generate.", file=sys.stderr)
+            return 1
+        blocks = [
+            "# Changelog",
+            "",
+            "Generated from conventional commits by `.github/scripts/changelog.py`."
+            " Run `pnpm changelog` to refresh it.",
+        ]
+        for index, tag in enumerate(tags):
+            previous = tags[index + 1] if index + 1 < len(tags) else None
+            blocks.append("")
+            blocks.append(section(args.repo, previous, tag, heading_level=2))
+        text = "\n".join(blocks)
+
+    text = text.rstrip("\n") + "\n"
+
+    if args.output:
+        args.output.write_text(text)
+    else:
+        sys.stdout.write(text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -1,4 +1,4 @@
-name: Release Mobile (build + submit)
+name: Release Mobile (release + build + submit)
 
 # ---------------------------------------------------------------------------
 # WHY GITHUB ACTIONS INSTEAD OF EAS CLOUD BUILDS
@@ -44,9 +44,14 @@ name: Release Mobile (build + submit)
 #
 # A new native binary must NOT be auto-submitted to the stores: it needs
 # TestFlight/internal-track testing and a deliberate staged rollout first. So:
-#   - tag push (v*)        -> builds artifacts only, NEVER submits
+#   - tag push (v*)        -> GitHub release + changelog, then builds
+#                             artifacts, NEVER submits
 #   - manual dispatch      -> submit is an explicit opt-in (defaults to false)
 # `eas submit` is only ever reached when a human sets submit=true on a dispatch.
+#
+# Tags come from `./scripts/tag-release.sh`, which reads the version out of
+# apps/mobile/app.config.ts and writes the generated release notes into the
+# annotated tag's own message.
 # ---------------------------------------------------------------------------
 on:
   workflow_dispatch:
@@ -77,6 +82,119 @@ env:
   EXPO_NO_TELEMETRY: 1
 
 jobs:
+  # -------------------------------------------------------------------------
+  # GitHub release + changelog. Deliberately has NO `needs:` on the build
+  # jobs: the notes describe what's in the tag, which is knowable the second
+  # the tag lands, and waiting 40-90 minutes for a native build to finish
+  # before the release page exists is how this repo ended up with two tags
+  # and zero releases.
+  #
+  # `.github/scripts/changelog.py` is the single source for release text. The
+  # annotated tag's own message comes from the same generator (via
+  # scripts/tag-release.sh), so the tag, the release body and the CHANGELOG.md
+  # entry can't tell three different stories about the same commits, and a
+  # breaking change (`feat!:` or a `BREAKING CHANGE:` footer) shows up in all
+  # three plus the release title.
+  # -------------------------------------------------------------------------
+  github-release:
+    name: GitHub release (notes + changelog)
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      # Full history and every tag: the generator diffs this tag against the
+      # previous one, which a shallow clone doesn't have.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          PREVIOUS=$(git tag --list 'v*' --sort=-creatordate | grep -Fxv "$TAG" | head -1 || true)
+
+          python3 .github/scripts/changelog.py \
+            --notes "$TAG" \
+            --previous "$PREVIOUS" \
+            --repo "$GITHUB_REPOSITORY" \
+            --output release-notes.md
+
+          TITLE="$TAG"
+          if python3 .github/scripts/changelog.py \
+            --is-breaking "$TAG" --previous "$PREVIOUS" >/dev/null; then
+            TITLE="$TAG (contains breaking changes)"
+          fi
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+          # Anything with a suffix after the version (-rc1, -beta.2) is not a
+          # store release; GitHub should not mark it "Latest".
+          if printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "::group::release notes"
+          cat release-notes.md
+          echo "::endgroup::"
+
+      - name: Create or update the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          TITLE: ${{ steps.notes.outputs.title }}
+          PRERELEASE: ${{ steps.notes.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          FLAGS=()
+          if [ "$PRERELEASE" = "true" ]; then
+            FLAGS+=(--prerelease)
+          else
+            FLAGS+=(--latest)
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$TITLE" \
+              --notes-file release-notes.md \
+              "${FLAGS[@]}"
+          else
+            gh release create "$TAG" \
+              --title "$TITLE" \
+              --notes-file release-notes.md \
+              "${FLAGS[@]}"
+          fi
+
+      # Regenerated from scratch rather than prepended to, so the file always
+      # matches git history even if a tag was deleted or backfilled.
+      - name: Refresh CHANGELOG.md on the default branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.event.repository.default_branch }}"
+          git checkout -B changelog-refresh "origin/${{ github.event.repository.default_branch }}"
+
+          python3 .github/scripts/changelog.py \
+            --all --repo "$GITHUB_REPOSITORY" --output CHANGELOG.md
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs: regenerate the changelog for ${GITHUB_REF_NAME}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"
+
   # -------------------------------------------------------------------------
   # iOS: local EAS build on a macOS runner, production profile.
   # -------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# Changelog
+
+Generated from conventional commits by `.github/scripts/changelog.py`. Run `pnpm changelog` to refresh it.
+
+## v1.4.0-rc7 (2026-07-06)
+
+### Build and CI
+
+- **mobile:** fix Gradle daemon Metaspace OOM + Android lint ExtraTranslation ([`adb2c5a`](https://github.com/GSTJ/pegada/commit/adb2c5ab68405105e95f7725174dc3d7636f524f))
+
+[Full diff](https://github.com/GSTJ/pegada/compare/v1.4.0-rc6...v1.4.0-rc7)
+
+## v1.4.0-rc6 (2026-07-06)
+
+### Features
+
+- dual-path image uploads — R2 for new clients, S3 legacy for shipped binaries ([#58](https://github.com/GSTJ/pegada/pull/58)) ([`818730c`](https://github.com/GSTJ/pegada/commit/818730c906c698c5ad28a2b163f8719fd8295e65))
+- **database:** Neon pooled/direct URL split ([#57](https://github.com/GSTJ/pegada/pull/57)) ([`3aaf1b7`](https://github.com/GSTJ/pegada/commit/3aaf1b7abadda84864cdd419d19edafd8913d6f7))
+- vendor consolidation — Cloudflare mail, Vercel Queues, PostHog, Next 15/React 19 ([#56](https://github.com/GSTJ/pegada/pull/56)) ([`5f6012d`](https://github.com/GSTJ/pegada/commit/5f6012d49655f636aa63ccb186b603987141ed0a))
+- **mobile:** MAESTRO_E2E placeholder photo affordance for iOS 26 picker (#44) ([#46](https://github.com/GSTJ/pegada/pull/46)) ([`c34548b`](https://github.com/GSTJ/pegada/commit/c34548b69870e207452405ae2ea09dd557997466))
+
+### Fixes
+
+- **vercel:** drop apps/nextjs prefix from function path keys ([#61](https://github.com/GSTJ/pegada/pull/61)) ([`11c4dca`](https://github.com/GSTJ/pegada/commit/11c4dca46c4d3f69699816b7a346f5f7a76f5b39))
+- **vercel:** register queue triggers from repo-root vercel.json ([#60](https://github.com/GSTJ/pegada/pull/60)) ([`4806326`](https://github.com/GSTJ/pegada/commit/4806326f74559ef41d457179c2d5dfc2cea76a9c))
+- **mobile:** Hermes import.meta transform ([#59](https://github.com/GSTJ/pegada/pull/59)) ([`6057600`](https://github.com/GSTJ/pegada/commit/6057600e83cd2dca147796a705d319bcb89031cf))
+- **ci:** make the e2e hard gate real — Release builds + the app/test fixes it flushed out ([#54](https://github.com/GSTJ/pegada/pull/54)) ([`365c8ce`](https://github.com/GSTJ/pegada/commit/365c8ce2f20761d72cad2ab8a22fadc1341446e4))
+- **test:** logout flow taps "Logout" (one word) to match i18n string ([#39](https://github.com/GSTJ/pegada/pull/39)) ([`eb19284`](https://github.com/GSTJ/pegada/commit/eb192841eb53ed0b3c1bb88ccfb1e953fea7e6ab))
+- **mobile:** ToS/Privacy URLs + StoreKit sim config + upgrade wall close hit area ([#37](https://github.com/GSTJ/pegada/pull/37)) ([`2cba6e5`](https://github.com/GSTJ/pegada/commit/2cba6e5eb90bc702f132424ac58fce5972867ffb))
+- **mobile:** photo upload fails on iOS 26 Release build ([#36](https://github.com/GSTJ/pegada/pull/36)) ([`a076df4`](https://github.com/GSTJ/pegada/commit/a076df48f004d44bb816630f2883d1bead86297d))
+- **mobile:** swipe stack UX (hit target, back nav, seed coverage) ([#38](https://github.com/GSTJ/pegada/pull/38)) ([`67b9e8b`](https://github.com/GSTJ/pegada/commit/67b9e8beb69a3d521cdf82e010144267376e4d58))
+- **test:** Maestro login utility taps keyboard region on iPhone 17 Pro Max iOS 26 (#40) ([#41](https://github.com/GSTJ/pegada/pull/41)) ([`dedd6c4`](https://github.com/GSTJ/pegada/commit/dedd6c4207d2d506ed8708947ca6da188f5bb3cb))
+- **test:** Maestro login email tap coord 65% -> 84% ([#28](https://github.com/GSTJ/pegada/pull/28)) ([`d807d1c`](https://github.com/GSTJ/pegada/commit/d807d1c2dfe7b26bfce52721983dacaea4406f43))
+- **mobile:** grey gap at bottom of profile scroll (missing tab-bar inset) ([#27](https://github.com/GSTJ/pegada/pull/27)) ([`dfef6c6`](https://github.com/GSTJ/pegada/commit/dfef6c65afb3fe62b40f31447980221d0eeea954))
+- **mobile:** surface real error when EditProfile image upload fails ([#26](https://github.com/GSTJ/pegada/pull/26)) ([`f17957f`](https://github.com/GSTJ/pegada/commit/f17957face26d1b353d8f1352376228cfe77728b))
+- **mobile:** new chat messages appear at the bottom (FlashList v2 inverted drop) ([#25](https://github.com/GSTJ/pegada/pull/25)) ([`5f436fe`](https://github.com/GSTJ/pegada/commit/5f436fe500a5b10344620495e08a74a0e73af492))
+- **mobile:** swipe screen top inset rendered grey instead of white ([#22](https://github.com/GSTJ/pegada/pull/22)) ([`530bbe6`](https://github.com/GSTJ/pegada/commit/530bbe6749507f9822ba0aa6021ad419de95324c))
+- **mobile:** make RevenueCat failures non-fatal ([#21](https://github.com/GSTJ/pegada/pull/21)) ([`6d8f2dc`](https://github.com/GSTJ/pegada/commit/6d8f2dc851160edd5bceb1867d0f124c7795d718))
+- **mobile:** remove invalid tabBarTestID + soft-fail e2e-mobile CI ([#20](https://github.com/GSTJ/pegada/pull/20)) ([`3c92175`](https://github.com/GSTJ/pegada/commit/3c921752d6db358648a52ef640d2a6ad081a2619))
+- **mobile:** patch redux-saga ESM proxy double-unwrap ([#18](https://github.com/GSTJ/pegada/pull/18)) ([`f7b1bf3`](https://github.com/GSTJ/pegada/commit/f7b1bf3b5eccab172a7a9f2bff5fad4bd08327bc))
+- **mobile:** bump react-native-purchases for Xcode 26 SubscriptionPeriod ambiguity ([#17](https://github.com/GSTJ/pegada/pull/17)) ([`edc1b73`](https://github.com/GSTJ/pegada/commit/edc1b73a3ef4f62bbb15890fb225d600bed27ec0))
+- **mobile:** bump react-native-reanimated to 4.3.1 for worklets 0.8 compat ([#16](https://github.com/GSTJ/pegada/pull/16)) ([`74f51fb`](https://github.com/GSTJ/pegada/commit/74f51fba0368db3e455c3029dbac70badc72af27))
+
+### Performance
+
+- **test:** OTP per-digit wait 25ms (was 150ms) ([#23](https://github.com/GSTJ/pegada/pull/23)) ([`b84630b`](https://github.com/GSTJ/pegada/commit/b84630bac4d65b274bee4834a67293404c2ddc46))
+
+### Dependencies
+
+- bump actions/checkout from 6 to 7 ([#52](https://github.com/GSTJ/pegada/pull/52)) ([`1ff7c6f`](https://github.com/GSTJ/pegada/commit/1ff7c6fd40f7f70c2612889598e0fcba2eb4fb18))
+- bump pnpm/action-setup from 4.2.0 to 6.0.9 ([#51](https://github.com/GSTJ/pegada/pull/51)) ([`762e7b5`](https://github.com/GSTJ/pegada/commit/762e7b550d0fdbb631cf4121523cfe3b5911085e))
+- bump actions/setup-java from 4 to 5 ([#47](https://github.com/GSTJ/pegada/pull/47)) ([`6e9ad4a`](https://github.com/GSTJ/pegada/commit/6e9ad4a7b262206e638df1972469d5623557e349))
+- bump actions/upload-artifact from 4 to 7 ([#48](https://github.com/GSTJ/pegada/pull/48)) ([`d514ce5`](https://github.com/GSTJ/pegada/commit/d514ce5bb0cfcf4ae1cabd19166ba4489cca1e24))
+- bump expo/expo-github-action from 8 to 9 ([#50](https://github.com/GSTJ/pegada/pull/50)) ([`1a36baa`](https://github.com/GSTJ/pegada/commit/1a36baaebb71b2f4ab755b66e733883adbe07ae0))
+- bump actions/cache from 4 to 5 ([#10](https://github.com/GSTJ/pegada/pull/10)) ([`2685820`](https://github.com/GSTJ/pegada/commit/2685820a120100f412c2f8af8dc926606686acc5))
+- bump actions/checkout from 4 to 6 ([#9](https://github.com/GSTJ/pegada/pull/9)) ([`861df6d`](https://github.com/GSTJ/pegada/commit/861df6d27f331d8fbb4577c92daba94a7b5cd9c9))
+- bump actions/setup-node from 4 to 6 ([#8](https://github.com/GSTJ/pegada/pull/8)) ([`06bf6d4`](https://github.com/GSTJ/pegada/commit/06bf6d450b3a5ddafc68571695fb4bb84289aae7))
+- bump pnpm/action-setup from 4.0.0 to 4.2.0 ([#7](https://github.com/GSTJ/pegada/pull/7)) ([`794e394`](https://github.com/GSTJ/pegada/commit/794e394cc2b6c4c2d58f61263356066802a7c6fb))
+
+### Tests
+
+- **e2e:** rewrite flows 20-27 with real verifications + DB post-checks ([#43](https://github.com/GSTJ/pegada/pull/43)) ([`3f4bc69`](https://github.com/GSTJ/pegada/commit/3f4bc69d7e828d8fb81f16d2b8589ea712a40424))
+- **e2e:** upgrade journey with BE-mocked purchase (replaces #16) (#25) ([#35](https://github.com/GSTJ/pegada/pull/35)) ([`158039e`](https://github.com/GSTJ/pegada/commit/158039eb8794d2d85bb046ff23d373364fb0aeeb))
+- **e2e:** account-creation user journey flow (#20) ([#34](https://github.com/GSTJ/pegada/pull/34)) ([`4ac6a4e`](https://github.com/GSTJ/pegada/commit/4ac6a4e93b23f73041dc7339f98ced09c8ebd1d1))
+- **e2e:** logout + delete-account journeys (#26+#27) ([#33](https://github.com/GSTJ/pegada/pull/33)) ([`a0c51dd`](https://github.com/GSTJ/pegada/commit/a0c51ddaff9d2afea19821455f481067ebfd6f90))
+- **e2e:** preferences/location/language/theme journey (replaces #15+#17) (#23) ([#32](https://github.com/GSTJ/pegada/pull/32)) ([`ccc6c05`](https://github.com/GSTJ/pegada/commit/ccc6c05fb92cff57a5d5d1ac939f9fa7a9022069))
+- **e2e:** profile + ToS + Privacy + Rate journey (replaces #13+#14) (#24) ([#31](https://github.com/GSTJ/pegada/pull/31)) ([`660521b`](https://github.com/GSTJ/pegada/commit/660521b30b877500e8ea3512cd15ca9c34be8349))
+- **e2e:** real new-match modal journey (replaces #18 stub) (#22) ([#30](https://github.com/GSTJ/pegada/pull/30)) ([`1cc6611`](https://github.com/GSTJ/pegada/commit/1cc66113fe8a76147053bae18e13588361b57fcc))
+- **e2e:** swipe-stack user journey (like/dislike/profile/report) (#21) ([#29](https://github.com/GSTJ/pegada/pull/29)) ([`66aeb22`](https://github.com/GSTJ/pegada/commit/66aeb22aaffb0fef57617d3171ac64b455eef078))
+- **mobile:** tighten Maestro login helpers (real screen-advancing flows) ([#19](https://github.com/GSTJ/pegada/pull/19)) ([`1e110a4`](https://github.com/GSTJ/pegada/commit/1e110a4748ed0aae1866f35779d3af7eaf684fe6))
+- **mobile:** add Maestro e2e smoke flows + CI ([#15](https://github.com/GSTJ/pegada/pull/15)) ([`6cbf8a8`](https://github.com/GSTJ/pegada/commit/6cbf8a87d9951da43a44b6a46b9c50b3f9b14976))
+
+### Build and CI
+
+- **mobile:** bump Android build timeout, guarantee Gradle cache save ([`e46b19b`](https://github.com/GSTJ/pegada/commit/e46b19b5481d9786b28ab1fb0b3b5e912cf0a23e))
+- **mobile:** decode GoogleService secrets before pnpm install, not after ([`174b4d8`](https://github.com/GSTJ/pegada/commit/174b4d8c718fe0633fc3207ffd735e673bfcfed9))
+- **mobile:** fix GoogleService file delivery for eas build --local ([`a16d58d`](https://github.com/GSTJ/pegada/commit/a16d58d52ce299526eb17462611c6bf9ec28dd5f))
+- **mobile:** write real GoogleService files before local EAS builds ([`bbb36a8`](https://github.com/GSTJ/pegada/commit/bbb36a80de8703bdfa770c18a5b406de9aedc034))
+- **mobile:** add GHA release workflow, EAS local builds + manual submit ([`ec59077`](https://github.com/GSTJ/pegada/commit/ec5907736594407316968fa5a538274ccbd20794))
+- e2e fingerprint cache, bundle swap, dead-time cuts, sharded extended suite ([#62](https://github.com/GSTJ/pegada/pull/62)) ([`f85e0c6`](https://github.com/GSTJ/pegada/commit/f85e0c6fdae8ae5d8e45c5546f71d30be22a1272))
+- **e2e:** make Maestro CI a real gate (no more continue-on-error) ([#42](https://github.com/GSTJ/pegada/pull/42)) ([`4e25347`](https://github.com/GSTJ/pegada/commit/4e2534784d1158825c3fa62a3a1b65968f54f5b1))
+
+### Chores
+
+- gitignore + deps cleanup (session replay dep, stray app.json) ([#64](https://github.com/GSTJ/pegada/pull/64)) ([`c2a2776`](https://github.com/GSTJ/pegada/commit/c2a2776a537e6f7b4073cec7e96a930c50dfbd1e))
+- gitignore local artifacts (env.production, maestro screenshots, claude worktrees) ([#53](https://github.com/GSTJ/pegada/pull/53)) ([`e834c93`](https://github.com/GSTJ/pegada/commit/e834c93b85b14c3ffc0400aa422018f716c52105))
+- **test:** auto-seed Maestro test DB state on every flow run ([#24](https://github.com/GSTJ/pegada/pull/24)) ([`c653c2d`](https://github.com/GSTJ/pegada/commit/c653c2dace17f3b707617ebb07aaf16591aa63a2))
+- upgrade Expo SDK 51 → 55 ([#14](https://github.com/GSTJ/pegada/pull/14)) ([`109cd6e`](https://github.com/GSTJ/pegada/commit/109cd6ee550baecb1469027ad936f1094c6cfe8c))
+- migrate from ESLint+Prettier to oxlint+oxfmt ([#13](https://github.com/GSTJ/pegada/pull/13)) ([`d9c2a74`](https://github.com/GSTJ/pegada/commit/d9c2a743cbd89add20843a435ce317a18a8e9549))
+- dependency bumps (2026-05-18, 7-day rule) ([#11](https://github.com/GSTJ/pegada/pull/11)) ([`3943797`](https://github.com/GSTJ/pegada/commit/394379784c16cab6b5fda28ec085466464cc4027))
+
+### Other
+
+- **mobile:** bump version to 1.4.0 ([`08f898c`](https://github.com/GSTJ/pegada/commit/08f898cec3b9cf121a7f81392162d591bcd3a173))
+- ✨ Update README.md ([`624372d`](https://github.com/GSTJ/pegada/commit/624372d88b9e0bb852efda278dbd6b5441a7b532))
+- ✨ Update README.md ([`3fe92f1`](https://github.com/GSTJ/pegada/commit/3fe92f1bd43a4b134e183b188e3b316e84758266))
+- ✨ Add banner to README.md ([`10b045b`](https://github.com/GSTJ/pegada/commit/10b045b6175b95a91639092b4177b665e5e81c70))
+- ✨ Add logo asset ([`559f233`](https://github.com/GSTJ/pegada/commit/559f233a31d7f2bb7e13afabec2eb1e89361020e))
+- 🚀 Make it Open-Source! ([`e9f2e57`](https://github.com/GSTJ/pegada/commit/e9f2e579cc34ab55ab07cfab3598f38cce935114))
+
+[Full history](https://github.com/GSTJ/pegada/commits/v1.4.0-rc6)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,41 @@ We follow the [conventional commits specification](https://www.conventionalcommi
 - `test`: adding or updating tests, e.g. add integration tests using detox.
 - `chore`: tooling changes, e.g. change CI config.
 
+The type and scope are not decoration: [CHANGELOG.md](./CHANGELOG.md), the
+GitHub release and the annotated tag are all generated from them by
+`.github/scripts/changelog.py`. A commit that doesn't parse still shows up,
+just under "Other".
+
+Breaking changes get a `!` before the colon and a `BREAKING CHANGE:` footer
+explaining what callers have to do:
+
+```
+feat(api)!: return message ids as strings
+
+BREAKING CHANGE: `message.send` used to return a numeric `id`. Clients
+that compared it to a number need to compare strings now.
+```
+
+Both markers land the commit under "Breaking changes" at the top of the
+release, and the footer text travels with it into all three places.
+
+### Cutting a release
+
+```sh
+./scripts/tag-release.sh              # v<version from apps/mobile/app.config.ts>
+./scripts/tag-release.sh v1.5.0-rc1   # explicit, e.g. a release candidate
+DRY_RUN=1 ./scripts/tag-release.sh    # print the notes and stop
+```
+
+The script creates an annotated tag whose message is the generated notes and
+pushes it. That push is what starts `release-mobile.yml`: it publishes the
+GitHub release, refreshes `CHANGELOG.md` on `main`, and builds the native
+artifacts. Anything with a suffix (`-rc1`, `-beta.2`) is marked a prerelease.
+Store submission stays a separate, opt-in manual dispatch.
+
+Most changes never need any of this. `deploy-mobile.yml` ships an OTA update
+on every push to `main`; a tag is only for when native actually changed.
+
 ### Sending a pull request
 
 > **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://app.egghead.io/playlists/how-to-contribute-to-an-open-source-project-on-github).

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format:fix": "oxfmt",
     "i18n:parse": "npx i18next-parser",
     "typecheck": "turbo typecheck",
+    "changelog": "python3 .github/scripts/changelog.py --all --repo GSTJ/pegada --output CHANGELOG.md",
     "convert:images": "./scripts/convert-png-images-to-webp.sh",
     "download:secrets": "dotenv -- ./scripts/download-secrets.sh"
   },

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tag a release from apps/mobile/app.config.ts's version.
+#
+# The tag is ANNOTATED and its message is the generated release notes, so
+# `git show <tag>` tells you what shipped without a network round trip, and it
+# matches the GitHub release body and the CHANGELOG.md entry byte for byte
+# (release-mobile.yml runs the same generator on the same range).
+#
+#   ./scripts/tag-release.sh              # v<version from app.config.ts>
+#   ./scripts/tag-release.sh v1.5.0-rc1   # explicit, e.g. a release candidate
+#   DRY_RUN=1 ./scripts/tag-release.sh    # print the notes, tag nothing
+#
+# Pushing the tag is what starts release-mobile.yml: the native builds and the
+# GitHub release. It never submits to a store on its own.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+REPO=${REPO:-GSTJ/pegada}
+REMOTE=${REMOTE:-origin}
+
+if [ $# -gt 0 ]; then
+  TAG=$1
+else
+  # app.config.ts is TypeScript with a top-level `version: "x.y.z",`, so read
+  # the literal instead of standing up a TS runtime just for one string.
+  VERSION=$(sed -n 's/^[[:space:]]*version: "\([^"]*\)",$/\1/p' apps/mobile/app.config.ts | head -1)
+  if [ -z "$VERSION" ]; then
+    echo "error: could not read version from apps/mobile/app.config.ts" >&2
+    exit 1
+  fi
+  TAG="v$VERSION"
+fi
+
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  echo "error: tag $TAG already exists locally" >&2
+  exit 1
+fi
+
+if git ls-remote --exit-code --tags "$REMOTE" "refs/tags/$TAG" >/dev/null 2>&1; then
+  echo "error: tag $TAG already exists on $REMOTE" >&2
+  exit 1
+fi
+
+PREVIOUS=$(git tag --list 'v*' --sort=-creatordate | head -1)
+NOTES=$(python3 .github/scripts/changelog.py --notes HEAD --previous "$PREVIOUS" --repo "$REPO")
+
+TITLE="$TAG"
+if python3 .github/scripts/changelog.py --is-breaking HEAD --previous "$PREVIOUS" >/dev/null; then
+  TITLE="$TAG (contains breaking changes)"
+fi
+
+MESSAGE=$(printf '%s\n\n%s\n' "$TITLE" "$NOTES")
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  printf '%s\n' "$MESSAGE"
+  echo
+  echo "(dry run, nothing tagged)"
+  exit 0
+fi
+
+git tag -a "$TAG" -m "$MESSAGE"
+git push "$REMOTE" "refs/tags/$TAG"
+
+echo "Tagged and pushed $TAG. release-mobile.yml takes it from here."


### PR DESCRIPTION
## Summary

Two tags exist, `v1.4.0-rc6` and `v1.4.0-rc7`, and neither has a release behind it. There's no changelog either, so the only record of what went into 1.4.0 is `git log`. This wires the whole thing up from the conventional commits we already write.

## Details

- `.github/scripts/changelog.py` is the one generator. It groups commits by type, links PR numbers and SHAs, and puts anything that doesn't parse under "Other" so nothing disappears from a release.
- `CHANGELOG.md` (`pnpm changelog`), the annotated tag's own message (`./scripts/tag-release.sh`) and the GitHub release body (new `github-release` job in `release-mobile.yml`) all call the same generator over the same commit range, so the three can't disagree.
- Breaking changes come from either marker the spec allows, a `!` before the colon or a `BREAKING CHANGE:` footer. Both lift the commit into a "Breaking changes" heading at the top of the release, keep the footer text with it, and add `(contains breaking changes)` to the release title.
- The release job has no `needs` on the native builds. Blocking the release page on a 40-90 minute `.ipa` is part of how we got two tags and no releases.
- `-rc1` / `-beta.2` style tags are marked prerelease; a bare `vX.Y.Z` gets `--latest`. Store submission stays the opt-in manual dispatch it already was.
- `CHANGELOG.md` is committed backfilled from history, and the release job regenerates it on `main` from scratch on every tag, so a deleted or backfilled tag can't leave it stale.

## Testing steps

1. `DRY_RUN=1 ./scripts/tag-release.sh` prints the notes for the next tag and exits without tagging.
2. `pnpm changelog` regenerates `CHANGELOG.md`; it should come back byte-identical to what's committed here.
3. `python3 .github/scripts/changelog.py --is-breaking v1.4.0-rc7` exits 1 (nothing breaking in it). Add a local `feat(x)!: ...` commit and it exits 0.
