### PR TITLE
fix(mobile): harden PostHog release uploads

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -26,7 +26,10 @@ const posthogSourcemapsEnabled = Boolean(process.env.POSTHOG_CLI_API_KEY);
 // earlier build. Keep that conflict from failing the native archive.
 const posthogSourcemapPlugins: NonNullable<ExpoConfig["plugins"]> =
   posthogSourcemapsEnabled
-    ? [["posthog-react-native/expo", { skipOnConflict: true }]]
+    ? [
+        "./plugins/with-posthog-release-version",
+        ["posthog-react-native/expo", { skipOnConflict: true }],
+      ]
     : [];
 
 const config: ExpoConfig = {

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -22,6 +22,12 @@ const defaultLocaleNativeStrings = require("@pegada/shared/i18n/locales/en/nativ
 // pull POSTHOG_CLI_API_KEY from the EAS "production" environment, so the
 // plugin activates there automatically.
 const posthogSourcemapsEnabled = Boolean(process.env.POSTHOG_CLI_API_KEY);
+// Rebuilding the same release can encounter a symbol set uploaded by an
+// earlier build. Keep that conflict from failing the native archive.
+const posthogSourcemapPlugins: NonNullable<ExpoConfig["plugins"]> =
+  posthogSourcemapsEnabled
+    ? [["posthog-react-native/expo", { skipOnConflict: true }]]
+    : [];
 
 const config: ExpoConfig = {
   /**
@@ -208,9 +214,7 @@ const config: ExpoConfig = {
     // posthogSourcemapsEnabled above) -- omitted entirely from the plugins
     // list otherwise, so a plain local build never has the upload step in
     // its generated Xcode/Gradle project.
-    ...(posthogSourcemapsEnabled
-      ? (["posthog-react-native/expo"] as const)
-      : []),
+    ...posthogSourcemapPlugins,
   ],
   androidStatusBar: {
     barStyle: "dark-content",

--- a/apps/mobile/plugins/with-posthog-release-version.js
+++ b/apps/mobile/plugins/with-posthog-release-version.js
@@ -1,0 +1,50 @@
+// @ts-nocheck
+/**
+ * Make PostHog read the iOS release version from the Info.plist that EAS
+ * updates before archiving. Expo's Xcode template leaves MARKETING_VERSION
+ * and CURRENT_PROJECT_VERSION at 1.0/1, which otherwise sends sourcemaps to
+ * the wrong PostHog release.
+ */
+const { withXcodeProject } = require("expo/config-plugins");
+
+const RELEASE_VERSION_SNIPPET = `# posthog-release-version
+POSTHOG_INFO_PLIST="\${PROJECT_DIR}/\${INFOPLIST_FILE}"
+if [ -f "$POSTHOG_INFO_PLIST" ]; then
+  export MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$POSTHOG_INFO_PLIST")"
+  export CURRENT_PROJECT_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$POSTHOG_INFO_PLIST")"
+fi`;
+
+const withPostHogReleaseVersion = (config) => {
+  return withXcodeProject(config, (modConfig) => {
+    const bundlePhase = modConfig.modResults.pbxItemByComment(
+      "Bundle React Native code and images",
+      "PBXShellScriptBuildPhase",
+    );
+
+    if (!bundlePhase) {
+      throw new Error(
+        "withPostHogReleaseVersion: could not find the React Native bundle phase",
+      );
+    }
+
+    const script = JSON.parse(bundlePhase.shellScript);
+    if (script.includes("# posthog-release-version")) {
+      return modConfig;
+    }
+
+    const posthogCommand = /^.*posthog-xcode\.sh.*$/m;
+    if (!posthogCommand.test(script)) {
+      throw new Error(
+        "withPostHogReleaseVersion: PostHog did not add its Xcode bundle command",
+      );
+    }
+
+    bundlePhase.shellScript = JSON.stringify(
+      script.replace(posthogCommand, `${RELEASE_VERSION_SNIPPET}\n\n$&`),
+    );
+
+    return modConfig;
+  });
+};
+
+module.exports = withPostHogReleaseVersion;


### PR DESCRIPTION
## Summary

Stops production native builds from failing on existing PostHog symbol sets and keeps iOS sourcemaps attached to the version EAS actually built.

## Details

- Passes `skipOnConflict` through the official Expo plugin for Android and iOS.
- Reads the iOS version and build number from the Info.plist that EAS updates before archiving, instead of Xcode's static 1.0/1 template values.
- Keeps sourcemap uploads enabled when the PostHog API key is present. Local builds without the key stay unchanged.

## Verification

- A production prebuild writes `posthogReactNativeSkipOnConflict = true` into the Android Gradle project.
- The same prebuild adds `--posthog-skip-on-conflict` and the EAS-updated Info.plist version lookup to the Xcode bundle phase.
- A credential-free prebuild still omits the PostHog upload hooks.
- Format, lint, typecheck, and all 79 tests pass locally.
