### PR TITLE
chore(tooling): track magic by tag and ban hand-built className

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -50,7 +50,7 @@ jobs:
   checkup:
     name: 👮 Checkup
     needs: dedupe
-    uses: GSTJ/magic/.github/workflows/ci.yml@main
+    uses: GSTJ/magic/.github/workflows/ci.yml@v1
 
   # Kept out of the shared checkup job: only this one needs a database, and
   # folding it in would spin up Postgres for typecheck/lint/format too. No

--- a/apps/nextjs/oxlint.config.mts
+++ b/apps/nextjs/oxlint.config.mts
@@ -1,9 +1,27 @@
+import { extendConfig } from "magic-oxlint-config";
+import next from "magic-oxlint-config/next";
+
 /**
  * A nested config replaces the root one for everything under `apps/nextjs`, so
- * this file has to be complete on its own. Re-exporting the preset — rather
- * than `defineConfig({ extends: [next] })` — is what makes it complete:
- * `extends` still drops the extended config's `ignorePatterns` on oxlint
- * 1.75.0, so the extends form needs them copied back by hand. The re-export
- * loads the preset as *the* config and every field applies.
+ * this file has to be complete on its own. `extendConfig` flattens the preset
+ * and the additions below into one config, which is what makes it complete:
+ * oxlint's own `extends` still drops the extended config's `ignorePatterns` on
+ * 1.75.0 and needs them re-listed by hand.
+ *
+ * This is the only config in the repo that loads the `magic` jsPlugin.
+ * `magic/no-manual-classname` is a Tailwind rule and Tailwind stops at this
+ * app — the mobile app styles with styled-components and `packages/*` has no
+ * JSX at all, so loading the plugin there would cost startup time to lint
+ * nothing.
  */
-export { default } from "magic-oxlint-config/next";
+export default extendConfig(next, {
+  jsPlugins: [{ name: "magic", specifier: "magic-oxlint-plugin" }],
+
+  rules: {
+    // Class strings go through `cn` (src/lib/utils.ts, `twMerge(clsx(...))`)
+    // or a `cva` variant table. A hand-built one loses the conflict
+    // resolution: `p-2 ${active ? "p-4" : ""}` emits both paddings and leaves
+    // the winner to stylesheet order, where `cn` keeps the last one.
+    "magic/no-manual-classname": "error",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "magic-codemods": "^1.1.0",
     "magic-oxfmt-config": "^1.2.0",
     "magic-oxlint-config": "^1.2.0",
+    "magic-oxlint-plugin": "^1.1.0",
     "magic-tsconfig": "^1.2.0",
     "oxfmt": "0.60.0",
     "oxlint": "1.75.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       magic-oxlint-config:
         specifier: ^1.2.0
         version: 1.2.0(eslint@9.39.5(jiti@1.21.0)(supports-color@8.1.1))(oxlint@1.75.0)
+      magic-oxlint-plugin:
+        specifier: ^1.1.0
+        version: 1.1.0(oxlint@1.75.0)
       magic-tsconfig:
         specifier: ^1.2.0
         version: 1.2.0
@@ -5733,6 +5736,15 @@ packages:
   magic-oxlint-config@1.2.0:
     resolution: {integrity: sha512-QBqa4xdsLwi3a9yo8hGW5ZZwXdHzGBmz6GCK86nHza2r+8s9tztwP6mxIzP/8HGd6xbzP2zOfcwHsUIso3ROvQ==}
     engines: {node: '>=22.18.0'}
+    peerDependencies:
+      oxlint: '>=1.75.0'
+    peerDependenciesMeta:
+      oxlint:
+        optional: true
+
+  magic-oxlint-plugin@1.1.0:
+    resolution: {integrity: sha512-SdxWuNO9B0g5vMivlk9gP0B+PIKmBoImn8QWn9HQy0tIiyELzSmdrBkGtB2OB7IY23KK6b3gx1WDy8gxy763EA==}
+    engines: {node: '>=22'}
     peerDependencies:
       oxlint: '>=1.75.0'
     peerDependenciesMeta:
@@ -13731,6 +13743,10 @@ snapshots:
       oxlint: 1.75.0
     transitivePeerDependencies:
       - eslint
+
+  magic-oxlint-plugin@1.1.0(oxlint@1.75.0):
+    optionalDependencies:
+      oxlint: 1.75.0
 
   magic-tsconfig@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,6 +64,7 @@ minimumReleaseAgeExclude:
   - magic-oxfmt-config@1.2.0
   - magic-oxlint-config@1.2.0
   - magic-tsconfig@1.2.0
+  - magic-oxlint-plugin@1.1.0
 
 # pnpm 10+ does not run dependency install scripts unless they are listed here,
 # and pnpm 11 makes an unanswered list a hard install failure. Every entry ran


### PR DESCRIPTION
Two changes, both in the shared-tooling direction.

## `ci.yml@main` -> `ci.yml@v1`

`.github/workflows/branch-check.yml` called the reusable checkup workflow by
branch. That means an unreviewed merge in `GSTJ/magic` reruns this repo's CI
with code nobody looked at. `@v1` is a moving major tag: fixes still land on
the next run, but only once someone cuts a release. `v1` currently points at
`v1.4.0`.

The call passes no `with:` block, so there was no input signature to
reconcile — every input on `ci.yml` is optional and defaults sensibly
(`.nvmrc` for Node, `packageManager` for pnpm).

## `magic/no-manual-classname` at error

Enabled in `apps/nextjs/oxlint.config.mts`, which had to grow from a bare
re-export into an `extendConfig` call to carry the `jsPlugins` entry.

It is on in that one config on purpose. The rule is about Tailwind class
strings; `apps/mobile` styles with styled-components and `packages/*` has no
JSX at all, so putting the plugin in the root config would pay the jsPlugin
startup cost to lint files that can never violate it.

**Zero violations.** Every class string in the app already goes through `cn`
(`src/lib/utils.ts`, `twMerge(clsx(...))`). Verified the rule actually fires
by planting a `` className={`p-2 ${active ? "p-4" : ""}`} `` and watching it
error, then removing it — a rule that reports nothing because it never loaded
looks identical to a clean repo.

## The `minimumReleaseAgeExclude` line

`magic-oxlint-plugin@1.1.0` published today, and pnpm 11 refuses anything
under 24h old on `--frozen-lockfile`. pnpm wrote the exclude entry into
`pnpm-workspace.yaml` itself during the first local install. It looks like
local-machine noise; it is the only reason CI can install. It comes back out
once the version ages past the window. No two-version dance was needed here
since the plugin is a new dependency, not a bump.

The other `magic-*` packages are already on current latest (configs 1.2.0,
codemods 1.1.0), so this PR bumps nothing.

## Checks

- `pnpm install --frozen-lockfile` clean from an empty `node_modules`
- `pnpm dedupe --check` clean
- `oxlint --report-unused-disable-directives`: 0 diagnostics
- `oxfmt --check .`: 464 files, all formatted
- `pnpm typecheck`: 5/5 packages

Tests run on CI, where the PostGIS service container exists.

Claude-Session: https://claude.ai/code/session_01Fe92vvdc4R3F4BDBFoLcw1