### PR TITLE
feat(web): explain the product below the landing hero

### DIFF
--- a/apps/nextjs/src/app/[locale]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/page.tsx
@@ -2,44 +2,50 @@ import { Cta } from "@/components/cta";
 import { HeroImage } from "@/components/hero-image";
 import { Logo } from "@/components/logo";
 import { Restricter } from "@/components/restricter";
+import { Features } from "@/components/sections/features";
+import { HowItWorks } from "@/components/sections/how-it-works";
 import { t } from "@/lib/translate";
 
 const App = () => {
   return (
-    <Restricter>
-      <div className="flex flex-1 min-h-screen flex-wrap flex-col lg:flex-row">
-        <div className="p-12 flex flex-col flex-1 gap-20 justify-between items-center lg:items-start">
-          <Logo />
-          <Cta />
-          <div className="gap-4 flex flex-col items-center lg:items-start">
-            <a
-              href="https://www.producthunt.com/posts/pegada?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-pegada"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {/* oxlint-disable-next-line nextjs/no-img-element -- Product Hunt's embed is served from their host and must stay an <img>. */}
-              <img
-                src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=465930&theme=light"
-                alt="Pegada - Find&#0032;a&#0032;Match&#0032;For&#0032;Your&#0032;Dog | Product Hunt"
-                className="h-12"
-              />
-            </a>
-            <p className="text-center lg:text-left">
-              {t("home.madeWithLoveBy")}
+    <>
+      <Restricter>
+        <div className="flex flex-1 min-h-screen flex-wrap flex-col lg:flex-row">
+          <div className="p-12 flex flex-col flex-1 gap-20 justify-between items-center lg:items-start">
+            <Logo />
+            <Cta />
+            <div className="gap-4 flex flex-col items-center lg:items-start">
               <a
-                href="https://gabrieltaveira.dev"
+                href="https://www.producthunt.com/posts/pegada?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-pegada"
                 target="_blank"
-                className="text-blue-500 hover:underline"
                 rel="noreferrer"
               >
-                <b>Gabriel Taveira</b>
+                {/* oxlint-disable-next-line nextjs/no-img-element -- Product Hunt's embed is served from their host and must stay an <img>. */}
+                <img
+                  src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=465930&theme=light"
+                  alt="Pegada - Find&#0032;a&#0032;Match&#0032;For&#0032;Your&#0032;Dog | Product Hunt"
+                  className="h-12"
+                />
               </a>
-            </p>
+              <p className="text-center lg:text-left">
+                {t("home.madeWithLoveBy")}
+                <a
+                  href="https://gabrieltaveira.dev"
+                  target="_blank"
+                  className="text-blue-500 hover:underline"
+                  rel="noreferrer"
+                >
+                  <b>Gabriel Taveira</b>
+                </a>
+              </p>
+            </div>
           </div>
+          <HeroImage />
         </div>
-        <HeroImage />
-      </div>
-    </Restricter>
+      </Restricter>
+      <Features />
+      <HowItWorks />
+    </>
   );
 };
 

--- a/apps/nextjs/src/components/sections/features.tsx
+++ b/apps/nextjs/src/components/sections/features.tsx
@@ -1,0 +1,121 @@
+import { t } from "@/lib/translate";
+
+const iconProps = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.7,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+  "aria-hidden": true,
+  className: "size-8",
+} as const;
+
+/** Two dogs, one heart where they overlap. */
+const MatchIcon = () => (
+  <svg {...iconProps}>
+    <circle cx="8.4" cy="12" r="5.4" />
+    <circle cx="15.6" cy="12" r="5.4" />
+    <path
+      d="M12 14.1c-1.05-.75-2-1.5-2-2.45 0-.62.5-1.1 1.1-1.1.37 0 .7.17.9.45.2-.28.53-.45.9-.45.6 0 1.1.48 1.1 1.1 0 .95-.95 1.7-2 2.45Z"
+      fill="currentColor"
+      stroke="none"
+    />
+  </svg>
+);
+
+/** A collar with a name tag, and the tag carries a paw. */
+const ProfileIcon = () => (
+  <svg {...iconProps}>
+    <path d="M4 6c2.4 2.1 5 3.2 8 3.2S17.6 8.1 20 6" />
+    <path d="M12 9.2v1.3" />
+    <rect x="7.9" y="10.5" width="8.2" height="8.2" rx="2.6" />
+    <circle cx="10.2" cy="13.9" r="0.75" fill="currentColor" stroke="none" />
+    <circle cx="12" cy="13.4" r="0.75" fill="currentColor" stroke="none" />
+    <circle cx="13.8" cy="13.9" r="0.75" fill="currentColor" stroke="none" />
+    <ellipse
+      cx="12"
+      cy="16.4"
+      rx="1.7"
+      ry="1.3"
+      fill="currentColor"
+      stroke="none"
+    />
+  </svg>
+);
+
+/** One paw, four toes, every one a different size. */
+const InclusiveIcon = () => (
+  <svg {...iconProps}>
+    <ellipse
+      cx="5.2"
+      cy="10.4"
+      rx="1.9"
+      ry="2.3"
+      transform="rotate(-20 5.2 10.4)"
+    />
+    <ellipse cx="9.6" cy="6.6" rx="1.5" ry="2" transform="rotate(-8 9.6 6.6)" />
+    <ellipse
+      cx="14.4"
+      cy="6.9"
+      rx="2.2"
+      ry="2.7"
+      transform="rotate(8 14.4 6.9)"
+    />
+    <ellipse
+      cx="18.9"
+      cy="11"
+      rx="1.3"
+      ry="1.7"
+      transform="rotate(22 18.9 11)"
+    />
+    <path d="M12 20.6c-2.6 0-4.7-1.5-4.7-3.5 0-2 2.1-4 4.7-4s4.7 2 4.7 4c0 2-2.1 3.5-4.7 3.5Z" />
+  </svg>
+);
+
+/** A message bubble holding a shield. */
+const MessagingIcon = () => (
+  <svg {...iconProps}>
+    <path d="M19.4 13.4a2.6 2.6 0 0 1-2.6 2.6h-5.1L7.4 19.2v-3.2h-.2a2.6 2.6 0 0 1-2.6-2.6V7.4a2.6 2.6 0 0 1 2.6-2.6h9.6a2.6 2.6 0 0 1 2.6 2.6Z" />
+    <path d="M12 7.6 14.7 8.7v2.1c0 1.6-1.6 2.5-2.7 2.9-1.1-.4-2.7-1.3-2.7-2.9V8.7Z" />
+  </svg>
+);
+
+export const Features = () => {
+  const features = [
+    { key: "match", Icon: MatchIcon },
+    { key: "profile", Icon: ProfileIcon },
+    { key: "inclusive", Icon: InclusiveIcon },
+    { key: "messaging", Icon: MessagingIcon },
+  ] as const;
+
+  return (
+    <section className="px-6 py-20 sm:px-12 sm:py-28">
+      <div className="mx-auto flex max-w-7xl flex-col gap-10 lg:gap-14">
+        <h2 className="mx-auto max-w-2xl text-center text-4xl font-extrabold text-text sm:text-5xl lg:mx-0 lg:text-left">
+          {t("home.features.title")}
+        </h2>
+        <ul className="grid gap-5 sm:grid-cols-2">
+          {features.map(({ key, Icon }) => (
+            <li
+              key={key}
+              className="flex flex-col gap-5 rounded-3xl bg-card p-8 sm:p-10"
+            >
+              <span className="flex size-14 items-center justify-center rounded-2xl bg-secondary text-primary">
+                <Icon />
+              </span>
+              <div className="flex flex-col gap-2">
+                <h3 className="text-xl font-bold text-text">
+                  {t(`home.features.${key}.title`)}
+                </h3>
+                <p className="text-lg font-light text-subtitle">
+                  {t(`home.features.${key}.description`)}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};

--- a/apps/nextjs/src/components/sections/how-it-works.tsx
+++ b/apps/nextjs/src/components/sections/how-it-works.tsx
@@ -1,0 +1,106 @@
+import { t } from "@/lib/translate";
+import { cn } from "@/lib/utils";
+
+/**
+ * The brand mark reduced to a single print: four toes and a heart for the heel
+ * pad. "Pegada" is Portuguese for pawprint, so the steps are literally a walk.
+ */
+const PawStamp = ({ className }: { className?: string }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden
+    className={cn("size-7", className)}
+  >
+    <ellipse
+      cx="4.9"
+      cy="9.1"
+      rx="1.9"
+      ry="2.4"
+      transform="rotate(-24 4.9 9.1)"
+    />
+    <ellipse
+      cx="9.4"
+      cy="5.7"
+      rx="1.9"
+      ry="2.5"
+      transform="rotate(-9 9.4 5.7)"
+    />
+    <ellipse
+      cx="14.6"
+      cy="5.7"
+      rx="1.9"
+      ry="2.5"
+      transform="rotate(9 14.6 5.7)"
+    />
+    <ellipse
+      cx="19.1"
+      cy="9.1"
+      rx="1.9"
+      ry="2.4"
+      transform="rotate(24 19.1 9.1)"
+    />
+    <path d="M12 20.8c-.8-.5-5.6-3.4-5.6-6.7 0-1.8 1.4-3.1 3.1-3.1 1 0 2 .5 2.5 1.3.5-.8 1.5-1.3 2.5-1.3 1.7 0 3.1 1.3 3.1 3.1 0 3.3-4.8 6.2-5.6 6.7Z" />
+  </svg>
+);
+
+/** The pads between two prints. They grow, so the walk has a direction. */
+const Trail = () => (
+  <>
+    <span
+      aria-hidden
+      className="absolute -bottom-10 left-7 top-[3.75rem] flex -translate-x-1/2 flex-col items-center justify-center gap-2 lg:hidden"
+    >
+      <span className="size-1 rounded-full bg-primary" />
+      <span className="size-1.5 rounded-full bg-primary" />
+      <span className="size-2 rounded-full bg-primary" />
+    </span>
+    <span
+      aria-hidden
+      className="absolute left-16 top-7 hidden -translate-y-1/2 items-center justify-center gap-2.5 lg:-right-8 lg:flex"
+    >
+      <span className="size-1 rounded-full bg-primary" />
+      <span className="size-1 rounded-full bg-primary" />
+      <span className="size-1.5 rounded-full bg-primary" />
+      <span className="size-1.5 rounded-full bg-primary" />
+      <span className="size-2 rounded-full bg-primary" />
+    </span>
+  </>
+);
+
+export const HowItWorks = () => {
+  const steps = [
+    { key: "profile", tilt: "-rotate-[9deg]" },
+    { key: "swipe", tilt: "rotate-[7deg]" },
+    { key: "match", tilt: "-rotate-[4deg]" },
+    { key: "chat", tilt: "rotate-[11deg]" },
+  ] as const;
+
+  return (
+    <section className="bg-secondary px-6 py-20 sm:px-12 sm:py-28">
+      <div className="mx-auto flex max-w-7xl flex-col gap-12 lg:gap-16">
+        <h2 className="mx-auto max-w-2xl text-center text-4xl font-extrabold text-text sm:text-5xl lg:mx-0 lg:text-left">
+          {t("home.howItWorks.title")}
+        </h2>
+        <ol className="grid gap-10 lg:grid-cols-4 lg:gap-8">
+          {steps.map(({ key, tilt }, index) => (
+            <li key={key} className="relative flex gap-5 lg:flex-col lg:gap-6">
+              <span className="flex size-14 shrink-0 items-center justify-center rounded-full bg-white">
+                <PawStamp className={cn("text-primary", tilt)} />
+              </span>
+              {index < steps.length - 1 && <Trail />}
+              <div className="flex flex-col gap-2">
+                <h3 className="text-xl font-bold text-text">
+                  {t(`home.howItWorks.${key}.title`)}
+                </h3>
+                <p className="text-lg font-light text-subtitle">
+                  {t(`home.howItWorks.${key}.description`)}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+};

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -11,7 +11,45 @@
       "googlePlay": "Google Play",
       "appStore": "App Store"
     },
-    "madeWithLoveBy": "Made with ❤️ by "
+    "madeWithLoveBy": "Made with ❤️ by ",
+    "features": {
+      "title": "Built for dogs",
+      "match": {
+        "title": "Dogs that suit yours",
+        "description": "Breed, personality, and how far you'd actually walk. That's what we sort by."
+      },
+      "profile": {
+        "title": "The profile is your dog's",
+        "description": "Photos, age, the stuff they hate. You just hold the phone."
+      },
+      "inclusive": {
+        "title": "Mutts welcome",
+        "description": "Pedigree or no papers at all, everyone gets the same shot."
+      },
+      "messaging": {
+        "title": "You decide who talks to your dog",
+        "description": "The chat opens only after a match. Block or report any time."
+      }
+    },
+    "howItWorks": {
+      "title": "From profile to first walk",
+      "profile": {
+        "title": "Set up the profile",
+        "description": "Name, breed, a few photos."
+      },
+      "swipe": {
+        "title": "See who's nearby",
+        "description": "One dog at a time, from your neighborhood. Like or skip."
+      },
+      "match": {
+        "title": "Wait for the match",
+        "description": "If the other dog likes yours back, you both hear about it."
+      },
+      "chat": {
+        "title": "Say hi",
+        "description": "Pick a park, pick a time."
+      }
+    }
   },
   "privacyPolicy": {
     "metadata": {

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -28,7 +28,7 @@
       },
       "messaging": {
         "title": "You decide who talks to your dog",
-        "description": "The chat opens only after a match. Block or report any time."
+        "description": "The chat opens only after a match. Unmatch or report any time."
       }
     },
     "howItWorks": {

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -29,7 +29,7 @@
       },
       "messaging": {
         "title": "Você decide quem fala com ele",
-        "description": "Conversa só depois do match. E dá pra bloquear ou denunciar a qualquer hora."
+        "description": "Conversa só depois do match. E dá pra desfazer o match ou denunciar a qualquer hora."
       }
     },
     "howItWorks": {

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -12,7 +12,45 @@
       "googlePlay": "Google Play",
       "appStore": "App Store"
     },
-    "madeWithLoveBy": "Feito com ❤️ por "
+    "madeWithLoveBy": "Feito com ❤️ por ",
+    "features": {
+      "title": "Feito pro cachorro",
+      "match": {
+        "title": "Cachorro que combina com o seu",
+        "description": "Raça, jeito e distância que dá pra ir a pé."
+      },
+      "profile": {
+        "title": "O perfil é do seu cachorro",
+        "description": "Foto, idade, o que ele detesta. Você só segura o celular."
+      },
+      "inclusive": {
+        "title": "Vira-lata é bem-vindo",
+        "description": "Com pedigree ou sem papel nenhum, faz amizade do mesmo jeito."
+      },
+      "messaging": {
+        "title": "Você decide quem fala com ele",
+        "description": "Conversa só depois do match. E dá pra bloquear ou denunciar a qualquer hora."
+      }
+    },
+    "howItWorks": {
+      "title": "Do perfil ao primeiro passeio",
+      "profile": {
+        "title": "Cria o perfil",
+        "description": "Nome, raça, umas fotos."
+      },
+      "swipe": {
+        "title": "Vê quem tá perto",
+        "description": "Um cachorro por vez, do seu bairro. Curte ou passa."
+      },
+      "match": {
+        "title": "Espera o match",
+        "description": "Se o outro cachorro curtir o seu, os dois ficam sabendo."
+      },
+      "chat": {
+        "title": "Puxa assunto",
+        "description": "Escolhe o parque, marca a hora."
+      }
+    }
   },
   "privacyPolicy": {
     "metadata": {


### PR DESCRIPTION
## Summary

The landing page now explains what Pegada does after the hero instead of ending at the download buttons.

## Details

- Adds four product cards for matching, profiles, inclusion, and messaging.
- Adds a four-step walkthrough from creating a profile to arranging the first walk.
- Keeps the safety copy honest: matches can be undone or reported; the app does not advertise blocking.
- Ships English and Portuguese copy with responsive layouts.

## Testing steps

1. Open the landing page on a phone, tablet, and desktop.
2. Scroll past the hero and confirm every card and step is readable without clipping or overlap.
3. Switch between English and Portuguese and check that both sections stay complete.