### PR TITLE
ci(e2e): give the iOS build room to finish a cold build

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -314,7 +314,12 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: quarantine-lint
     runs-on: macos-latest
-    timeout-minutes: 45
+    # A cold .app cache means a full Xcode release build plus a simulator
+    # boot, which measured 44m50s on main — ten seconds under the old
+    # 45-minute budget, so any slower runner killed the job and Actions
+    # reported it as `cancelled`, not `timed out`. 75 leaves real headroom
+    # for a cold build; a warm fingerprint hit still finishes in minutes.
+    timeout-minutes: 75
     outputs:
       app-artifact: ${{ steps.vars.outputs.app-artifact }}
     env:
@@ -981,7 +986,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: quarantine-lint
     runs-on: macos-latest
-    timeout-minutes: 45
+    # Same cold-cache build as the required variant, so it carries the same
+    # budget. Keeping the two in step stops one from timing out alone.
+    timeout-minutes: 75
     outputs:
       app-artifact: ${{ steps.vars.outputs.app-artifact }}
       skip: ${{ steps.preflight.outputs.skip }}


### PR DESCRIPTION
The push-to-main run for #105 came back `cancelled` with no error in the log. Worth ruling out the usual suspects first: it was not concurrency (`cancel-in-progress` is scoped to `pull_request`, so a push-to-main run is never killed by a newer one) and not a lost runner.

`Build iOS (required)` ran out its `timeout-minutes: 45`. Actions reports a timed-out job as `cancelled`, which is why the run looks like someone hit the button.

The margin was never there. Timings from the two runs:

| run | job time | budget |
|---|---|---|
| main @ 12:07 (green) | 44m50s | 45m |
| main @ 19:30 (cancelled) | 45m00s | 45m |

Ten seconds. A cold `.app` cache makes the job pay for a full Xcode release build — 31 minutes in the failed run — plus the simulator boot, so whether main went green came down to how fast a given macOS runner felt that morning.

It also compounds: the cancel skipped every cache-save post step, so the next run starts cold too and re-rolls the same dice.

Both iOS build jobs go to 75 minutes. A warm fingerprint hit still finishes in minutes — this only buys the cold path enough room to land.

Claude-Session: https://claude.ai/code/session_01Fe92vvdc4R3F4BDBFoLcw1