### PR TITLE
docs(release): prepare v1.5.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Generated from conventional commits by `.github/scripts/changelog.py`. Run `pnpm changelog` to refresh it.
 
+## v1.5.1 (2026-08-26)
+
+### Fixes
+
+- **mobile:** support Google Play Billing Library 8 ([#146](https://github.com/GSTJ/pegada/pull/146)) ([`4441cc4`](https://github.com/GSTJ/pegada/commit/4441cc458587984fa11ea89ac916dc82885ec5e6))
+
+[Full diff](https://github.com/GSTJ/pegada/compare/v1.5.0...v1.5.1)
+
 ## v1.5.0 (2026-08-10)
 
 ### Breaking changes


### PR DESCRIPTION
## Summary

Adds the generated v1.5.1 changelog entry before tagging the Billing Library 8 release.

## Details

- Records #146 under Fixes.
- Links the merged commit and the v1.5.0...v1.5.1 diff.
- Leaves tag creation for the clean, updated main branch after this merges.

## Testing steps

1. Run `DRY_RUN=1 ./scripts/tag-release.sh`.
2. Confirm the output says the changelog is ready and lists #146 as the only fix.
