### PR TITLE
fix(ci): limit workflow token permissions

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Dedupe runs alone first: it's a lockfile sanity check, not a per-task
   # matrix concern, and gating the matrix on it avoids paying for 3 parallel

--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   update:
     name: Create Update

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -274,6 +274,9 @@ concurrency:
   # runs). Never cancel push-to-main or scheduled runs midway.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 # Workflow-level env. Each job inherits and may extend.
 env:
   # The single source of truth for which flow stems are HARD-GATED.

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -78,6 +78,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   EXPO_NO_TELEMETRY: 1
 


### PR DESCRIPTION
## Summary

We set every workflow's default GitHub token access to read-only, while the release job keeps its explicit contents write grant.

## Details

- Adds workflow-level `contents: read` permissions to branch checks, EAS publishing, mobile E2E, and mobile releases.
- Leaves the GitHub release job's existing `contents: write` grant scoped to that job.
- Clears 13 CodeQL `actions/missing-workflow-permissions` findings.

## Testing steps

Run:

```sh
actionlint -shellcheck= .github/workflows/*.yml
```

The command should exit without errors.

![Local workflow validation](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/evidence/pegada-workflow-permissions/pegada/pegada-workflow-permissions.png)