### PR TITLE
fix(mobile): trigger OTA publishes for shared changes

### DIFF
--- a/.github/scripts/test_release.py
+++ b/.github/scripts/test_release.py
@@ -12,6 +12,18 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parent
 CHANGELOG_SCRIPT = SCRIPTS / "changelog.py"
 TAG_SCRIPT = SCRIPTS.parents[1] / "scripts" / "tag-release.sh"
+MOBILE_DEPLOY_WORKFLOW = SCRIPTS.parents[1] / ".github" / "workflows" / "deploy-mobile.yml"
+
+
+class MobileDeployWorkflowTest(unittest.TestCase):
+    def test_publish_paths_cover_mobile_runtime_inputs(self) -> None:
+        workflow = MOBILE_DEPLOY_WORKFLOW.read_text()
+
+        self.assertIn('- "apps/mobile/**"', workflow)
+        self.assertIn('- "packages/shared/**"', workflow)
+        self.assertIn('- "pnpm-lock.yaml"', workflow)
+        self.assertNotIn('- "apps/shared/**"', workflow)
+        self.assertNotIn('- ".github/scripts/**"', workflow)
 
 
 class GitRepositoryTest(unittest.TestCase):

--- a/.github/workflows/deploy-mobile.yml
+++ b/.github/workflows/deploy-mobile.yml
@@ -5,9 +5,9 @@ on:
       - main
     paths:
       - "apps/mobile/**"
-      - "apps/shared/**"
+      - "packages/shared/**"
+      - "pnpm-lock.yaml"
       - ".github/workflows/deploy-mobile.yml"
-      - ".github/scripts/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

The mobile OTA workflow now publishes when the shared package or lockfile changes, and skips release-helper-only changes.

## Details

- Replaces `apps/shared/**` with the real `packages/shared/**` path.
- Watches `pnpm-lock.yaml`, since transitive dependency changes can alter the mobile bundle.
- Excludes unrelated release helper changes under `.github/scripts/**`.

## Testing steps

```sh
python3 -m unittest discover -s .github/scripts -p 'test_release.py' -v
```

The output should show the mobile publish path test as `ok`, and the command should exit successfully.
