### PR TITLE
fix(nextjs): serve real robots.txt and sitemap.xml

### DIFF
--- a/apps/nextjs/src/app/robots.ts
+++ b/apps/nextjs/src/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://www.pegada.app";
+
+// `/robots.txt` falls under the `[locale]` dynamic segment, so without this
+// file the request renders the homepage HTML instead of a robots file.
+const robots = (): MetadataRoute.Robots => {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/api/",
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+};
+
+export default robots;

--- a/apps/nextjs/src/app/sitemap.ts
+++ b/apps/nextjs/src/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://www.pegada.app";
+
+// Keep in sync with the `locales` list in `src/middleware.ts`.
+const LOCALES = ["en-us", "pt-br"] as const;
+
+// `localePrefix: "as-needed"` (middleware.ts) means the default locale
+// (en-us) is served unprefixed and every other locale is prefixed.
+const DEFAULT_LOCALE: (typeof LOCALES)[number] = "en-us";
+
+// Static, indexable pages. `/dog/[id]` is excluded on purpose: those pages
+// are per-swipe-card and not meant to be crawled or ranked individually.
+const PAGES = ["", "privacy-policy", "terms-of-use", "delete-account"] as const;
+
+const localizedPath = (
+  locale: (typeof LOCALES)[number],
+  page: (typeof PAGES)[number],
+) => {
+  const prefix = locale === DEFAULT_LOCALE ? "" : `/${locale}`;
+
+  return page === "" ? prefix || "/" : `${prefix}/${page}`;
+};
+
+const sitemap = (): MetadataRoute.Sitemap => {
+  return PAGES.flatMap((page) => {
+    const languages = Object.fromEntries(
+      LOCALES.map((locale) => [
+        locale,
+        `${BASE_URL}${localizedPath(locale, page)}`,
+      ]),
+    );
+
+    return LOCALES.map((locale) => ({
+      url: `${BASE_URL}${localizedPath(locale, page)}`,
+      alternates: { languages },
+    }));
+  });
+};
+
+export default sitemap;


### PR DESCRIPTION
Stack: pegada-web wave 1, PR 1/4 — based on main

📝 **DESCRIPTION:**

`/robots.txt` and `/sitemap.xml` fall under the `[locale]` dynamic segment. next-intl's middleware matcher (`/((?!api|store|_next|.*\..*).*)`) skips dotted paths on purpose, so neither request ever reaches next-intl — but nothing else claims them either, and `[locale]/page.tsx` catches both, so a crawler hitting either URL gets the homepage HTML back with a 200. No file, no rules, no sitemap.

Adds the two metadata route files Next.js looks for at the app root — `apps/nextjs/src/app/robots.ts` and `apps/nextjs/src/app/sitemap.ts`. Both sit outside `[locale]`, so they bypass the middleware regardless of its matcher and Next serves them as real `text/plain` / `application/xml` responses.

- `robots.ts`: allow everything, disallow `/api/`, point to the sitemap.
- `sitemap.ts`: `/` and `/pt-br` (home), plus both locales of `/privacy-policy`, `/terms-of-use`, `/delete-account`. Locale prefixing follows the existing `localePrefix: "as-needed"` middleware config — en-us unprefixed, pt-br prefixed — and every entry carries `alternates.languages` so each URL's hreflang pair points at its sibling. `/dog/[id]` is left out on purpose: those pages are per-swipe-card and not meant to be indexed.

🖼 **PRINTS:**

`next start` output for both routes, local build, same code as this PR:

Robots:

![robots.txt served correctly](https://raw.githubusercontent.com/GSTJ/pegada/37a5d820dc1ce7e9b21693111923a44477e9103f/web/robots-sitemap/robots-screenshot.png)

Sitemap (`view-source:` — Chrome hangs navigating `application/xml` responses directly, screenshot uses the source view instead):

![sitemap.xml served correctly](https://raw.githubusercontent.com/GSTJ/pegada/37a5d820dc1ce7e9b21693111923a44477e9103f/web/robots-sitemap/sitemap-screenshot.png)

**BEFORE** — production, `https://www.pegada.app`:

```
$ curl -sI https://www.pegada.app/robots.txt
HTTP/2 200
content-type: text/html; charset=utf-8
x-matched-path: /[locale]
server: Vercel
...

$ curl -s https://www.pegada.app/robots.txt | head -c 600
<!DOCTYPE html><html lang="en-us"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="/_next/static/css/4fcc4a514df9c67a.css" data-precedence="next"/>...<title>Pegada - Dog Dating App</title>...
```

`x-matched-path: /[locale]` confirms the theory — the request is landing on the homepage route, not a metadata route. `/sitemap.xml` returns the identical homepage HTML on production today.

**AFTER** — local `next start`, this branch:

```
$ curl -sI localhost:3000/robots.txt
HTTP/1.1 200 OK
content-type: text/plain
cache-control: public, max-age=0, must-revalidate
...

$ curl -s localhost:3000/robots.txt
User-Agent: *
Allow: /
Disallow: /api/

Sitemap: https://www.pegada.app/sitemap.xml
```

```
$ curl -sI localhost:3000/sitemap.xml
HTTP/1.1 200 OK
content-type: application/xml
cache-control: public, max-age=0, must-revalidate
...

$ curl -s localhost:3000/sitemap.xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
<url>
<loc>https://www.pegada.app/</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br" />
</url>
<url>
<loc>https://www.pegada.app/pt-br</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br" />
</url>
<url>
<loc>https://www.pegada.app/privacy-policy</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/privacy-policy" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br/privacy-policy" />
</url>
<url>
<loc>https://www.pegada.app/pt-br/privacy-policy</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/privacy-policy" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br/privacy-policy" />
</url>
<url>
<loc>https://www.pegada.app/terms-of-use</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/terms-of-use" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br/terms-of-use" />
</url>
<url>
<loc>https://www.pegada.app/pt-br/terms-of-use</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/terms-of-use" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br/terms-of-use" />
</url>
<url>
<loc>https://www.pegada.app/delete-account</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/delete-account" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br/delete-account" />
</url>
<url>
<loc>https://www.pegada.app/pt-br/delete-account</loc>
<xhtml:link rel="alternate" hreflang="en-us" href="https://www.pegada.app/delete-account" />
<xhtml:link rel="alternate" hreflang="pt-br" href="https://www.pegada.app/pt-br/delete-account" />
</url>
</urlset>
```

💛 **MY AMAZING PR CONTAINS:**

##### Does this PR change only one thing (And only what is necessary for it)?

Yes — two new files, nothing existing touched. `robots.ts` and `sitemap.ts` are the entire fix; the bug is that these routes don't exist yet, not that anything else is wrong.

Gates run locally before opening this PR: `pnpm lint` (oxlint direct, not the rtk-wrapped script), `pnpm format`, `pnpm --filter @pegada/nextjs typecheck`, `pnpm --filter @pegada/nextjs build`, then `next start` + the curl/screenshot evidence above. All clean.
