### PR TITLE
fix(release): preserve the full annotated tag message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Generated from conventional commits by `.github/scripts/changelog.py`. Run `pnpm changelog` to refresh it.
 
+## v1.5.0-rc4 (2026-08-03)
+
+### Fixes
+
+- **release:** preserve changelog headings in tag notes ([#136](https://github.com/GSTJ/pegada/pull/136)) ([`a869028`](https://github.com/GSTJ/pegada/commit/a869028b38a69e5fb8ecbf6a21c68d347548c0e1))
+
+[Full diff](https://github.com/GSTJ/pegada/compare/v1.5.0-rc3...v1.5.0-rc4)
+
 ## v1.5.0-rc3 (2026-08-03)
 
 ### Fixes

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -55,16 +55,15 @@ if python3 .github/scripts/changelog.py --is-breaking HEAD --previous "$PREVIOUS
   TITLE="$TAG (contains breaking changes)"
 fi
 
-MESSAGE=$(printf '%s\n\n%s\n' "$TITLE" "$NOTES")
-
 if [ "${DRY_RUN:-0}" = "1" ]; then
-  printf '%s\n' "$MESSAGE"
+  printf '%s\n\n%s\n' "$TITLE" "$NOTES"
   echo
   echo "(dry run, nothing tagged)"
   exit 0
 fi
 
-git tag -a --cleanup=verbatim "$TAG" -m "$MESSAGE"
+printf '%s\n\n%s\n' "$TITLE" "$NOTES" \
+  | git tag -a --cleanup=verbatim "$TAG" -F -
 git push "$REMOTE" "refs/tags/$TAG"
 
 echo "Tagged and pushed $TAG. release-mobile.yml takes it from here."


### PR DESCRIPTION
## Summary

Preserves the complete annotated release-tag message and adds the generated v1.5.0-rc4 changelog entry.

## Details

- Pipes the rendered message into `git tag -F -`, avoiding Bash command substitution that removed its final newline.
- Keeps `--cleanup=verbatim`, so Markdown headings remain intact.
- Leaves the published rc4 tag immutable; the corrected behavior starts with the next tag.

## Verification

- A local annotated tag and the generator output match byte for byte at 288 bytes each.
- `pnpm changelog` regenerates the committed changelog entry.
- `bash -n`, ShellCheck, and Python byte-compilation pass for the release scripts.
- Format, lint, typecheck, and all 79 tests pass locally.
