### PR TITLE
fix(api): harden image ownership and request boundaries

### DIFF
--- a/packages/api/src/routes/input-schemas.ts
+++ b/packages/api/src/routes/input-schemas.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const messageListInputSchema = z.object({
+  matchId: z.string().uuid(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
+  gt: z.coerce.date().optional(),
+  lt: z.coerce.date().optional(),
+});
+
+export const messageSendInputSchema = z.object({
+  matchId: z.string().uuid(),
+  content: z.string().trim().min(1).max(2_000),
+});
+
+export const messageDeleteInputSchema = z.object({
+  messageId: z.string().uuid(),
+});
+
+export const swipeQueryInputSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
+  notIn: z.array(z.string().cuid()).max(500).optional(),
+});
+
+export const swipeInputSchema = z.object({
+  id: z.string().cuid(),
+  swipeType: z.enum(["NOT_INTERESTED", "MAYBE", "INTERESTED"]),
+});

--- a/packages/api/src/routes/input-validation.test.ts
+++ b/packages/api/src/routes/input-validation.test.ts
@@ -1,0 +1,59 @@
+import {
+  messageListInputSchema,
+  messageSendInputSchema,
+  swipeQueryInputSchema,
+} from "./input-schemas";
+
+const matchId = "550e8400-e29b-41d4-a716-446655440000";
+const dogId = "clh9u9mqh0000qw3i5g2h4q7p";
+
+describe("message input limits", () => {
+  it("bounds pagination", () => {
+    expect(messageListInputSchema.parse({ matchId }).limit).toBe(10);
+    expect(
+      messageListInputSchema.safeParse({ matchId, limit: 100 }).success,
+    ).toBe(true);
+    expect(
+      messageListInputSchema.safeParse({ matchId, limit: 0 }).success,
+    ).toBe(false);
+    expect(
+      messageListInputSchema.safeParse({ matchId, limit: 101 }).success,
+    ).toBe(false);
+    expect(
+      messageListInputSchema.safeParse({ matchId, limit: 1.5 }).success,
+    ).toBe(false);
+  });
+
+  it("rejects empty and oversized messages", () => {
+    expect(
+      messageSendInputSchema.safeParse({ matchId, content: "hello" }).success,
+    ).toBe(true);
+    expect(
+      messageSendInputSchema.safeParse({ matchId, content: "   " }).success,
+    ).toBe(false);
+    expect(
+      messageSendInputSchema.safeParse({
+        matchId,
+        content: "a".repeat(2_001),
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("swipe input limits", () => {
+  it("bounds page size and the exclusion list", () => {
+    expect(swipeQueryInputSchema.safeParse({ limit: 100 }).success).toBe(true);
+    expect(swipeQueryInputSchema.safeParse({ limit: 101 }).success).toBe(false);
+    expect(swipeQueryInputSchema.safeParse({ limit: -1 }).success).toBe(false);
+    expect(
+      swipeQueryInputSchema.safeParse({
+        notIn: Array.from({ length: 500 }, () => dogId),
+      }).success,
+    ).toBe(true);
+    expect(
+      swipeQueryInputSchema.safeParse({
+        notIn: Array.from({ length: 501 }, () => dogId),
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/api/src/routes/message.ts
+++ b/packages/api/src/routes/message.ts
@@ -1,28 +1,15 @@
-import { z } from "zod";
-
 import { DogService } from "../services/dog-service";
 import MessageService from "../services/message-service";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
-
-const allByMatchSchema = z.object({
-  matchId: z.string(),
-  limit: z.coerce.number().optional().default(10),
-  gt: z.coerce.date().optional(),
-  lt: z.coerce.date().optional(),
-});
-
-const sendSchema = z.object({
-  matchId: z.string(),
-  content: z.string(),
-});
-
-const deleteSchema = z.object({
-  messageId: z.string(),
-});
+import {
+  messageDeleteInputSchema,
+  messageListInputSchema,
+  messageSendInputSchema,
+} from "./input-schemas";
 
 export const messageRouter = createTRPCRouter({
   allByMatch: protectedProcedure
-    .input(allByMatchSchema)
+    .input(messageListInputSchema)
     .query(async ({ ctx, input }) => {
       const { gt, lt, limit, matchId } = input;
 
@@ -39,7 +26,7 @@ export const messageRouter = createTRPCRouter({
       return messages;
     }),
   send: protectedProcedure
-    .input(sendSchema)
+    .input(messageSendInputSchema)
     .mutation(async ({ ctx, input }) => {
       const { matchId, content } = input;
 
@@ -55,7 +42,7 @@ export const messageRouter = createTRPCRouter({
       return newMessage;
     }),
   delete: protectedProcedure
-    .input(deleteSchema)
+    .input(messageDeleteInputSchema)
     .mutation(async ({ ctx, input }) => {
       const { messageId } = input;
 

--- a/packages/api/src/routes/swipe.ts
+++ b/packages/api/src/routes/swipe.ts
@@ -1,40 +1,29 @@
-import { z } from "zod";
-
 import { DogService } from "../services/dog-service";
 import { SuggestionService } from "../services/SuggestionService/suggestion-service";
 import { SwipeService } from "../services/swipe-service";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
-
-const DEFAULT_LIMIT = 10;
-
-const querySchema = z.object({
-  limit: z.coerce.number().optional().default(DEFAULT_LIMIT),
-  notIn: z.array(z.string()).optional(),
-});
-
-const swipeSchema = z.object({
-  id: z.string(),
-  swipeType: z.enum(["NOT_INTERESTED", "MAYBE", "INTERESTED"]),
-});
+import { swipeInputSchema, swipeQueryInputSchema } from "./input-schemas";
 
 export const swipeRouter = createTRPCRouter({
-  all: protectedProcedure.input(querySchema).query(async ({ ctx, input }) => {
-    const dog = await DogService.getDogByUserId(ctx.session.user.id);
+  all: protectedProcedure
+    .input(swipeQueryInputSchema)
+    .query(async ({ ctx, input }) => {
+      const dog = await DogService.getDogByUserId(ctx.session.user.id);
 
-    if (!dog) {
-      throw new Error("Dog not found");
-    }
+      if (!dog) {
+        throw new Error("Dog not found");
+      }
 
-    const potentialMatches = await SuggestionService.getPotentialMatches(
-      dog,
-      input.limit,
-      input.notIn ?? [],
-    );
+      const potentialMatches = await SuggestionService.getPotentialMatches(
+        dog,
+        input.limit,
+        input.notIn ?? [],
+      );
 
-    return potentialMatches;
-  }),
+      return potentialMatches;
+    }),
   swipe: protectedProcedure
-    .input(swipeSchema)
+    .input(swipeInputSchema)
     .mutation(async ({ ctx, input }) => {
       const dog = await DogService.getFullDogByUserId(ctx.session.user.id);
 

--- a/packages/api/src/services/SuggestionService/suggestion-service.test.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.test.ts
@@ -154,6 +154,26 @@ describe("SuggestionService", () => {
       expect(fullPotentialMatches).toHaveLength(10);
     });
 
+    it("excludes every dog the client already loaded", async () => {
+      const [{ dog }, { dog: excludedDog }, { dog: includedDog }] =
+        await Promise.all([
+          generateFakeUserWithDog({ gender: Gender.MALE }),
+          generateFakeUserWithDog({ gender: Gender.FEMALE }),
+          generateFakeUserWithDog({ gender: Gender.FEMALE }),
+        ]);
+
+      const potentialMatches = await SuggestionService.getPotentialMatches(
+        dog,
+        LIMIT,
+        [excludedDog.id],
+      );
+
+      expect(potentialMatches.map(({ id }) => id)).toContain(includedDog.id);
+      expect(potentialMatches.map(({ id }) => id)).not.toContain(
+        excludedDog.id,
+      );
+    });
+
     it("throws an error if dog user ID is not provided", async () => {
       const dog = {} as Dog;
 

--- a/packages/api/src/services/SuggestionService/suggestion-service.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.ts
@@ -106,7 +106,10 @@ export class SuggestionService {
       throw new Error("User ID is required");
     }
 
-    const notInString = notIn.map((id) => `'${id}'`).join(",");
+    const notInCondition =
+      notIn.length > 0
+        ? Prisma.sql`AND "Dog"."id" NOT IN (${Prisma.join(notIn)})`
+        : Prisma.empty;
 
     const potentialMatches = await prisma.$queryRaw<DogSafeSchema[]>`
     /* Select all wanted columns from the subquery */
@@ -182,8 +185,9 @@ export class SuggestionService {
       JOIN "User" ON "Dog"."userId" = "User"."id"
       /* Join the User table with the MainUser table */
       JOIN "User" AS "MainUser" ON "MainUser"."id" = ${dog.userId}
-      /* Exclude dogs that are in the notInString */
-      WHERE "Dog"."id" NOT IN (${notInString})
+      WHERE TRUE
+      /* Exclude dogs already loaded on the client. */
+      ${notInCondition}
       /* Exclude dogs that have been deleted */
       AND "Dog"."deletedAt" IS NULL
       /* Exclude dogs with any rejected images and no approved images. Shadowban */

--- a/packages/api/src/services/authentication-service.test.ts
+++ b/packages/api/src/services/authentication-service.test.ts
@@ -60,3 +60,11 @@ describe("AuthenticationService.checkVerification", () => {
     );
   });
 });
+
+describe("AuthenticationService.generateCode", () => {
+  it("returns a zero-padded six-digit code", () => {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      expect(AuthenticationService.generateCode()).toMatch(/^\d{6}$/);
+    }
+  });
+});

--- a/packages/api/src/services/authentication-service.ts
+++ b/packages/api/src/services/authentication-service.ts
@@ -1,5 +1,7 @@
 import type { Language } from "@pegada/shared/i18n/types/types";
 
+import { randomInt } from "node:crypto";
+
 import prisma from "@pegada/database";
 import {
   InvalidOTPCodeError,
@@ -119,13 +121,8 @@ export class AuthenticationService {
     return user;
   }
 
-  // Generate a 6 digits number for OTP
   static generateCode() {
-    // Generate a random number between 0 and 999999
-    const num = Math.floor(Math.random() * 1000000);
-
-    // Convert the number to a string and pad it with zeros if necessary
-    return num.toString().padStart(6, "0");
+    return randomInt(0, 1_000_000).toString().padStart(6, "0");
   }
 
   async sendVerification(email: string) {

--- a/packages/api/src/services/dog-service.test.ts
+++ b/packages/api/src/services/dog-service.test.ts
@@ -1,0 +1,59 @@
+import prisma from "@pegada/database";
+import { Gender } from "@prisma/client";
+
+import { DogService } from "./dog-service";
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.message.deleteMany();
+  await prisma.match.deleteMany();
+  await prisma.interest.deleteMany();
+  await prisma.image.deleteMany();
+  await prisma.dog.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+const seedDog = async (email: string, imageUrl: string) => {
+  const user = await prisma.user.create({ data: { email } });
+
+  return prisma.dog.create({
+    data: {
+      name: "Rex",
+      gender: Gender.MALE,
+      userId: user.id,
+      images: { create: { url: imageUrl, position: 0 } },
+    },
+    include: { images: true },
+  });
+};
+
+describe("DogService.updateDog", () => {
+  it("updates the server-owned image even when the client sends another image id", async () => {
+    const [ownerDog, otherDog] = await Promise.all([
+      seedDog("image-owner@pegada.app", "https://images.test/owner.webp"),
+      seedDog("other-owner@pegada.app", "https://images.test/other.webp"),
+    ]);
+    const ownerImage = ownerDog.images[0]!;
+    const otherImage = otherDog.images[0]!;
+
+    await DogService.updateDog(ownerDog.id, {
+      images: [
+        {
+          id: otherImage.id,
+          url: ownerImage.url,
+          position: 3,
+        },
+      ],
+    });
+
+    await expect(
+      prisma.image.findUniqueOrThrow({ where: { id: ownerImage.id } }),
+    ).resolves.toMatchObject({ position: 3 });
+    await expect(
+      prisma.image.findUniqueOrThrow({ where: { id: otherImage.id } }),
+    ).resolves.toMatchObject({ position: 0 });
+  });
+});

--- a/packages/api/src/services/dog-service.ts
+++ b/packages/api/src/services/dog-service.ts
@@ -42,13 +42,17 @@ export class DogService {
     existingImages: DogServerSchema["images"] = [],
     newImages: DogServerSchema["images"] = [],
   ) =>
-    newImages?.filter((newImage) =>
-      existingImages?.find(
-        (existingImage) =>
-          newImage.url === existingImage.url &&
-          newImage.position !== existingImage.position,
-      ),
-    ) ?? ([] as DogImagesWithId);
+    newImages.flatMap((newImage) => {
+      const existingImage = existingImages.find(
+        (candidate) => candidate.url === newImage.url,
+      );
+
+      if (!existingImage?.id || newImage.position === existingImage.position) {
+        return [];
+      }
+
+      return [{ ...newImage, id: existingImage.id }];
+    });
 
   static #classifyImages = (
     existingImages: DogServerSchema["images"],

--- a/packages/api/src/services/image-service.test.ts
+++ b/packages/api/src/services/image-service.test.ts
@@ -1,0 +1,14 @@
+import { createTemporaryUploadKey } from "./image-service";
+
+describe("createTemporaryUploadKey", () => {
+  it("creates distinct UUID-backed keys", () => {
+    const keys = Array.from({ length: 100 }, createTemporaryUploadKey);
+
+    expect(new Set(keys)).toHaveProperty("size", keys.length);
+    for (const key of keys) {
+      expect(key).toMatch(
+        /^dogs-temporary\/[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/,
+      );
+    }
+  });
+});

--- a/packages/api/src/services/image-service.ts
+++ b/packages/api/src/services/image-service.ts
@@ -1,6 +1,8 @@
 import type { DogServerSchema } from "@pegada/shared/schemas/dog-schema";
 import type { Image } from "@prisma/client";
 
+import { randomUUID } from "node:crypto";
+
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import prisma from "@pegada/database";
@@ -16,6 +18,9 @@ import {
 } from "../shared/file-upload";
 
 const PERMANENT_STORAGE_FOLDER = "dogs";
+
+export const createTemporaryUploadKey = () =>
+  `${TEMPORARY_UPLOAD_PREFIX}/${randomUUID()}`;
 
 /**
  * Storage-agnostic upload descriptor returned by `image.signedUpload`.
@@ -42,7 +47,7 @@ export class ImageService {
    * MIN_APP_VERSION is past the release that switched to `signedUpload`.
    */
   static async getSignedUrl() {
-    const key = `${TEMPORARY_UPLOAD_PREFIX}/${Date.now().toString()}`;
+    const key = createTemporaryUploadKey();
 
     const command = new PutObjectCommand({
       Bucket: config.AWS_S3_BUCKET_NAME,
@@ -64,7 +69,7 @@ export class ImageService {
    * just builds its own descriptor here.
    */
   static async getSignedUpload(): Promise<SignedUpload> {
-    const key = `${TEMPORARY_UPLOAD_PREFIX}/${Date.now().toString()}`;
+    const key = createTemporaryUploadKey();
 
     if (r2UploadsEnabled) {
       const command = new PutObjectCommand({


### PR DESCRIPTION
## Summary

This closes an authorization hole in dog-image reordering and tightens the public API inputs that can drive expensive work.

## Details

- Resolves reordered images from the authenticated dog's database records, so a forged image ID cannot update another owner's image.
- Bounds message and swipe pagination, message length, and the client-side exclusion list.
- Validates match, message, and dog IDs before they reach service code.
- Fixes the exclusion query so every dog already loaded on the client is actually omitted.
- Generates OTPs and temporary upload keys with cryptographic randomness.

## Testing steps

1. Reorder a dog photo and confirm the new order is saved.
2. Load another page of dogs and confirm cards already on screen do not repeat.
3. Send a normal chat message and load older messages.
4. Confirm blank or oversized messages and oversized page requests are rejected.
5. Submit malformed match, message, and dog IDs and confirm the API returns a validation error.
6. Run `pnpm exec dotenv -e .env.test -- pnpm -F @pegada/api exec jest src/services/authentication-service.test.ts src/services/image-service.test.ts --runInBand` and confirm both token-generation suites pass. The randomness source has no useful manual UI check.