### PR TITLE
fix(auth): make login codes one-time use

### DIFF
--- a/packages/api/src/services/authentication-service.test.ts
+++ b/packages/api/src/services/authentication-service.test.ts
@@ -1,0 +1,62 @@
+import prisma from "@pegada/database";
+
+import { AuthenticationService } from "./authentication-service";
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.user.deleteMany({ where: { email: "otp-test@pegada.app" } });
+});
+
+const seedCode = async () =>
+  prisma.user.create({
+    data: {
+      email: "otp-test@pegada.app",
+      code: "123456",
+      codeExpiresAt: new Date(Date.now() + 60_000),
+    },
+  });
+
+describe("AuthenticationService.checkVerification", () => {
+  it("consumes a valid OTP after its first use", async () => {
+    const user = await seedCode();
+
+    await expect(
+      AuthenticationService.checkVerification({
+        email: user.email,
+        code: "123456",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      AuthenticationService.checkVerification({
+        email: user.email,
+        code: "123456",
+      }),
+    ).rejects.toThrow("Invalid OTP code");
+
+    await expect(
+      prisma.user.findUnique({ where: { id: user.id } }),
+    ).resolves.toMatchObject({ code: null, codeExpiresAt: null });
+  });
+
+  it("lets only one concurrent request consume an OTP", async () => {
+    const user = await seedCode();
+    const verify = () =>
+      AuthenticationService.checkVerification({
+        email: user.email,
+        code: "123456",
+      });
+
+    const results = await Promise.allSettled([verify(), verify()]);
+
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(
+      1,
+    );
+    expect(results.filter(({ status }) => status === "rejected")).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/api/src/services/authentication-service.ts
+++ b/packages/api/src/services/authentication-service.ts
@@ -183,17 +183,18 @@ export class AuthenticationService {
       return true;
     }
 
-    const user = await prisma.user.findUnique({
-      where: { email },
+    // Match and clear in one write so a successful OTP cannot be replayed,
+    // including by two requests that arrive at the same time.
+    const consumed = await prisma.user.updateMany({
+      where: {
+        email,
+        code,
+        codeExpiresAt: { gte: new Date() },
+      },
+      data: { code: null, codeExpiresAt: null },
     });
 
-    if (!user) throw new Error("User not found");
-
-    if (user.code !== code || !user.codeExpiresAt) {
-      throw new InvalidOTPCodeError();
-    }
-
-    if (user.codeExpiresAt < new Date()) throw new Error("Code expired");
+    if (consumed.count !== 1) throw new InvalidOTPCodeError();
 
     return true;
   }


### PR DESCRIPTION
## Summary

Login codes are now consumed when they succeed, so the same code can't be used to sign in twice.

## Details

- Matches and clears an unexpired code in one database write. Concurrent login attempts can't both win.
- Returns the existing invalid-code response when a code is wrong, expired, or already used.

## Testing steps

1. Start the local test database:

```sh
pnpm -F @pegada/database test:db:up
```

2. Run the login-code check:

```sh
pnpm exec dotenv -e .env.test -- pnpm -F @pegada/api exec jest src/services/authentication-service.test.ts --runInBand
```

3. Confirm the replay and simultaneous-request checks pass.

![Local one-time-code proof](https://raw.githubusercontent.com/GSTJ/pegada/pr-assets/security/consume-otp/otp-one-time-proof.png)