### PR TITLE
fix(release): preserve changelog headings in tag notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Generated from conventional commits by `.github/scripts/changelog.py`. Run `pnpm changelog` to refresh it.
 
+## v1.5.0-rc3 (2026-08-03)
+
+### Fixes
+
+- **mobile:** harden PostHog release uploads ([#135](https://github.com/GSTJ/pegada/pull/135)) ([`a201ab5`](https://github.com/GSTJ/pegada/commit/a201ab59ba31bf7d792dc564c3ed918a1807833b))
+- **release:** keep tag and release compare links aligned ([#134](https://github.com/GSTJ/pegada/pull/134)) ([`d6ca029`](https://github.com/GSTJ/pegada/commit/d6ca0298acb4083d4726cf3c462441605a6aa513))
+
+[Full diff](https://github.com/GSTJ/pegada/compare/v1.5.0-rc2...v1.5.0-rc3)
+
 ## v1.5.0-rc2 (2026-08-03)
 
 ### Features

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -64,7 +64,7 @@ if [ "${DRY_RUN:-0}" = "1" ]; then
   exit 0
 fi
 
-git tag -a "$TAG" -m "$MESSAGE"
+git tag -a --cleanup=verbatim "$TAG" -m "$MESSAGE"
 git push "$REMOTE" "refs/tags/$TAG"
 
 echo "Tagged and pushed $TAG. release-mobile.yml takes it from here."


### PR DESCRIPTION
## Summary

Preserves Markdown section headings in annotated release tags and adds the generated v1.5.0-rc3 changelog entry.

## Details

- Creates annotated tags with `--cleanup=verbatim`, so Git does not strip lines beginning with `#`.
- Keeps the published rc3 tag immutable; the corrected behavior starts with the next tag.

## Verification

- A local annotated tag message matches its input byte for byte with the `### Fixes` heading intact.
- `pnpm changelog` leaves the committed changelog unchanged.
- `bash -n`, ShellCheck, and Python byte-compilation pass for the release scripts.
- Format, lint, typecheck, and all 79 tests pass locally.
