### PR TITLE
fix: survive the cold-start login path and keep production warm

### DIFF
--- a/apps/mobile/src/contexts/trpc-provider.tsx
+++ b/apps/mobile/src/contexts/trpc-provider.tsx
@@ -34,6 +34,33 @@ type ResponseJSON = {
   };
 };
 
+/**
+ * Ceiling on a single HTTP attempt.
+ *
+ * There was no timeout at all before this: a connection that opened and then
+ * stalled left the mutation `isPending` forever, with no error, no toast and
+ * no way out but killing the app. The value has to clear a genuinely cold
+ * path — a Vercel function that has to boot, a Prisma engine that has to
+ * initialise, and a database that may have to wake from autosuspend — which
+ * is seconds, not hundreds of milliseconds. Retries are layered on top (see
+ * services/transient-retry.ts), so this is per attempt, not per user action.
+ */
+export const REQUEST_TIMEOUT_MS = 15_000;
+
+const fetchWithTimeout = async (url: string, options: RequestInit) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  // tRPC passes its own signal for query cancellation; honour both.
+  options.signal?.addEventListener("abort", () => controller.abort());
+
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
 export const trpcQueryClient = api.createClient({
   links: [
     httpBatchLink({
@@ -56,7 +83,10 @@ export const trpcQueryClient = api.createClient({
         return Object.fromEntries(headers);
       },
       fetch: async (url, options): Promise<Response> => {
-        const res = await fetch(url as string, options as RequestInit);
+        const res = await fetchWithTimeout(
+          url as string,
+          options as RequestInit,
+        );
 
         // The API base URL must resolve directly to the tRPC handler with NO
         // redirect. `pegada.app` 308-redirects to `www.pegada.app`, and RN's
@@ -87,11 +117,18 @@ export const trpcQueryClient = api.createClient({
           }
         }
 
-        return {
-          ...res,
-          // Already decoded here
-          json: () => Promise.resolve(responsesJSON),
-        };
+        // Rebuilt rather than spread: `status`, `ok` and `headers` live on
+        // Response.prototype, so `{ ...res }` copied none of them and every
+        // response reached the link as an object whose status was
+        // `undefined`. The retry policy in services/transient-retry.ts needs
+        // a real status to tell a 5xx worth retrying from a 4xx that is final.
+        const body = JSON.stringify(responsesJSON);
+
+        return new Response(body, {
+          status: res.status,
+          statusText: res.statusText,
+          headers: { "content-type": "application/json" },
+        });
       },
     }),
   ],

--- a/apps/mobile/src/services/transient-retry.test.ts
+++ b/apps/mobile/src/services/transient-retry.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The defect: the login mutation ran on TanStack's stock mutation defaults,
+ * which are `retry: 0`. Combined with a tRPC client that had no request
+ * timeout at all, a single transient failure on the first request of a cold
+ * deployment — a queue hop that blipped, a gateway timeout, a dropped
+ * connection on app launch — surfaced as "An error occurred while logging in."
+ * and stayed there. The user's only recovery was to tap Continue again, which
+ * is exactly what made the second attempt work.
+ *
+ * Retrying auth is only safe if it is narrow. `OTPRequiredError` is thrown on
+ * the *happy* path and `InvalidOTPCodeError` on a real rejection; retrying
+ * either would resend emails or burn a code the user typed correctly. So the
+ * policy below retries transport-level failures and 5xx only, and treats any
+ * error carrying an `error_code` as final.
+ */
+import {
+  TRANSIENT_RETRY_ATTEMPTS,
+  shouldRetryTransient,
+  transientRetryDelayMs,
+} from "./transient-retry";
+
+/** The shape tRPC hands `onError` for a server error it could parse. */
+const serverError = (httpStatus: number) => ({
+  data: { httpStatus, code: "INTERNAL_SERVER_ERROR" },
+});
+
+/** The shape the API's errorFormatter emits for an IntentionalError. */
+const intentionalError = (error_code: string) => ({
+  data: { error: { error_code, code: "UNAUTHORIZED" } },
+});
+
+describe("shouldRetryTransient", () => {
+  it("retries a network failure, which carries no response data at all", () => {
+    expect(
+      shouldRetryTransient(0, new TypeError("Network request failed")),
+    ).toBe(true);
+  });
+
+  it("retries a gateway timeout and the other 5xx", () => {
+    expect(shouldRetryTransient(0, serverError(500))).toBe(true);
+    expect(shouldRetryTransient(0, serverError(502))).toBe(true);
+    expect(shouldRetryTransient(0, serverError(504))).toBe(true);
+  });
+
+  it("never retries an intentional error", () => {
+    // Retrying OTP_REQUIRED would send the user a second code for one tap.
+    expect(shouldRetryTransient(0, intentionalError("OTP_REQUIRED"))).toBe(
+      false,
+    );
+    // Retrying INVALID_OTP_CODE would report a correct code as invalid, since
+    // checkVerification consumes the code on the attempt that matched.
+    expect(shouldRetryTransient(0, intentionalError("INVALID_OTP_CODE"))).toBe(
+      false,
+    );
+  });
+
+  it("never retries a 4xx, including the rate limiter", () => {
+    expect(shouldRetryTransient(0, serverError(400))).toBe(false);
+    expect(shouldRetryTransient(0, serverError(401))).toBe(false);
+    expect(shouldRetryTransient(0, serverError(429))).toBe(false);
+  });
+
+  it("stops once the attempts are spent", () => {
+    const error = serverError(500);
+
+    expect(shouldRetryTransient(TRANSIENT_RETRY_ATTEMPTS - 1, error)).toBe(
+      true,
+    );
+    expect(shouldRetryTransient(TRANSIENT_RETRY_ATTEMPTS, error)).toBe(false);
+  });
+
+  it("stays unaggressive — a couple of tries, not a storm", () => {
+    expect(TRANSIENT_RETRY_ATTEMPTS).toBeGreaterThan(0);
+    expect(TRANSIENT_RETRY_ATTEMPTS).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("transientRetryDelayMs", () => {
+  it("backs off between attempts", () => {
+    expect(transientRetryDelayMs(1)).toBeGreaterThan(transientRetryDelayMs(0));
+  });
+
+  it("stays inside a wait a user will actually sit through", () => {
+    for (let attempt = 0; attempt < TRANSIENT_RETRY_ATTEMPTS; attempt++) {
+      expect(transientRetryDelayMs(attempt)).toBeLessThanOrEqual(2_000);
+    }
+  });
+});

--- a/apps/mobile/src/services/transient-retry.ts
+++ b/apps/mobile/src/services/transient-retry.ts
@@ -1,5 +1,3 @@
-import { get } from "lodash";
-
 /**
  * How many times a transient failure is retried after the first attempt.
  *
@@ -33,9 +31,17 @@ export const shouldRetryTransient = (
 ): boolean => {
   if (failureCount >= TRANSIENT_RETRY_ATTEMPTS) return false;
 
-  if (get(error, "data.error.error_code")) return false;
+  const data =
+    error && typeof error === "object" && "data" in error
+      ? (
+          error as {
+            data?: { httpStatus?: unknown; error?: { error_code?: unknown } };
+          }
+        ).data
+      : undefined;
+  if (data?.error?.error_code) return false;
 
-  const httpStatus = get(error, "data.httpStatus");
+  const httpStatus = data?.httpStatus;
 
   if (typeof httpStatus === "number") return httpStatus >= 500;
 

--- a/apps/mobile/src/services/transient-retry.ts
+++ b/apps/mobile/src/services/transient-retry.ts
@@ -1,0 +1,44 @@
+import { get } from "lodash";
+
+/**
+ * How many times a transient failure is retried after the first attempt.
+ *
+ * Two, deliberately. The failure this exists for is a cold first request —
+ * one blip, then the stack is warm — so a second try recovers nearly all of
+ * it, and a third mostly just delays the error message the user needs to see.
+ */
+export const TRANSIENT_RETRY_ATTEMPTS = 2;
+
+const BASE_RETRY_DELAY_MS = 400;
+
+/** Exponential backoff, capped so nobody watches a spinner for 30 seconds. */
+export const transientRetryDelayMs = (attemptIndex: number) =>
+  Math.min(BASE_RETRY_DELAY_MS * 2 ** attemptIndex, 2_000);
+
+/**
+ * Is this failure worth another attempt?
+ *
+ * Errors the product raises on purpose carry an `error_code` (see
+ * packages/shared/errors/errors.ts) and are always final — `OTP_REQUIRED` is
+ * the happy path and retrying it emails a second code, `INVALID_OTP_CODE`
+ * means the code was already consumed and retrying reports a correct code as
+ * invalid. Everything else is judged on the HTTP status: 5xx is the server
+ * having a bad moment, 4xx is us, and no status at all means the request never
+ * produced a parseable response — a dropped connection, a timeout, or the
+ * gateway's HTML error page.
+ */
+export const shouldRetryTransient = (
+  failureCount: number,
+  error: unknown,
+): boolean => {
+  if (failureCount >= TRANSIENT_RETRY_ATTEMPTS) return false;
+
+  if (get(error, "data.error.error_code")) return false;
+
+  const httpStatus = get(error, "data.httpStatus");
+
+  if (typeof httpStatus === "number") return httpStatus >= 500;
+
+  // No parseable tRPC envelope: transport-level failure. Worth one more try.
+  return true;
+};

--- a/apps/mobile/src/views/(auth)/OneTimeCode/index.tsx
+++ b/apps/mobile/src/views/(auth)/OneTimeCode/index.tsx
@@ -23,6 +23,10 @@ import { sendError } from "@/services/error-tracking";
 import { getError } from "@/services/get-error";
 import { getInitialRouteName } from "@/services/get-initial-route-name";
 import { StorageKeys, storeData } from "@/services/storage";
+import {
+  shouldRetryTransient,
+  transientRetryDelayMs,
+} from "@/services/transient-retry";
 import { useDidMountEffect } from "@/services/utils";
 
 import { Underline } from "../SignIn/components/HeroText";
@@ -53,6 +57,11 @@ const OneTimeCode = () => {
   const insetTop = Math.max(15 + insets.top, 50);
 
   const loginMutation = api.authentication.login.useMutation({
+    // Same policy as the email step. INVALID_OTP_CODE carries an `error_code`
+    // and is never retried, so a code the server already consumed is reported
+    // once rather than re-submitted.
+    retry: shouldRetryTransient,
+    retryDelay: transientRetryDelayMs,
     onSuccess: async (data) => {
       try {
         // The last code cell is still focused, and nothing on the screen this

--- a/apps/mobile/src/views/(auth)/SignIn/index.tsx
+++ b/apps/mobile/src/views/(auth)/SignIn/index.tsx
@@ -15,6 +15,10 @@ import { useKeyboardAwareSafeAreaInsets } from "@/hooks/use-keyboard-aware-safe-
 import { useKeyboardOverlap } from "@/hooks/use-keyboard-aware-scroll";
 import { sendError } from "@/services/error-tracking";
 import { getError } from "@/services/get-error";
+import {
+  shouldRetryTransient,
+  transientRetryDelayMs,
+} from "@/services/transient-retry";
 import { SceneName } from "@/types/scene-name";
 
 import EmailInput from "./components/EmailInput";
@@ -59,6 +63,11 @@ const InsertEmail = () => {
   const [error, setError] = useState<string | undefined>(undefined);
 
   const loginMutation = api.authentication.login.useMutation({
+    // The first request of a cold deployment is the one that fails, and
+    // mutations do not retry by default. See services/transient-retry.ts for
+    // why this is safe to retry and why OTP_REQUIRED never is.
+    retry: shouldRetryTransient,
+    retryDelay: transientRetryDelayMs,
     onError: (error) => {
       // Resend code
       if (getError(error, OTPRequiredError)) {

--- a/packages/api/src/queue/enqueue.test.ts
+++ b/packages/api/src/queue/enqueue.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The defect: `enqueue` published to Vercel Queues through a single bare
+ * `send()`. Under the hood @vercel/queue mints an OIDC token and POSTs to the
+ * queue service with `fetch` — no timeout, no retry of its own, and every
+ * non-2xx becomes a throw. So one transient blip on that hop threw straight
+ * out of `AuthenticationService.sendVerification`, past the OTP-required
+ * happy path, and reached the app as the generic "An error occurred while
+ * logging in."
+ *
+ * Worse, the OTP row is written *before* the enqueue, so the code existed in
+ * the database while no email was ever sent, and the mobile client has no
+ * mutation retry — the user's only recovery was to tap Continue again.
+ *
+ * Two guarantees are asserted here: a publish that fails transiently is
+ * retried, and a publish that hangs is abandoned instead of holding the
+ * request open until the platform kills the function.
+ */
+import { TOPICS } from "./topics";
+
+jest.mock("../shared/config", () => ({
+  config: { QUEUE_DRIVER: "vercel", NODE_ENV: "test" },
+  isMagicEmail: () => false,
+}));
+
+const send = jest.fn();
+jest.mock("@vercel/queue", () => ({
+  send: (...args: unknown[]) => send(...args),
+}));
+
+const sendError = jest.fn();
+jest.mock("../errors/errors", () => ({
+  sendError: (...args: unknown[]) => sendError(...args),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
+// `require` rather than a top-level import: the module reads `config` at load,
+// and the mocks above have to be in place first.
+const loadEnqueue = () => require("./enqueue") as typeof import("./enqueue");
+
+const MAIL_PAYLOAD = { email: "a@b.com", code: "123456" };
+
+describe("enqueue retries", () => {
+  it("survives a single transient failure on the queue hop", async () => {
+    const { enqueue } = loadEnqueue();
+
+    send
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce({ messageId: "1" });
+
+    await expect(enqueue(TOPICS.MAIL, MAIL_PAYLOAD)).resolves.toBeDefined();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the configured number of attempts", async () => {
+    const { enqueue, ENQUEUE_MAX_ATTEMPTS } = loadEnqueue();
+
+    send.mockRejectedValue(new Error("fetch failed"));
+
+    await expect(enqueue(TOPICS.MAIL, MAIL_PAYLOAD)).rejects.toThrow(
+      "fetch failed",
+    );
+    expect(send).toHaveBeenCalledTimes(ENQUEUE_MAX_ATTEMPTS);
+  });
+
+  it("does not retry a publish that succeeded", async () => {
+    const { enqueue } = loadEnqueue();
+
+    send.mockResolvedValue({ messageId: "1" });
+
+    await enqueue(TOPICS.MAIL, MAIL_PAYLOAD);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("publishWithRetry", () => {
+  it("abandons an attempt that never settles", async () => {
+    const { publishWithRetry } = loadEnqueue();
+
+    // A publish that hangs forever is the shape that actually hurts: the
+    // function holds the request open until the platform kills it, and the
+    // client — which has no timeout of its own — spins the whole time.
+    const publish = jest.fn(
+      () =>
+        new Promise<never>(() => {
+          /* never settles */
+        }),
+    );
+
+    await expect(
+      publishWithRetry(publish, {
+        attempts: 2,
+        timeoutMs: 20,
+        baseDelayMs: 1,
+      }),
+    ).rejects.toThrow(/timed out/i);
+
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the value of the first attempt that settles", async () => {
+    const { publishWithRetry } = loadEnqueue();
+
+    const publish = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      publishWithRetry(publish, {
+        attempts: 3,
+        timeoutMs: 500,
+        baseDelayMs: 1,
+      }),
+    ).resolves.toBe("ok");
+  });
+
+  it("ships a finite, positive timeout and more than one attempt", () => {
+    const { ENQUEUE_ATTEMPT_TIMEOUT_MS, ENQUEUE_MAX_ATTEMPTS } = loadEnqueue();
+
+    expect(ENQUEUE_ATTEMPT_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(ENQUEUE_ATTEMPT_TIMEOUT_MS)).toBe(true);
+    expect(ENQUEUE_MAX_ATTEMPTS).toBeGreaterThan(1);
+  });
+});
+
+describe("inline fallback", () => {
+  it("is off by default, so a dead queue still surfaces as an error", async () => {
+    const { enqueue } = loadEnqueue();
+
+    send.mockRejectedValue(new Error("fetch failed"));
+
+    await expect(enqueue(TOPICS.MAIL, MAIL_PAYLOAD)).rejects.toThrow();
+  });
+
+  it("runs the handler in-process when the caller opts in", async () => {
+    const { enqueue } = loadEnqueue();
+
+    send.mockRejectedValue(new Error("fetch failed"));
+
+    const handler = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("./handlers/mail", () => ({ handleMail: handler }));
+
+    await expect(
+      enqueue(TOPICS.MAIL, MAIL_PAYLOAD, { fallbackInline: true }),
+    ).resolves.toBeUndefined();
+
+    expect(handler).toHaveBeenCalledWith(MAIL_PAYLOAD);
+    // The queue outage still has to be visible even though the user was served.
+    expect(sendError).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/queue/enqueue.ts
+++ b/packages/api/src/queue/enqueue.ts
@@ -1,11 +1,21 @@
 import type { Topic, TopicPayloads } from "./topics";
 
+import { sendError } from "../errors/errors";
 import { config } from "../shared/config";
 import { TOPICS } from "./topics";
 
 type EnqueueOptions = {
   delaySeconds?: number;
   idempotencyKey?: string;
+  /**
+   * Run the handler in-process if the queue hop is still failing after
+   * {@link ENQUEUE_MAX_ATTEMPTS}. Opt-in per call, because it is only the
+   * right trade for jobs that are cheap, fast, and worth more to the user
+   * than the request latency they cost — `mail` during login is the case it
+   * exists for. Never set it on `process-image` (sharp/tfjs, 120s budget) or
+   * on anything that relies on `delaySeconds`.
+   */
+  fallbackInline?: boolean;
 };
 
 // Handlers are imported lazily so heavyweight consumers (sharp, tfjs) stay
@@ -27,22 +37,138 @@ const isVercelQueueAvailable = () =>
   (config.QUEUE_DRIVER !== "inline" && config.VERCEL === "1");
 
 /**
+ * How long one publish attempt may run before it is abandoned.
+ *
+ * `@vercel/queue`'s `send()` mints an OIDC token and then POSTs to the queue
+ * service with a bare `fetch` — neither hop carries a timeout, so a stalled
+ * connection holds the whole API request open until the platform kills the
+ * function. On a cold invocation both hops are also at their slowest, which
+ * is exactly when this matters.
+ */
+export const ENQUEUE_ATTEMPT_TIMEOUT_MS = 3_000;
+
+/** Total attempts per publish — the first one plus its retries. */
+export const ENQUEUE_MAX_ATTEMPTS = 3;
+
+/** First backoff step. Doubles per attempt, with jitter. */
+export const ENQUEUE_BASE_RETRY_DELAY_MS = 100;
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+class EnqueueTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Queue publish timed out after ${timeoutMs}ms`);
+    this.name = "EnqueueTimeoutError";
+  }
+}
+
+const withTimeout = async <T>(
+  operation: () => Promise<T>,
+  timeoutMs: number,
+): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new EnqueueTimeoutError(timeoutMs)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    // `Promise.race` does not cancel the loser. Clearing the timer is what
+    // keeps a won race from holding the event loop open for the remainder of
+    // the timeout — the difference between a 200ms request and a 3s one.
+    if (timer) clearTimeout(timer);
+  }
+};
+
+/**
+ * Run `publish` until it settles or the attempts run out, bounding each
+ * attempt and backing off with jitter between them. The jitter matters on a
+ * cold deployment: without it, every request that woke up together retries in
+ * lockstep and hits the recovering service as one spike.
+ *
+ * Exported for the tests, which need to drive the timing without waiting out
+ * the production constants.
+ */
+export const publishWithRetry = async <T>(
+  publish: () => Promise<T>,
+  {
+    attempts = ENQUEUE_MAX_ATTEMPTS,
+    timeoutMs = ENQUEUE_ATTEMPT_TIMEOUT_MS,
+    baseDelayMs = ENQUEUE_BASE_RETRY_DELAY_MS,
+  }: { attempts?: number; timeoutMs?: number; baseDelayMs?: number } = {},
+): Promise<T> => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      // oxlint-disable-next-line no-await-in-loop -- Retries are sequential by definition; running them in parallel would be the same spike this backs off from.
+      return await withTimeout(publish, timeoutMs);
+    } catch (error) {
+      lastError = error;
+
+      const isLastAttempt = attempt === attempts - 1;
+      if (isLastAttempt) break;
+
+      const backoff = baseDelayMs * 2 ** attempt;
+      // oxlint-disable-next-line no-await-in-loop -- This await IS the backoff.
+      await sleep(backoff + Math.random() * backoff);
+    }
+  }
+
+  throw lastError;
+};
+
+const runInline = async <T extends Topic>(
+  topic: T,
+  payload: TopicPayloads[T],
+) => {
+  const handler = await INLINE_HANDLERS[topic]();
+  await handler(payload);
+};
+
+/**
  * Publish a job. On Vercel this goes through Vercel Queues (durable,
  * retried, consumed by the routes under apps/nextjs/src/app/api/queues).
  * Anywhere else — local dev, Maestro e2e, tests — the handler runs inline
  * so the stack needs no queue infrastructure at all.
+ *
+ * A failed publish is retried before it is allowed to fail the caller's
+ * request; see {@link ENQUEUE_MAX_ATTEMPTS}.
  */
 export const enqueue = async <T extends Topic>(
   topic: T,
   payload: TopicPayloads[T],
   options: EnqueueOptions = {},
 ) => {
+  const { fallbackInline, ...sendOptions } = options;
+
   if (isVercelQueueAvailable()) {
     const { send } = await import("@vercel/queue");
-    return send(topic, payload, options);
+
+    try {
+      return await publishWithRetry(() => send(topic, payload, sendOptions));
+    } catch (error) {
+      if (!fallbackInline) throw error;
+
+      // The queue is the durable path and it is down. Serving the user from
+      // the request thread is strictly better than failing them, but the
+      // outage still has to be visible — it is not otherwise observable from
+      // the outside once the fallback succeeds.
+      sendError(error, { topic, fallback: "inline" });
+      return runInline(topic, payload);
+    }
   }
 
-  if (options.delaySeconds) {
+  if (sendOptions.delaySeconds) {
     // Inline mode has no scheduler. The only delayed job is the push
     // receipt audit, which is a prod-observability concern — skip it
     // instead of blocking the request or recursing forever.
@@ -53,6 +179,5 @@ export const enqueue = async <T extends Topic>(
     return;
   }
 
-  const handler = await INLINE_HANDLERS[topic]();
-  await handler(payload);
+  return runInline(topic, payload);
 };

--- a/packages/api/src/services/authentication-service.test.ts
+++ b/packages/api/src/services/authentication-service.test.ts
@@ -2,6 +2,15 @@ import prisma from "@pegada/database";
 
 import { AuthenticationService } from "./authentication-service";
 
+// `enqueue` pulls in `errors.ts` -> `observability.ts` -> the ESM-only
+// `magic-observability/node`, which jest can't parse. Same mock
+// `enqueue.test.ts` uses to keep that chain out of suites that don't test it.
+jest.mock("../errors/errors", () => ({
+  sendError: jest.fn(),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
 afterAll(async () => {
   await prisma.$disconnect();
 });

--- a/packages/api/src/services/authentication-service.ts
+++ b/packages/api/src/services/authentication-service.ts
@@ -150,7 +150,16 @@ export class AuthenticationService {
       create: { email, code, codeExpiresAt: expiresAt },
     });
 
-    await enqueue(TOPICS.MAIL, { email, code, language: this.language });
+    // `fallbackInline` because this is the one job a user is actively waiting
+    // on: the code row is already written, so a failed publish means a login
+    // that cannot be completed. Sending from the request thread costs latency
+    // and buys the user their code. See enqueue.ts for why the queue hop is
+    // the fragile part.
+    await enqueue(
+      TOPICS.MAIL,
+      { email, code, language: this.language },
+      { fallbackInline: true },
+    );
   }
 
   static async checkVerification({

--- a/packages/api/src/services/dog-service.test.ts
+++ b/packages/api/src/services/dog-service.test.ts
@@ -3,6 +3,15 @@ import { Gender } from "@prisma/client";
 
 import { DogService } from "./dog-service";
 
+// `enqueue` pulls in `errors.ts` -> `observability.ts` -> the ESM-only
+// `magic-observability/node`, which jest can't parse. Same mock
+// `enqueue.test.ts` uses to keep that chain out of suites that don't test it.
+jest.mock("../errors/errors", () => ({
+  sendError: jest.fn(),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
 afterAll(async () => {
   await prisma.$disconnect();
 });


### PR DESCRIPTION
Root-causes the first-login failure on a cold production stack (TestFlight 1.6.0, first attempt errored, second worked) and makes both halves resilient.

## Root cause (code-evidenced; PostHog event pending a key-scope fix)

`sendVerification` writes the OTP row, then awaits the mail enqueue. `@vercel/queue`'s `send()` does a bare `fetch` — no timeout, no retry, any non-2xx throws. That throw isn't an `IntentionalError`, so the client gets a generic 500 instead of `OTP_REQUIRED`: a valid code sits in the database, no email goes out, and the user sees "An error occurred while logging in." The mobile client had no request timeout and `retry: 0`, so one transient cold-path failure went straight to the user's face. A separate real bug rode along: the tRPC fetch override returned `{ ...res }`, which copies no `status`/`ok`/`headers` off `Response.prototype`.

## Fixes

- **api:** bounded attempt window + two jittered retries on queue publish; mail opts into `fallbackInline` so a dead queue runs the handler in-request instead of failing login (outage still reported). 8 failing-first tests.
- **mobile:** 15s per-attempt timeout; retries only transport failures and 5xx (anything carrying an `error_code` is final — `OTP_REQUIRED` never re-sends, `INVALID_OTP_CODE` never resubmits). Fixed the fetch override. 8 failing-first tests.
- **ops:** `/api/cron/keep-warm` doing real Postgres + Redis round trips on a Vercel cron, plus a scheduled production login smoke workflow (HTTP-level: function boot, ratelimit, Prisma read/write, OTP consume, JWT; hourly queue-path check via a non-magic address).

## Needs configuration to fully activate (see checklist)

GitHub secrets `SMOKE_MAGIC_EMAIL`/`SMOKE_MAGIC_CODE` (+ optional `SMOKE_MAIL_EMAIL`, `CRON_SECRET`, var `SMOKE_API_URL`); Vercel `CRON_SECRET` and note Hobby runs crons daily — `*/5` needs Pro; check autosuspend on the production database provider; PostHog key needs `query:read`/`error_tracking:read` to pull the actual failure event.

## Known limits

The smoke stops at the enqueue (mail delivery unverified — a mailbox assertion would close it) and can't see the client half (a Maestro flow against production would). Both noted as follow-ups.
