### PR TITLE
deps: bump brace-expansion to 5.0.9

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -8,8 +8,9 @@ Fixes typescript errors
 
 # Minimatch Patches (3.1.5 and 9.0.9)
 
-brace-expansion <= 5.0.7 is CVE-2026-14257, and the fix only exists on 5.x.
+brace-expansion <= 5.0.8 is vulnerable to CVE-2026-14257 and its incomplete
+follow-up fix, GHSA-rgw5-rvv9-x895. Both fixes only exist on 5.x.
 Both of these minimatch lines are EOL on brace-expansion 1.x/2.x, so the root
-override forces 5.0.8 everywhere and these patches teach them to read the named
+override forces the patched 5.x line everywhere and these patches read the named
 `expand` export 5.x switched to. Drop them if either minimatch ever ships a
 release that depends on brace-expansion 5.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@react-native-async-storage/async-storage': 2.2.0
   react-native-svg: 15.15.3
   '@xmldom/xmldom': ^0.8.13
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   braces: ^3.0.3
   diff@4: ^4.0.4
   esbuild: ^0.28.1
@@ -3851,8 +3851,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -11583,7 +11583,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14528,15 +14528,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5(patch_hash=476a0494e59e628ca5f44098245651424dd99db4757bc172a9e7bf6c4fe9daf1):
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9(patch_hash=291dd2efac7e5cd6b31364c2548f9e97e74ae39487476509acbf3218cea1b813):
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ overrides:
   "@react-native-async-storage/async-storage": 2.2.0
   react-native-svg: 15.15.3
   "@xmldom/xmldom": ^0.8.13
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   braces: ^3.0.3
   diff@4: ^4.0.4
   esbuild: ^0.28.1


### PR DESCRIPTION
## Summary

We bumped `brace-expansion` to 5.0.9, clearing the new high-severity denial-of-service advisory across every transitive path.

## Details

- Updates the root override and lockfile from 5.0.8 to 5.0.9 for `GHSA-rgw5-rvv9-x895`.
- Keeps the compatibility patches for `minimatch` 3 and 9, and updates their security rationale.

## Testing steps

1. Run:

```sh
pnpm audit --prod --audit-level low && pnpm test
```

2. Confirm the audit prints `No known vulnerabilities found` and the command exits successfully.
