### PR TITLE
chore(deps): enforce a 14-day package age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,17 +55,36 @@ overrides:
   ws@8: ^8.21.0
 
 # pnpm 11 refuses to resolve a version published less than `minimumReleaseAge`
-# ago (24h by default) as a supply-chain guard. The magic-* packages were
-# published the same day this migration landed, so without these entries a
-# fresh `pnpm install` cannot resolve them at all.
+# ago. These exact versions were already reviewed and committed before the
+# 14-day guard landed; future versions still have to age normally.
+minimumReleaseAge: 20160
 minimumReleaseAgeExclude:
+  - "@emnapi/runtime@1.11.3"
+  - "@eslint-community/eslint-utils@4.10.1"
+  - "@next/env@15.5.22"
+  - "@next/swc-darwin-arm64@15.5.22"
+  - "@next/swc-darwin-x64@15.5.22"
+  - "@next/swc-linux-arm64-gnu@15.5.22"
+  - "@next/swc-linux-arm64-musl@15.5.22"
+  - "@next/swc-linux-x64-gnu@15.5.22"
+  - "@next/swc-linux-x64-musl@15.5.22"
+  - "@next/swc-win32-arm64-msvc@15.5.22"
+  - "@next/swc-win32-x64-msvc@15.5.22"
+  - "@posthog/browser-common@0.2.1"
+  - "@posthog/core@1.45.1"
+  - "@posthog/types@1.398.0"
+  - baseline-browser-mapping@2.11.3
+  - brace-expansion@5.0.9
+  - electron-to-chromium@1.5.396
   - eslint-plugin-safe-jsx@1.3.0
-  - magic-codemods@1.1.0
-  - magic-observability@1.0.0
-  - magic-oxfmt-config@1.2.0
-  - magic-oxlint-config@1.2.0
-  - magic-tsconfig@1.2.0
-  - magic-oxlint-plugin@1.1.0
+  - fast-uri@3.1.5
+  - flatted@3.4.3
+  - "magic-*"
+  - next@15.5.22
+  - node-stream-zip@1.16.0
+  - postcss@8.5.23
+  - posthog-js@1.407.2
+  - sax@1.6.1
 
 # pnpm 10+ does not run dependency install scripts unless they are listed here,
 # and pnpm 11 makes an unanswered list a hard install failure. Every entry ran


### PR DESCRIPTION
## Summary

Pegada now quarantines newly published third-party packages for 14 days before pnpm can install them.

## Details

- Sets the pnpm release-age floor to 20,160 minutes, matching the shared Renovate preset.
- Keeps `magic-*` first-party packages immediately available.
- Grandfathers only exact third-party versions already reviewed in the committed lockfile. New versions still wait 14 days.
- Renovate remains the sole dependency updater and inherits merge-after-green for eligible non-major updates from `GSTJ/magic`.

## Testing steps

1. Install dependencies from the branch:

```sh
pnpm install --frozen-lockfile
```

2. Confirm the install completes successfully.
3. Run the local checks:

```sh
pnpm format && pnpm lint && pnpm typecheck && pnpm test
pnpm exec dotenv -e .env.test -- turbo build --env-mode=loose --force
```

4. Confirm formatting, lint, type checks, tests, and the production build complete successfully.

![Local verification](https://raw.githubusercontent.com/GSTJ/pr-assets-dump/e1fd60a3c9c52eaf3dc8148c85ad862bb71ed59b/evidence/pegada-renovate-14d-a2884de.png)
