### PR TITLE
feat(web): align the landing copy with the brand banner

### DIFF
--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -5,8 +5,8 @@
     "ogImageAlt": "An iPhone running Pegada, showing the profile of a golden retriever named Maui, beside the words “Friends For Your Doggie” and “Pawfect Matches”."
   },
   "home": {
-    "title": "Find a Match For Your Dog",
-    "description": "Our algorithm ensures that your puppy finds the perfect match based on breed, location, and even personality!",
+    "title": "Friends For Your Doggie",
+    "description": "Pawfect matches by breed and personality, close enough to walk to.",
     "cta": {
       "googlePlay": "Google Play",
       "appStore": "App Store"

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -6,8 +6,8 @@
   },
 
   "home": {
-    "title": "Dê um Match Pro Seu Dog",
-    "description": "O algoritmo garante que seu cachorrinho encontre o par perfeito baseado na raça, localização e até mesmo personalidade!",
+    "title": "Amigos Pro Seu Dog",
+    "description": "Aqui do lado tem cachorro da mesma raça e com o mesmo jeito do seu.",
     "cta": {
       "googlePlay": "Google Play",
       "appStore": "App Store"


### PR DESCRIPTION
`Stack: pegada-web wave 2, PR 5 — based on main; wave 2 successors stack on this branch`

The banner in `.github/images/banner.png` says **Friends For Your Doggie** over **Pawfect Matches**. The site said "Find a Match For Your Dog". Same product, two different promises, and the art is the one people actually know. Per your call, the art wins.

Four strings, two files. No component changes.

| key | before | after |
| --- | --- | --- |
| `en.home.title` | Find a Match For Your Dog | Friends For Your Doggie |
| `en.home.description` | Our algorithm ensures that your puppy finds the perfect match based on breed, location, and even personality! | Pawfect matches by breed and personality, close enough to walk to. |
| `pt-BR.home.title` | Dê um Match Pro Seu Dog | Amigos Pro Seu Dog |
| `pt-BR.home.description` | O algoritmo garante que seu cachorrinho encontre o par perfeito baseado na raça, localização e até mesmo personalidade! | Aqui do lado tem cachorro da mesma raça e com o mesmo jeito do seu. |

![EN before/after, desktop](https://raw.githubusercontent.com/GSTJ/pegada/pr-assets/web/banner-copy/en-before-after-desktop.png)

### EN

The H1 is the banner headline verbatim. Desktop even breaks it `Friends For` / `Your Doggie`, which is the banner's own two-line lockup.

The old supporting line led with "Our algorithm ensures", which is the site talking about itself. The new one leads with what the banner promises and keeps the two matching dimensions that mean something to a dog owner. "location" is gone as a list item because "close enough to walk to" already says it, and says it better than a noun would.

### pt-BR — I built both and picked B

You asked me to decide rather than assume. Both candidates, same supporting line so the H1 is the only variable:

![pt-BR candidate matrix, mobile](https://raw.githubusercontent.com/GSTJ/pegada/pr-assets/web/banner-copy/ptbr-candidate-matrix-mobile.png)

I went with **B, "Amigos Pro Seu Dog"**. Three reasons, in the order they mattered:

1. It's the framing the banner sells. A is a fine line but it promises dating; the art promises friendship. If the art is the tiebreaker, A loses on the thing this PR is for.
2. "Dê" is the formal/subjunctive imperative. Spoken BR is "dá". Keeping A means keeping a form nobody says out loud, and I'd rather not ship that when the alternative has no verb at all to get wrong.
3. Every blind reviewer I ran read A's "dar um match" + "mesma raça" as *cruza* — a breeding service, not a walking-buddy app. "Amigos" doesn't have that reading.

Layout was a tiebreaker rather than a reason: B is 3 lines at 390px, A is 4, and 3 matches what EN now does.

The supporting line is written in Portuguese, not translated from the EN. "Aqui do lado tem cachorro" is the impersonal spoken existential, not "há" and not "existem". It leads on proximity because that's the one fact a dog owner acts on.

### Layout — the 6xl holds, `cta.tsx` untouched

`h1Lines` here is the rendered box height over the computed line-height, not a guess.

| locale | viewport | before | after |
| --- | --- | --- | --- |
| en | desktop 1440x900 | 2 lines | 2 lines |
| en | mobile 390x844 | 4 lines | **3 lines** |
| pt-BR | desktop 1440x900 | 2 lines | 2 lines |
| pt-BR | mobile 390x844 | 4 lines | **3 lines** |

Both locales got *shorter* on mobile. Longest words are "Friends" (~206px) and "Doggie" (~195px) against a 294px column, so ~30% headroom before anything wraps badly. Nothing to adjust.

### metadata

Checked, deliberately unchanged in both locales.

`en.metadata.description` already says "find other dogs to walk, play and even date" — friendship first, dating as one of the things. That reads fine under the new H1. `en.metadata.title` stays "Pegada - Dog Dating App" because it's the SEO title carrying the keyword people search, and swapping it for the banner line would trade ranking for internal tidiness. Same reasoning for pt-BR. Tell me if you'd rather I move them and I'll do it in a follow-up.

The "Android and iOS" wording is untouched, as is every Android surface.

### Reviewer: no PASS, and I'm not going to pretend otherwise

I ran the adversarial slop loop, seven rounds, fresh blind reviewer each time. It caught real things and the copy is much better for it — an earlier pt-BR draft had "combina na raça", which collides with the idiom *na raça* (by brute force), and another had "o match ... mora aqui do lado", where an abstract noun was given a home address. Both fixed.

But it never returned PASS, and the remaining flags are ones I don't think I should decide alone:

- **"Doggie" and "Pawfect"** — flagged every single round as affected-cute tone. They're also the banner's own words, which you told me win. I kept them. This is the one to overrule me on if you disagree, and it's a two-word change.
- **Title case in pt-BR** — flagged as an English convention transplanted onto Portuguese ("Amigos pro seu dog" would be native). It's also the existing site convention and matches the banner's treatment, so changing it is a design call across both locales, not a copy fix.
- **"Dog" reading as *cachorro-quente*** — real ambiguity, but it's the live string today and this PR doesn't introduce it.
- **"do seu" vs "que o seu"** in the pt-BR line — reviewers split across rounds and kept reversing each other, so I took the majority and stopped. Genuinely marginal.

Happy to take any of these in a follow-up. I just didn't want to quietly overrule the art or ship a casing change to both locales under a copy PR.

---

**Evidence:** [`pr-assets:web/banner-copy`](https://github.com/GSTJ/pegada/tree/pr-assets/web/banner-copy). Before/after at 1440x900 and 390x844, both locales, DPR 2, plus the candidate matrix and the banner as reference. Both sides are `next build` + `next start`, main at 19b8d55 and this branch, same machine, same session, animations frozen so `appearFromBottom` can't leave a half-drawn frame.

**Gates:** `oxlint` clean (run directly, exit 0 — and sanity-checked against a seeded error so it isn't a false green), `oxfmt --check` clean on 469 files, `turbo typecheck` 5/5, `next build` green.

### Deviations

- `apps/nextjs/src/app/[locale]/page.tsx:23` still has `alt="Pegada - Find a Match For Your Dog | Product Hunt"` (HTML-entity-encoded, which is why it doesn't grep). That's the Product Hunt listing name, it's outside the two files in scope, and changing it desyncs from their page. Left alone on purpose — say the word and I'll take it.
- `README.md:27` describes the match algorithm with the old "breed, location, and personality" phrasing. Same call, out of scope here.
