### PR TITLE
feat(web): align the landing copy with the brand banner

### DIFF
--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -5,8 +5,8 @@
     "ogImageAlt": "An iPhone running Pegada, showing the profile of a golden retriever named Maui, beside the words “Friends For Your Doggie” and “Pawfect Matches”."
   },
   "home": {
-    "title": "Find a Match For Your Dog",
-    "description": "Our algorithm ensures that your puppy finds the perfect match based on breed, location, and even personality!",
+    "title": "Friends For Your Doggie",
+    "description": "Pawfect matches by breed and personality, close enough to walk to.",
     "cta": {
       "googlePlay": "Google Play",
       "appStore": "App Store"

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -6,8 +6,8 @@
   },
 
   "home": {
-    "title": "Dê um Match Pro Seu Dog",
-    "description": "O algoritmo garante que seu cachorrinho encontre o par perfeito baseado na raça, localização e até mesmo personalidade!",
+    "title": "Amigos Pro Seu Dog",
+    "description": "Aqui do lado tem cachorro da mesma raça e com o mesmo jeito do seu.",
     "cta": {
       "googlePlay": "Google Play",
       "appStore": "App Store"


### PR DESCRIPTION
## Summary

We brought the landing headline and intro copy in line with the current Pegada brand.

## Testing steps

1. Open the landing page in English and Portuguese.
2. Confirm the new headline and description fit without clipping on a phone, tablet, and desktop.