### PR TITLE
chore(deps): let renovate own the github-actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps"


### PR DESCRIPTION
`renovate.json` already extends `github>GSTJ/magic`, and that preset carries a `matchManagers: ["github-actions"]` rule grouping every action bump into one automerged PR. The `dependabot.yml` here declared the same ecosystem on the same directory, so both bots watched the same manifests.

Not theoretical — #107 was opened by Dependabot minutes ago to bump `rharkor/caching-for-turbo`, a bump Renovate was already going to make. Two bots, two PRs, two CI runs, one dependency.

Drops the Dependabot config and leaves Renovate as the single updater. Dependabot security *alerts* stay on; Renovate reads them and raises its own PRs.

Closing #107 alongside this.

Claude-Session: https://claude.ai/code/session_01Fe92vvdc4R3F4BDBFoLcw1