### PR TITLE
fix(mobile): chat opens at the latest message, keyboard keeps your place, carousel edge bounce stops going black

### DIFF
--- a/apps/mobile/.maestro/43-chat-opens-at-latest.yaml
+++ b/apps/mobile/.maestro/43-chat-opens-at-latest.yaml
@@ -1,0 +1,114 @@
+appId: ${APP_ID}
+name: Chat - opening a conversation must land on the newest message
+tags:
+  - regression
+---
+# REGRESSION GUARD - reported bug #1: a conversation SOMETIMES opens scrolled
+# to the top of the loaded page instead of the bottom, so the newest message
+# is off screen and you have to fling down to find out what was said.
+#
+# "Sometimes" is the whole point. FlashList v2 dropped `inverted`, so
+# `views/Chat` renders top-down with the newest row last and nothing asked it
+# to start at the end. What put it at the end when it did was
+# `maintainVisibleContentPosition.autoscrollToBottomThreshold` firing as the
+# rows measured and the content grew past the estimate — a race between the
+# first committed layout and the real one. Win it and the chat looks correct;
+# lose it and it opens on the middle of the history.
+#
+# Which is why this flow opens the conversation TWICE. The first open is cold:
+# react-query has one page, the list is short enough that offset 0 is inside
+# the autoscroll threshold, and the heuristic drags it to the end — it looks
+# fine. The second open is the one a real user does all day, and by then the
+# cache holds every page that was paginated in, so the list mounts 40 rows
+# tall, offset 0 is nowhere near the threshold, nothing fires, and the chat
+# opens on the OLDEST message. Measured on the pre-fix build: 12 of 12 warm
+# opens landed on row 1 (.unistyles-migration/chat-ux-fixes/probe-chat-open.mjs).
+#
+# scripts/pre/43-seed-long-chat.sh fills the Rex<->Nina match (which the normal
+# maestro seed leaves empty) with 40 messages, so the first page alone is
+# taller than the viewport and "did it land at the end" is answerable at all.
+# On the 3-message Rex<->Bella thread every message is on screen either way and
+# this flow would assert nothing.
+#
+# The YAML gets the app to the parked state; the geometry is
+# checks/43-chat-opens-at-latest.mjs, because "visible" here means "its rect is
+# above the composer", and `assertVisible` does not do occlusion — a bubble
+# painted underneath the composer is still in the accessibility tree with a
+# rect, and would satisfy it.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd
+- runFlow: utils/login-returning.yaml
+- waitForAnimationToEnd:
+    timeout: 15000
+
+- tapOn:
+    id: "tab-messages"
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertVisible:
+    id: "messages-screen"
+- runFlow: utils/dismiss-app-review.yaml
+# By name: the fixture conversation is Rex<->Nina, and row order depends on
+# which thread was last written to.
+- tapOn:
+    text: "Nina"
+- extendedWaitUntil:
+    visible:
+      id: "chat-input"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertVisible:
+    id: "chat-screen"
+- takeScreenshot: 43-01-first-open
+
+# Page the history in, so the second open mounts a list that is already 40
+# rows tall rather than one 20-row page. This is what a user does by reading
+# the conversation; the flow does it with three swipes.
+- swipe:
+    direction: DOWN
+    duration: 400
+- swipe:
+    direction: DOWN
+    duration: 400
+- swipe:
+    direction: DOWN
+    duration: 400
+- waitForAnimationToEnd:
+    timeout: 6000
+
+- tapOn:
+    id: "chat-back"
+# The first tap after a screen settles is sometimes eaten — flow 19 documents
+# the same thing on the Messages list. A second optional tap is a no-op once we
+# have already left, and without it this flow fails on the assertion below
+# roughly one run in ten for a reason that has nothing to do with the chat.
+- tapOn:
+    id: "chat-back"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "messages-screen"
+    timeout: 8000
+- waitForAnimationToEnd:
+    timeout: 4000
+
+# The open under test.
+- tapOn:
+    text: "Nina"
+- extendedWaitUntil:
+    visible:
+      id: "chat-input"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertVisible:
+    id: "chat-screen"
+- takeScreenshot: 43-02-reopened
+
+# Cheap first gate so a broken fixture reads as a broken fixture: the newest
+# row has to be in the tree at all. The check decides whether it is on screen.
+- assertVisible:
+    text: ".*chatux message 40.*"

--- a/apps/mobile/.maestro/44-chat-keyboard-anchor.yaml
+++ b/apps/mobile/.maestro/44-chat-keyboard-anchor.yaml
@@ -1,0 +1,59 @@
+appId: ${APP_ID}
+name: Keyboard - raising the composer must not take your place in the thread
+tags:
+  - regression
+---
+# REGRESSION GUARD - reported bug #2: opening the keyboard in a conversation
+# loses your reading context. The composer itself rides up correctly (that is
+# flow 37, and it still passes) — what does not is the list behind it. The
+# screen container shrinks by the keyboard's height, so the list's viewport
+# loses its bottom N points while its scroll offset stays put: the top of the
+# window is anchored and everything you were reading at the bottom slides in
+# behind the composer. Tap the field to reply to the message you are looking
+# at and that message is the first thing to disappear.
+#
+# The wanted behaviour is WhatsApp's: the content shifts up with the keyboard,
+# so the last row you could read is still the last row you can read, and
+# dismissing the keyboard puts it back.
+#
+# This flow only parks the screen. Everything after that is
+# checks/44-chat-keyboard-anchor.mjs, which raises and lowers the keyboard
+# itself and compares hierarchy reads either side — a before/after is the only
+# honest way to state "the row you were on is still on screen", and Maestro
+# runs a check after a flow rather than inside one.
+#
+# Same fixture as flow 43 (scripts/pre/44-seed-long-chat.sh): 40 messages in
+# the otherwise-empty Rex<->Nina match, so there is a history to lose your
+# place in.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd
+- runFlow: utils/login-returning.yaml
+- waitForAnimationToEnd:
+    timeout: 15000
+
+- tapOn:
+    id: "tab-messages"
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertVisible:
+    id: "messages-screen"
+- runFlow: utils/dismiss-app-review.yaml
+- tapOn:
+    text: "Nina"
+- extendedWaitUntil:
+    visible:
+      id: "chat-input"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertVisible:
+    id: "chat-screen"
+- takeScreenshot: 44-01-parked-keyboard-down
+
+# Pre-condition, same spirit as flow 37's: with the keyboard down the composer
+# is plainly there. If a future layout moves it, this fails loudly instead of
+# the check quietly measuring the wrong node.
+- assertVisible:
+    id: "chat-input"

--- a/apps/mobile/.maestro/45-dog-profile-photo-edges.yaml
+++ b/apps/mobile/.maestro/45-dog-profile-photo-edges.yaml
@@ -1,0 +1,63 @@
+appId: ${APP_ID}
+name: Dog profile - paging past the last photo must not black out the card
+tags:
+  - regression
+---
+# REGRESSION GUARD - reported bug #3: tapping forward on the LAST photo of a
+# dog profile warps the card and half of it renders black.
+#
+# `components/MainCard` covers the photo with two invisible Pressables. Tapping
+# forward on the last photo (or back on the first) has no photo to go to, so it
+# ran a spring on `rotateY` under a `perspective` of 100 to say so. A
+# non-affine transform on a layer that also has `overflow: hidden` makes Core
+# Animation composite it offscreen, and on iOS 26 half of it came back empty —
+# the DogProfile's black backdrop showing through, photo and pagination dots
+# and distance pill all gone, for the ~330ms the spring ran.
+#
+# It was never reachable from this suite: `maestro-seed.ts` gives every dog
+# exactly one image, and with one image there is no carousel and no boundary.
+# `scripts/pre/45-seed-gallery.sh` gives Nina four.
+#
+# The flow parks on Nina's profile at photo 1. checks/45-*.mjs does the rest,
+# because catching this needs frames sampled WHILE the spring is running, and
+# a Maestro `takeScreenshot` only ever lands before or after it.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd
+- runFlow: utils/login-returning.yaml
+- waitForAnimationToEnd:
+    timeout: 15000
+
+- tapOn:
+    id: "tab-messages"
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertVisible:
+    id: "messages-screen"
+- runFlow: utils/dismiss-app-review.yaml
+
+# Reached through the UI rather than `pegada://profile/<id>`: the deep link
+# needs the dog's id, and iOS puts an "Open in Pegada?" confirmation in front
+# of it that has nothing to do with what is under test.
+- tapOn:
+    text: "Nina"
+- extendedWaitUntil:
+    visible:
+      id: "chat-input"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 6000
+
+# The chat header's dog name opens that dog's profile.
+- tapOn:
+    text: "Nina"
+- extendedWaitUntil:
+    visible:
+      id: "dog-profile-name"
+    timeout: 10000
+- waitForAnimationToEnd:
+    timeout: 6000
+- assertVisible:
+    id: "swipe-card"
+- takeScreenshot: 45-01-photo-1-of-4

--- a/apps/mobile/.maestro/checks/43-chat-opens-at-latest.mjs
+++ b/apps/mobile/.maestro/checks/43-chat-opens-at-latest.mjs
@@ -1,0 +1,91 @@
+/**
+ * Post-check for flow 43 (chat-opens-at-latest.yaml).
+ *
+ * The flow leaves a 40-message conversation freshly opened, keyboard down.
+ * This asserts the two things that make "it opened at the latest message"
+ * true:
+ *
+ *  1. `chatux message 40` — the newest row — is entirely between the top of
+ *     the chat screen and the top of the composer. Not merely present: the
+ *     bug's signature is a row that exists in the tree but is painted off the
+ *     bottom of the viewport or under the composer.
+ *  2. The very first message of the thread is nowhere on screen. Without a
+ *     second assertion the check would go green on a fixture short enough to
+ *     fit, where landing at the end is not a claim about anything — and row 1
+ *     being absent is the statement that actually distinguishes the two ends
+ *     of a 40-row conversation.
+ *
+ * Runs on both platforms: it reads rects out of `maestro hierarchy`, which
+ * fills them in the same way on iOS and Android.
+ */
+
+import { describe, isReadable, readChat } from "./lib/chat-geometry.mjs";
+import { fail, pass } from "./lib/report.mjs";
+
+const TAG = "check-43";
+const NEWEST = 40;
+
+const { composer, chatScreen, messages, screen } = readChat();
+
+if (!composer) {
+  fail(TAG, "`chat-input` is not in the tree — flow 43 did not park on a chat");
+}
+if (messages.size === 0) {
+  fail(
+    TAG,
+    "no `chatux message NN` rows in the tree; run scripts/pre/43-seed-long-chat.sh (the flow wrapper does)",
+  );
+}
+
+const band = { top: chatScreen?.y ?? screen.y ?? 0, bottom: composer.y };
+
+const newest = messages.get(NEWEST);
+if (!newest) {
+  fail(
+    TAG,
+    `the newest row (chatux message ${NEWEST}) is not rendered at all; the list is parked somewhere in the history. Rendered: ${[
+      ...messages.keys(),
+    ]
+      .sort((a, b) => a - b)
+      .join(", ")}`,
+  );
+}
+
+const loaded = [...messages.keys()].sort((a, b) => a - b);
+const readable = loaded.filter((n) => isReadable(messages.get(n), band));
+const OLDEST = 1;
+
+console.log(
+  `[${TAG}] band ${band.top}..${band.bottom}, rendered ${loaded.join(",")}, readable ${readable.join(",")}`,
+);
+console.log(`[${TAG}] newest row ${describe(newest)}`);
+
+if (!isReadable(newest, band)) {
+  fail(
+    TAG,
+    `the chat did not open at the newest message: row ${NEWEST} is at ${describe(
+      newest,
+    )} but the readable band is ${band.top}..${band.bottom} (composer top ${composer.y})`,
+  );
+}
+
+// Not "some rendered row is off screen": FlashList's render window is not the
+// loaded page, and a window that happens to land entirely inside the viewport
+// made this fail on a chat that was sitting correctly on row 40. Row 1 is the
+// honest test — it is the other end of a 40-row thread, and the only way it is
+// on screen is if the list never left the start.
+if (messages.has(OLDEST)) {
+  fail(
+    TAG,
+    `row ${OLDEST} — the first message of the thread — is rendered at ${describe(
+      messages.get(OLDEST),
+    )}, so the list is parked at the START of the conversation, not the end`,
+  );
+}
+
+pass(
+  TAG,
+  `opened on row ${NEWEST} at ${describe(newest)}, clear of the composer by ${
+    composer.y - newest.bottom
+  }pt, with the thread's first row nowhere near the screen (rendered ${loaded[0]}..${loaded.at(-1)}, ${readable.length} readable)`,
+);

--- a/apps/mobile/.maestro/checks/43-chat-opens-at-latest.sh
+++ b/apps/mobile/.maestro/checks/43-chat-opens-at-latest.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Post-check for flow 43. The measurement lives in the .mjs next to this file;
+# run-flow.sh only knows how to launch `checks/<NN>-*.sh`.
+set -euo pipefail
+exec node "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/43-chat-opens-at-latest.mjs"

--- a/apps/mobile/.maestro/checks/44-chat-keyboard-anchor.mjs
+++ b/apps/mobile/.maestro/checks/44-chat-keyboard-anchor.mjs
@@ -1,0 +1,170 @@
+/**
+ * Post-check for flow 44 (chat-keyboard-anchor.yaml).
+ *
+ * Four phases, two of them transitions this check drives itself:
+ *
+ *   1. read   — the flow parked the chat freshly opened, keyboard down.
+ *   2. focus  — raise the keyboard. The newest row must STILL be readable.
+ *               (the at-bottom case: replying must not hide what you are
+ *               replying to.)
+ *   3. history— dismiss the keyboard, swipe back up the thread, and note the
+ *               last row that is readable there.
+ *   4. focus  — raise the keyboard again. That same row must still be
+ *               readable. (the mid-history case: the reported bug.)
+ *
+ * "Readable" is a rect entirely between the top of the chat screen and the top
+ * of the composer — see lib/chat-geometry.mjs for why `assertVisible` cannot
+ * express it.
+ *
+ * Platform-agnostic: every number comes out of `maestro hierarchy`. Only ever
+ * run against iOS so far; Android is pending a device.
+ */
+
+import {
+  describe,
+  driveFragment,
+  isReadable,
+  lastReadableMessage,
+  readChat,
+} from "./lib/chat-geometry.mjs";
+import { fail, pass } from "./lib/report.mjs";
+
+const TAG = "check-44";
+const NEWEST = 40;
+
+/**
+ * How far the composer has to travel before we believe the keyboard is up.
+ * The IME is at least ~250pt on every device this suite runs on; 100 is far
+ * enough above the noise floor to distinguish "keyboard" from "the layout
+ * settled by a point or two".
+ */
+const KEYBOARD_TRAVEL_MIN = 100;
+
+const bandOf = ({ composer, chatScreen, screen }) => ({
+  top: chatScreen?.y ?? screen.y ?? 0,
+  bottom: composer.y,
+});
+
+const snapshot = (label) => {
+  const chat = readChat();
+  if (!chat.composer) {
+    fail(TAG, `${label}: \`chat-input\` is not in the tree`);
+  }
+  const band = bandOf(chat);
+  console.log(
+    `[${TAG}] ${label}: composer top ${chat.composer.y}, band ${band.top}..${band.bottom}, rendered ${[
+      ...chat.messages.keys(),
+    ]
+      .sort((a, b) => a - b)
+      .join(",")}`,
+  );
+  return { ...chat, band };
+};
+
+// ---------------------------------------------------------------- phase 1
+const down = snapshot("keyboard down, at the end");
+
+if (down.messages.size === 0) {
+  fail(
+    TAG,
+    "no `chatux message NN` rows in the tree; run scripts/pre/44-seed-long-chat.sh (the flow wrapper does)",
+  );
+}
+
+const newestDown = down.messages.get(NEWEST);
+if (!newestDown || !isReadable(newestDown, down.band)) {
+  fail(
+    TAG,
+    `precondition: the chat did not open at the newest message (row ${NEWEST} ${describe(
+      newestDown,
+    )}, band ${down.band.top}..${down.band.bottom}). That is bug #1 — flow 43 owns it — and it makes this check meaningless`,
+  );
+}
+
+// ---------------------------------------------------------------- phase 2
+driveFragment("focus-composer");
+const upAtEnd = snapshot("keyboard up, at the end");
+
+const travel = down.composer.y - upAtEnd.composer.y;
+if (travel < KEYBOARD_TRAVEL_MIN) {
+  fail(
+    TAG,
+    `the keyboard did not come up: the composer moved ${travel}pt (needs > ${KEYBOARD_TRAVEL_MIN}). Nothing below this would be testing anything`,
+  );
+}
+
+const newestUp = upAtEnd.messages.get(NEWEST);
+if (!newestUp || !isReadable(newestUp, upAtEnd.band)) {
+  fail(
+    TAG,
+    `at-bottom case: raising the keyboard hid the newest message. Row ${NEWEST} was at ${describe(
+      newestDown,
+    )} with the composer at ${down.composer.y}; it is now at ${describe(
+      newestUp,
+    )} with the composer at ${upAtEnd.composer.y}`,
+  );
+}
+console.log(
+  `[${TAG}] at-bottom OK: row ${NEWEST} clears the composer by ${upAtEnd.composer.y - newestUp.bottom}pt with the keyboard up`,
+);
+
+// ---------------------------------------------------------------- phase 3
+driveFragment("into-history");
+const midDown = snapshot("keyboard down, mid-history");
+
+const anchor = lastReadableMessage(midDown.messages, midDown.band);
+if (!anchor) {
+  fail(
+    TAG,
+    "mid-history: no message row is readable at all after scrolling back",
+  );
+}
+if (anchor.n >= NEWEST) {
+  fail(
+    TAG,
+    `mid-history: the swipes did not move off the end (last readable row is still ${anchor.n}). The mid-history case would be a duplicate of the at-bottom one`,
+  );
+}
+console.log(
+  `[${TAG}] anchor: row ${anchor.n} at ${describe(anchor.rect)} — the last row readable before focusing`,
+);
+
+// ---------------------------------------------------------------- phase 4
+driveFragment("focus-composer");
+const midUp = snapshot("keyboard up, mid-history");
+
+const midTravel = midDown.composer.y - midUp.composer.y;
+if (midTravel < KEYBOARD_TRAVEL_MIN) {
+  fail(
+    TAG,
+    `the keyboard did not come up the second time: the composer moved ${midTravel}pt`,
+  );
+}
+
+const anchorUp = midUp.messages.get(anchor.n);
+if (!anchorUp) {
+  fail(
+    TAG,
+    `mid-history case: row ${anchor.n} was the last row you could read, and raising the keyboard scrolled it out of the rendered window entirely`,
+  );
+}
+if (!isReadable(anchorUp, midUp.band)) {
+  fail(
+    TAG,
+    `mid-history case: raising the keyboard took your place in the thread. Row ${anchor.n} was at ${describe(
+      anchor.rect,
+    )} above a composer at ${midDown.composer.y}; it is now at ${describe(
+      anchorUp,
+    )} and the composer is at ${midUp.composer.y}, so it is ${
+      anchorUp.bottom - midUp.composer.y
+    }pt underneath it`,
+  );
+}
+
+const shift = anchor.rect.y - anchorUp.y;
+pass(
+  TAG,
+  `the list held its place: row ${anchor.n} shifted up ${shift}pt against ${midTravel}pt of keyboard, and still clears the composer by ${
+    midUp.composer.y - anchorUp.bottom
+  }pt. At-bottom case held too.`,
+);

--- a/apps/mobile/.maestro/checks/44-chat-keyboard-anchor.sh
+++ b/apps/mobile/.maestro/checks/44-chat-keyboard-anchor.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Post-check for flow 44. The measurement lives in the .mjs next to this file;
+# run-flow.sh only knows how to launch `checks/<NN>-*.sh`.
+set -euo pipefail
+exec node "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/44-chat-keyboard-anchor.mjs"

--- a/apps/mobile/.maestro/checks/45-dog-profile-photo-edges.mjs
+++ b/apps/mobile/.maestro/checks/45-dog-profile-photo-edges.mjs
@@ -1,0 +1,190 @@
+/**
+ * Post-check for flow 45 (dog-profile-photo-edges.yaml).
+ *
+ * The bug is only on screen while a spring runs — about a third of a second —
+ * and it is a rendering fault, not a tree fault: every node stays exactly
+ * where it was, the pixels just stop arriving. So this measures the frame
+ * buffer, like checks/33 and 38 do, and it has to catch it mid-gesture.
+ *
+ * Aiming a ~0.5s screenshot at a ~0.33s window is not a thing, so it does the
+ * opposite: it starts a fragment that taps ten times in a row and samples the
+ * screen continuously while that runs. On the broken build 6 of 40 samples
+ * came back with half the card as pure #000000, so a couple of dozen samples
+ * per position is a wide margin.
+ *
+ * Three positions, because "which photo" is the part of the report that had to
+ * be checked: the first (paging back off the start), a middle one (an ordinary
+ * photo swap, no spring at all), and the last (paging forward off the end,
+ * which is what was reported).
+ *
+ * Platform-agnostic: `captureScreen` reads simctl's BMP or adb's raw
+ * framebuffer. Only ever run against iOS so far; Android is pending a device.
+ */
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+
+import { driveFragment } from "./lib/chat-geometry.mjs";
+import { resolveDevice } from "./lib/device.mjs";
+import { readHierarchy } from "./lib/hierarchy.mjs";
+import { fail, pass } from "./lib/report.mjs";
+import { boundingBox, captureScreen } from "./lib/screen.mjs";
+
+const TAG = "check-45";
+
+/**
+ * Pure black. Not "dark": a photograph's shadows are never all three channels
+ * at zero once it has been through JPEG, and the thing being detected is a
+ * region where nothing was drawn at all, so the backdrop shows through.
+ */
+const isPureBlack = ([r, g, b]) => r <= 8 && g <= 8 && b <= 8;
+
+/**
+ * Share of the card that may be pure black before this is a fault. The bug
+ * paints 49.7%; a photo that happens to be very dark will not reach 3%.
+ */
+const MAX_BLACK_SHARE = 0.03;
+
+/** How long to keep sampling while a fragment runs. */
+const SAMPLE_BUDGET_MS = 25_000;
+
+const device = resolveDevice();
+
+/** The card's rect in framebuffer pixels. */
+const cardRegion = () => {
+  const { byTestId, screen } = readHierarchy({ device });
+  const card = byTestId.get("swipe-card");
+  if (!card) {
+    fail(
+      TAG,
+      "`swipe-card` is not in the tree — flow 45 did not park on a dog profile",
+    );
+  }
+
+  const frame = captureScreen({ device });
+  // The hierarchy is in points and the frame buffer is in pixels.
+  const scale = frame.width / screen.width;
+
+  return {
+    frame,
+    scale,
+    region: {
+      x: Math.max(0, Math.round(card.x * scale)),
+      y: Math.max(0, Math.round(card.y * scale)),
+      right: Math.min(frame.width, Math.round(card.right * scale)),
+      bottom: Math.min(frame.height, Math.round(card.bottom * scale)),
+    },
+  };
+};
+
+const { scale, region } = cardRegion();
+const area = (region.right - region.x) * (region.bottom - region.y);
+console.log(
+  `[${TAG}] card ${region.x},${region.y}..${region.right},${region.bottom} px (scale ${scale.toFixed(2)}), ${area} px²`,
+);
+
+const blackShare = (frame) => {
+  const box = boundingBox(frame, isPureBlack, region);
+  return { share: (box?.count ?? 0) / area, box };
+};
+
+/** The worst frame seen while `fragment` runs. */
+const worstDuring = async (fragment) => {
+  const url = new URL(`lib/${fragment}.yaml`, import.meta.url);
+  const child = spawn(
+    "maestro",
+    [
+      "--device",
+      device.id,
+      "test",
+      "-e",
+      `APP_ID=${process.env.APP_ID ?? "app.pegada"}`,
+      url.pathname,
+    ],
+    { stdio: "ignore" },
+  );
+
+  let running = true;
+  child.on("exit", () => {
+    running = false;
+  });
+
+  const deadline = Date.now() + SAMPLE_BUDGET_MS;
+  let worst = { share: 0, box: null };
+  let samples = 0;
+
+  // `captureScreen` shells out synchronously, so the loop yields between
+  // captures — without that the event loop never runs and the child's `exit`
+  // never lands, and this would sample for the whole budget every time.
+  // oxlint-disable-next-line no-unmodified-loop-condition -- `running` is set by the child's `exit` handler, which is exactly what the `await` at the bottom of the body exists to let run.
+  while (running && Date.now() < deadline) {
+    const current = blackShare(captureScreen({ device }));
+    samples += 1;
+    if (current.share > worst.share) worst = current;
+    // oxlint-disable-next-line no-await-in-loop -- sequential is the point: this samples the screen over time while a child process taps, it is not a batch of independent promises.
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+
+  if (running) await once(child, "exit");
+
+  return { ...worst, samples };
+};
+
+const verdicts = [];
+
+const measure = async (label, fragment) => {
+  const { share, box, samples } = await worstDuring(fragment);
+  const line = `${label}: worst ${(share * 100).toFixed(2)}% pure black over ${samples} samples`;
+  console.log(
+    `[${TAG}] ${line}${box ? ` (bbox ${box.width}x${box.height}+${box.x}+${box.y})` : ""}`,
+  );
+  verdicts.push({ label, share, box, line });
+};
+
+// Photo 1 of 4 — paging BACK off the start, which runs the same spring.
+await measure("first photo, paging back", "card-tap-back");
+
+// An ordinary photo swap in the middle of the carousel: no spring, but the
+// report was about a photo position, so every position gets measured.
+driveFragment("card-next-photo");
+await measure("middle photo, paging forward", "card-next-photo");
+
+// Photo 4 of 4 — the reported gesture.
+driveFragment("card-next-photo");
+driveFragment("card-next-photo");
+await measure("last photo, paging forward", "card-tap-forward");
+
+// And the settled state afterwards, which is the "end state" half of the
+// evidence: whatever the spring did, the card has to be whole once it stops.
+const settled = blackShare(captureScreen({ device }));
+console.log(
+  `[${TAG}] settled after the last gesture: ${(settled.share * 100).toFixed(2)}% pure black`,
+);
+verdicts.push({
+  label: "settled end state",
+  share: settled.share,
+  box: settled.box,
+  line: `settled end state: ${(settled.share * 100).toFixed(2)}% pure black`,
+});
+
+const bad = verdicts.filter((verdict) => verdict.share > MAX_BLACK_SHARE);
+if (bad.length > 0) {
+  fail(
+    TAG,
+    `the card blacked out. ${bad
+      .map(
+        (verdict) =>
+          `${verdict.line}${verdict.box ? ` at ${verdict.box.width}x${verdict.box.height}+${verdict.box.x}+${verdict.box.y}` : ""}`,
+      )
+      .join("; ")}`,
+  );
+}
+
+pass(
+  TAG,
+  `the card stayed whole at every photo position — ${verdicts
+    .map((verdict) => `${verdict.label} ${(verdict.share * 100).toFixed(2)}%`)
+    .join(", ")}, all under ${(MAX_BLACK_SHARE * 100).toFixed(0)}%`,
+);

--- a/apps/mobile/.maestro/checks/45-dog-profile-photo-edges.sh
+++ b/apps/mobile/.maestro/checks/45-dog-profile-photo-edges.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Post-check for flow 45. The measurement lives in the .mjs next to this file;
+# run-flow.sh only knows how to launch `checks/<NN>-*.sh`.
+set -euo pipefail
+exec node "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/45-dog-profile-photo-edges.mjs"

--- a/apps/mobile/.maestro/checks/lib/card-next-photo.yaml
+++ b/apps/mobile/.maestro/checks/lib/card-next-photo.yaml
@@ -1,0 +1,8 @@
+appId: ${APP_ID}
+tags: [util]
+---
+# One step forward through the carousel.
+- tapOn:
+    point: "75%, 25%"
+- waitForAnimationToEnd:
+    timeout: 3000

--- a/apps/mobile/.maestro/checks/lib/card-tap-back.yaml
+++ b/apps/mobile/.maestro/checks/lib/card-tap-back.yaml
@@ -1,0 +1,9 @@
+appId: ${APP_ID}
+tags: [util]
+---
+# The left (previous) Pressable. See card-tap-forward.yaml.
+- repeat:
+    times: 10
+    commands:
+      - tapOn:
+          point: "25%, 25%"

--- a/apps/mobile/.maestro/checks/lib/card-tap-forward.yaml
+++ b/apps/mobile/.maestro/checks/lib/card-tap-forward.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+tags: [util]
+---
+# Driven by checks/45-dog-profile-photo-edges.mjs. `MainCard` covers the photo
+# with two invisible Pressables and neither carries a testID, so this has to be
+# a point: 75% of the width is inside the right (next) one, 25% of the height
+# is above the pagination dots and below the status bar.
+#
+# Repeated, because the check samples the screen WHILE the spring runs and one
+# ~330ms window is not something a ~0.5s screenshot can be aimed at.
+- repeat:
+    times: 10
+    commands:
+      - tapOn:
+          point: "75%, 25%"

--- a/apps/mobile/.maestro/checks/lib/chat-geometry.mjs
+++ b/apps/mobile/.maestro/checks/lib/chat-geometry.mjs
@@ -1,0 +1,83 @@
+/**
+ * Shared geometry for the two chat checks (43: opens at the newest message,
+ * 44: the keyboard does not steal your place in the thread).
+ *
+ * Both questions are "is this bubble on screen, above the composer", and
+ * neither is expressible with `assertVisible`: Maestro asserts an element is
+ * in the accessibility tree, not that anything is painted where you can see
+ * it. A message row sitting underneath the composer — which is exactly what
+ * both bugs look like — is in the tree, with a rect, and passes.
+ *
+ * The fixture (scripts/pre/lib-seed-long-chat.sh) numbers every message
+ * `chatux message NN`, so a row can be identified across two hierarchy reads
+ * even though every bubble in the list carries the same testID.
+ */
+
+import { execFileSync } from "node:child_process";
+
+import { resolveDevice } from "./device.mjs";
+import { readHierarchy } from "./hierarchy.mjs";
+
+const MARKER = /chatux message (\d{2})/;
+
+/**
+ * The chat as the checks care about it.
+ *
+ * `composerTop` is the top edge of the `chat-input` field. It is deliberately
+ * not the top of the composer's container (which has no testID): using the
+ * field makes the "is this bubble clear of the composer" test slightly
+ * stricter than the pixels require, and a check that is strict in the safe
+ * direction cannot pass a screen that is actually broken.
+ */
+export const readChat = ({ device = resolveDevice(), attempts = 3 } = {}) => {
+  // Retried, because `maestro hierarchy` sometimes comes back without the
+  // screen on it. Seen on a machine running four workflows at once: the flow
+  // had just asserted `chat-input` visible and the very next dump had no
+  // composer in it at all. Re-reading a second later gets the real tree; the
+  // read is free of side effects, so retrying costs a second and nothing else.
+  for (let attempt = 1; ; attempt += 1) {
+    const chat = readChatOnce(device);
+    if (chat.composer || attempt >= attempts) return chat;
+    execFileSync("sleep", ["1"]);
+  }
+};
+
+const readChatOnce = (device) => {
+  const { byTestId, nodes, screen } = readHierarchy({ device });
+
+  const composer = byTestId.get("chat-input");
+  const chatScreen = byTestId.get("chat-screen");
+
+  /** @type {Map<number, {x:number,y:number,right:number,bottom:number,width:number,height:number}>} */
+  const messages = new Map();
+  for (const node of nodes) {
+    const match = MARKER.exec(node.text ?? "");
+    if (match) {
+      const n = Number(match[1]);
+      // Both the `accessible` bubble and, on some runs, an inner text node
+      // carry the same string. Keep the outer (taller) rect: it is the bubble.
+      const existing = messages.get(n);
+      if (!existing || node.bounds.height > existing.height) {
+        messages.set(n, node.bounds);
+      }
+    }
+  }
+
+  return { composer, chatScreen, messages, screen };
+};
+
+/** Is `rect` entirely inside the band the user can actually read? */
+export const isReadable = (rect, { top, bottom }) =>
+  rect.y >= top && rect.bottom <= bottom;
+
+/** The highest-numbered message that is entirely readable, or null. */
+export const lastReadableMessage = (messages, band) => {
+  let best = null;
+  for (const [n, rect] of messages) {
+    if (isReadable(rect, band) && (!best || n > best.n)) best = { n, rect };
+  }
+  return best;
+};
+
+export const describe = (rect) =>
+  rect ? `[${rect.x},${rect.y}]..[${rect.right},${rect.bottom}]` : "absent";

--- a/apps/mobile/.maestro/checks/lib/chat-geometry.mjs
+++ b/apps/mobile/.maestro/checks/lib/chat-geometry.mjs
@@ -81,3 +81,31 @@ export const lastReadableMessage = (messages, band) => {
 
 export const describe = (rect) =>
   rect ? `[${rect.x},${rect.y}]..[${rect.right},${rect.bottom}]` : "absent";
+
+/**
+ * Drives one of the tiny `checks/lib/*.yaml` fragments.
+ *
+ * A check normally only reads. These two bugs are about what happens BETWEEN
+ * two states — "the row you were reading is still there once the keyboard is
+ * up" — and Maestro runs a check after a flow, not in the middle of one. So
+ * the check performs the transition itself: same binary, same device, one
+ * `tapOn` per fragment, and a hierarchy read on either side.
+ *
+ * The fragments are tagged `util`, which `config.yaml` excludes, so they never
+ * run as flows of their own.
+ */
+export const driveFragment = (name, { device = resolveDevice() } = {}) => {
+  const url = new URL(`${name}.yaml`, import.meta.url);
+  execFileSync(
+    "maestro",
+    [
+      "--device",
+      device.id,
+      "test",
+      "-e",
+      `APP_ID=${process.env.APP_ID ?? "app.pegada"}`,
+      url.pathname,
+    ],
+    { stdio: ["ignore", "inherit", "inherit"], maxBuffer: 32 * 1024 * 1024 },
+  );
+};

--- a/apps/mobile/.maestro/checks/lib/focus-composer.yaml
+++ b/apps/mobile/.maestro/checks/lib/focus-composer.yaml
@@ -1,0 +1,13 @@
+appId: ${APP_ID}
+name: util - focus the chat composer and let the keyboard settle
+tags:
+  - util
+---
+# Driven by checks/44-chat-keyboard-anchor.mjs between two hierarchy reads.
+# `util` is in config.yaml's excludeTags, so this never runs as a flow.
+#
+# No launchApp: it acts on whatever the previous step left on screen.
+- tapOn:
+    id: "chat-input"
+- waitForAnimationToEnd:
+    timeout: 5000

--- a/apps/mobile/.maestro/checks/lib/hierarchy.mjs
+++ b/apps/mobile/.maestro/checks/lib/hierarchy.mjs
@@ -45,6 +45,7 @@ export const readHierarchy = ({ device = resolveDevice() } = {}) => {
   const tree = JSON.parse(raw.slice(raw.indexOf("{")));
 
   const byTestId = new Map();
+  const nodes = [];
   let screen = null;
 
   const walk = (node) => {
@@ -60,6 +61,25 @@ export const readHierarchy = ({ device = resolveDevice() } = {}) => {
     }
     if (bounds && attributes["resource-id"]) {
       byTestId.set(attributes["resource-id"], bounds);
+    }
+    // Flat list of everything that has a rect. `byTestId` cannot answer "where
+    // is the message that reads X": every bubble in the chat carries the same
+    // testID (`chat-message-self` / `chat-message-other`), so the map keeps
+    // one of forty. Checks that need a specific row match on its text.
+    if (bounds) {
+      nodes.push({
+        bounds,
+        testId: attributes["resource-id"] ?? null,
+        // iOS puts a node's label in `accessibilityText` and leaves `text`
+        // empty; Android fills `text`. A check that read only one of them
+        // found nothing on the other platform.
+        text:
+          attributes.accessibilityText ||
+          attributes.text ||
+          attributes.title ||
+          attributes.value ||
+          "",
+      });
     }
 
     for (const child of node.children ?? []) walk(child);
@@ -84,5 +104,5 @@ export const readHierarchy = ({ device = resolveDevice() } = {}) => {
     }
   }
 
-  return { byTestId, screen: screen ?? { width: 0, height: 0 } };
+  return { byTestId, nodes, screen: screen ?? { width: 0, height: 0 } };
 };

--- a/apps/mobile/.maestro/checks/lib/into-history.yaml
+++ b/apps/mobile/.maestro/checks/lib/into-history.yaml
@@ -1,0 +1,26 @@
+appId: ${APP_ID}
+name: util - dismiss the keyboard and scroll back into the conversation history
+tags:
+  - util
+---
+# Driven by checks/44-chat-keyboard-anchor.mjs. Leaves the chat mid-thread
+# with the keyboard down, which is the state the mid-history half of the
+# check measures from.
+#
+# Three swipes, not one: one swipe from the end of a 40-message thread lands
+# close enough to the bottom that the rows the keyboard would cover are the
+# last ones anyway, and the check would be re-testing the at-bottom case.
+- hideKeyboard
+- waitForAnimationToEnd:
+    timeout: 5000
+- swipe:
+    direction: DOWN
+    duration: 400
+- swipe:
+    direction: DOWN
+    duration: 400
+- swipe:
+    direction: DOWN
+    duration: 400
+- waitForAnimationToEnd:
+    timeout: 5000

--- a/apps/mobile/.maestro/config.yaml
+++ b/apps/mobile/.maestro/config.yaml
@@ -49,6 +49,12 @@ executionOrder:
     # the keyboard already up never sees `keyboardDidShow`, so it never
     # consumed the IME inset at all.
     - 42-otp-resend-keyboard-clearance
+    # 43 guards the chat opening on the newest message. It runs after every
+    # flow that reads the seeded conversations, because its pre-script fills
+    # the Rex<->Nina match with 40 messages and that puts Nina at the top of
+    # the Messages list — the row flow 12 taps by coordinate. The fixture is
+    # dropped again by scripts/seed-before-test.sh at the head of every run.
+    - 43-chat-opens-at-latest
     - 26-logout-journey
     # 27 MUST run last — it hard-deletes the delete-me@pegada.app row. The
     # row is re-seeded by `pnpm -F @pegada/database maestro:seed` before

--- a/apps/mobile/.maestro/config.yaml
+++ b/apps/mobile/.maestro/config.yaml
@@ -59,6 +59,10 @@ executionOrder:
     # itself, so it needs the same "after everything that reads the seeded
     # conversations" slot.
     - 44-chat-keyboard-anchor
+    # 45 needs Nina to have four photos, which changes the pagination dots on
+    # every screen that renders her, so it sits down here with the other two
+    # fixture-heavy flows. `seed-before-test.sh` drops the extra photos again.
+    - 45-dog-profile-photo-edges
     - 26-logout-journey
     # 27 MUST run last — it hard-deletes the delete-me@pegada.app row. The
     # row is re-seeded by `pnpm -F @pegada/database maestro:seed` before

--- a/apps/mobile/.maestro/config.yaml
+++ b/apps/mobile/.maestro/config.yaml
@@ -55,6 +55,10 @@ executionOrder:
     # the Messages list — the row flow 12 taps by coordinate. The fixture is
     # dropped again by scripts/seed-before-test.sh at the head of every run.
     - 43-chat-opens-at-latest
+    # 44 shares 43's fixture and its post-check raises and lowers the keyboard
+    # itself, so it needs the same "after everything that reads the seeded
+    # conversations" slot.
+    - 44-chat-keyboard-anchor
     - 26-logout-journey
     # 27 MUST run last — it hard-deletes the delete-me@pegada.app row. The
     # row is re-seeded by `pnpm -F @pegada/database maestro:seed` before

--- a/apps/mobile/.maestro/scripts/pre/43-seed-long-chat.sh
+++ b/apps/mobile/.maestro/scripts/pre/43-seed-long-chat.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Pre-test setup for flow 43. See lib-seed-long-chat.sh.
+set -euo pipefail
+exec bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib-seed-long-chat.sh"

--- a/apps/mobile/.maestro/scripts/pre/44-seed-long-chat.sh
+++ b/apps/mobile/.maestro/scripts/pre/44-seed-long-chat.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Pre-test setup for flow 44. See lib-seed-long-chat.sh.
+set -euo pipefail
+exec bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib-seed-long-chat.sh"

--- a/apps/mobile/.maestro/scripts/pre/45-seed-gallery.sh
+++ b/apps/mobile/.maestro/scripts/pre/45-seed-gallery.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Pre-test setup for flow 45: give Nina four photos instead of one.
+#
+# Every dog `maestro-seed.ts` creates has exactly ONE image, so the photo
+# carousel in `components/MainCard` — the two half-screen Pressables, the
+# pagination dots, and the spring that fires when there is no photo that way —
+# is not reachable from any flow in the suite. That is why the black-half
+# rendering bug on the last photo went unnoticed: nothing could get to it.
+#
+# placedog.net is the same host the seed itself uses, and the ids are distinct
+# so it is obvious from a screenshot which photo is on screen.
+#
+# Every row is `chatux-gallery-%`, which `scripts/seed-before-test.sh` deletes
+# at the head of every run — the extra photos change the pagination dots on any
+# screen that renders Nina, and no other flow was written expecting them.
+set -euo pipefail
+
+DATABASE_URL="${DATABASE_URL:-postgresql://tony:hawk@localhost:3356/pegada}"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q <<'SQL'
+WITH nina AS (SELECT id FROM "Dog" WHERE name = 'Nina' LIMIT 1),
+     extra(n, dog_id) AS (
+       SELECT n, nina.id FROM nina, generate_series(1, 3) AS n
+     )
+INSERT INTO "Image" (id, url, "dogId", "createdAt", "updatedAt", position, status)
+SELECT
+  'chatux-gallery-' || extra.n,
+  'https://placedog.net/640/480?id=' || (30 + extra.n),
+  extra.dog_id,
+  now(),
+  now(),
+  extra.n,
+  'APPROVED'
+FROM extra
+ON CONFLICT (id) DO NOTHING;
+SQL
+
+psql "$DATABASE_URL" -tAc \
+  "SELECT 'Nina has ' || count(i.id) || ' photos, dogId ' || max(d.id)
+     FROM \"Dog\" d JOIN \"Image\" i ON i.\"dogId\" = d.id
+    WHERE d.name = 'Nina'" \
+  | sed 's/^/[pre-45] /'

--- a/apps/mobile/.maestro/scripts/pre/cleanup-long-chat.sh
+++ b/apps/mobile/.maestro/scripts/pre/cleanup-long-chat.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Removes every row `lib-seed-long-chat.sh` inserted.
+#
+# Not a `pre/<NN>-` script: run-flow.sh must never pick it up. Run it by hand
+# after flows 43/44 so the rest of the suite sees the conversation the normal
+# maestro seed created — an empty Rex<->Nina match.
+set -euo pipefail
+
+DATABASE_URL="${DATABASE_URL:-postgresql://tony:hawk@localhost:3356/pegada}"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q \
+  -c "DELETE FROM \"Message\" WHERE content LIKE 'chatux message %';"
+
+psql "$DATABASE_URL" -tAc \
+  "SELECT count(*) FROM \"Message\" WHERE content LIKE 'chatux message %'" \
+  | sed 's/^/[cleanup-chatux] remaining fixture rows: /'

--- a/apps/mobile/.maestro/scripts/pre/lib-seed-long-chat.sh
+++ b/apps/mobile/.maestro/scripts/pre/lib-seed-long-chat.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Shared fixture for flows 43 and 44: a conversation long enough to scroll.
+#
+# Why a separate conversation and not Rex<->Bella: flows 11, 12, 19 and 34 all
+# read the seeded Rex<->Bella thread — 34 back-dates every one of its messages,
+# 19 asserts on the message it sends there — so growing it to 40 messages would
+# change what four other flows are looking at. `maestro-seed.ts` also creates a
+# Rex<->Nina match with ZERO messages, which is exactly the empty slot this
+# fixture needs.
+#
+# Every row this inserts is tagged `chatux message NN`, which is what
+# `cleanup-long-chat.sh` deletes. Nothing else in the schema is touched.
+#
+# The messages are stamped `now - (COUNT - n) minutes` so they all land on
+# today: one "Today" separator at the top of the thread and none in between,
+# which keeps the geometry the checks measure free of separator rows appearing
+# and disappearing between runs.
+set -euo pipefail
+
+DATABASE_URL="${DATABASE_URL:-postgresql://tony:hawk@localhost:3356/pegada}"
+COUNT="${CHATUX_MESSAGE_COUNT:-40}"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -v count="$COUNT" -q <<'SQL'
+WITH convo AS (
+  SELECT m.id, m."requesterId", m."responderId"
+  FROM "Match" m
+  JOIN "Dog" r ON r.id = m."requesterId"
+  JOIN "Dog" s ON s.id = m."responderId"
+  WHERE m."deletedAt" IS NULL
+    AND ((r.name = 'Rex' AND s.name = 'Nina') OR (r.name = 'Nina' AND s.name = 'Rex'))
+  ORDER BY m."createdAt" ASC
+  LIMIT 1
+),
+-- Delete first so the fixture is idempotent: re-running a flow must not
+-- stack a second 40 messages on top of the first.
+wipe AS (
+  DELETE FROM "Message"
+  WHERE "matchId" = (SELECT id FROM convo)
+  RETURNING 1
+),
+series AS (SELECT generate_series(1, :count) AS n)
+INSERT INTO "Message" (id, content, "createdAt", "senderId", "receiverId", "matchId")
+SELECT
+  gen_random_uuid()::text,
+  'chatux message ' || lpad(series.n::text, 2, '0'),
+  now() - (interval '1 minute' * (:count - series.n)),
+  -- Alternate sides so the thread has both bubble variants, like a real one.
+  CASE WHEN series.n % 2 = 1 THEN convo."requesterId" ELSE convo."responderId" END,
+  CASE WHEN series.n % 2 = 1 THEN convo."responderId" ELSE convo."requesterId" END,
+  convo.id
+FROM series, convo
+WHERE (SELECT count(*) FROM wipe) >= 0;
+SQL
+
+psql "$DATABASE_URL" -tAc \
+  "SELECT count(*) FROM \"Message\" WHERE content LIKE 'chatux message %' AND \"deletedAt\" IS NULL" \
+  | sed 's/^/[pre-chatux] long-chat fixture rows: /'

--- a/apps/mobile/.maestro/scripts/seed-before-test.sh
+++ b/apps/mobile/.maestro/scripts/seed-before-test.sh
@@ -36,4 +36,10 @@ DATABASE_URL="$DATABASE_URL" pnpm -F @pegada/database maestro:seed >/dev/null 2>
 psql "$DATABASE_URL" -q -c \
   "DELETE FROM \"Message\" WHERE content LIKE 'chatux message %';" >/dev/null 2>&1 || true
 
+# Same story for flow 45's extra photos on Nina: they change the pagination
+# dots on every screen that renders her, and `pre/45-seed-gallery.sh` puts them
+# back for the one flow that wants them.
+psql "$DATABASE_URL" -q -c \
+  "DELETE FROM \"Image\" WHERE id LIKE 'chatux-gallery-%';" >/dev/null 2>&1 || true
+
 echo "seeded"

--- a/apps/mobile/.maestro/scripts/seed-before-test.sh
+++ b/apps/mobile/.maestro/scripts/seed-before-test.sh
@@ -23,4 +23,17 @@ DATABASE_URL="${DATABASE_URL:-postgresql://tony:hawk@localhost:3356/pegada}"
 
 cd "$REPO_ROOT"
 DATABASE_URL="$DATABASE_URL" pnpm -F @pegada/database maestro:seed >/dev/null 2>&1
+
+# Drop the long-conversation fixture flows 43 and 44 seed into the otherwise
+# empty Rex<->Nina match. `maestro:seed` is idempotent by not re-creating rows
+# that exist, so without this those 40 messages survive their flow and every
+# later run starts with Nina at the top of the Messages list — which is the row
+# flow 12 taps by coordinate and flow 19 taps as `messages-chat-row`.
+#
+# Here rather than at the end of the two checks: a flow that fails never
+# reaches its check, and the fixture has to be gone for the NEXT flow either
+# way. `pre/43-seed-long-chat.sh` runs after this, so 43 and 44 still get it.
+psql "$DATABASE_URL" -q -c \
+  "DELETE FROM \"Message\" WHERE content LIKE 'chatux message %';" >/dev/null 2>&1 || true
+
 echo "seeded"

--- a/apps/mobile/src/components/MainCard/index.tsx
+++ b/apps/mobile/src/components/MainCard/index.tsx
@@ -25,6 +25,28 @@ const springConfig = { mass: 0.2 };
 
 const START_IMAGE_INDEX = 0;
 
+/**
+ * How far the card slides when there is no photo that way, in dp.
+ *
+ * This used to be a `rotateY` of half a degree under a `perspective` of 100,
+ * and it rendered as a black rectangle over half the card. A non-affine
+ * transform on a layer that also has `overflow: hidden` forces Core Animation
+ * to composite it offscreen, and on iOS 26 one half of the card came back
+ * empty for the ~330ms the spring ran — the DogProfile's black backdrop
+ * showing through, photo, pagination dots and distance pill all gone.
+ * Measured across 40 screenshots taken during the gesture: 6 of them had
+ * 49.7% of the card as pure #000000, split by a dead-straight vertical seam
+ * down the middle.
+ *
+ * The seam is the tell. The half that DID draw was not rotated at all — no
+ * keystone, no skew — so the 3D warp was never visible in the first place.
+ * Half a degree of rotateY on a 393dp card is a sub-pixel effect; all it ever
+ * did was buy the compositing bug. A translate is affine, needs no offscreen
+ * pass, and is the rubber-band every list on the platform uses to say "this is
+ * the end".
+ */
+const EDGE_NUDGE = 10;
+
 // oxlint-disable-next-line typescript/consistent-type-definitions -- `Container` is a reanimated Animated.View, whose props carry a string index signature. `interface … extends` keeps the members below at their declared types; the `{…} & Props` intersection the rule wants intersects each of them with the index signature's `any` and silently widens all three to `any`.
 export interface VisitingCardProps extends React.ComponentProps<
   typeof Container
@@ -44,7 +66,7 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
   const [currentImage, setCurrentImage] = useState(startImageIndex);
   const router = useRouter();
 
-  const rotation = useSharedValue(0);
+  const nudge = useSharedValue(0);
 
   const openUserProfile = () => {
     router.push({
@@ -63,8 +85,10 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
 
     if (currentImage !== 0) return setCurrentImage((index) => index - 1);
 
-    rotation.value = withSequence(
-      withSpring(-0.5, springConfig),
+    // Already on the first photo: slide right, towards the edge the reader is
+    // trying to reach.
+    nudge.value = withSequence(
+      withSpring(EDGE_NUDGE, springConfig),
       withSpring(0, springConfig),
     );
   };
@@ -77,17 +101,16 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
     if (currentImage + 1 < images.length) {
       return setCurrentImage((index) => index + 1);
     }
-    rotation.value = withSequence(
-      withSpring(0.5, springConfig),
+    // Already on the last photo.
+    nudge.value = withSequence(
+      withSpring(-EDGE_NUDGE, springConfig),
       withSpring(0, springConfig),
     );
   };
 
   const transform = useAnimatedStyle(() => {
     "worklet";
-    return {
-      transform: [{ perspective: 100 }, { rotateY: `${rotation.value}deg` }],
-    };
+    return { transform: [{ translateX: nudge.value }] };
   });
 
   return (

--- a/apps/mobile/src/views/Chat/hooks/keyboard-anchor.test.ts
+++ b/apps/mobile/src/views/Chat/hooks/keyboard-anchor.test.ts
@@ -1,0 +1,117 @@
+import { anchorTargetForKeyboard, distanceFromEnd } from "./keyboard-anchor";
+
+/**
+ * The bug these pin: raising the keyboard in a conversation lost your place in
+ * it. `views/Chat` shrinks its container by the keyboard's overlap to keep the
+ * composer on screen, which takes the height off the BOTTOM of the list's
+ * viewport while leaving the scroll offset alone — so the window onto the
+ * thread is anchored by its top edge and everything at the bottom, including
+ * the message you tapped the field to answer, slides in behind the composer.
+ *
+ * The numbers below are an iPhone 17e in the seeded 40-message conversation:
+ * the composer's top edge travels 301pt when the IME arrives (335pt of
+ * keyboard, less the 34pt safe-area inset the composer stops reserving), over
+ * a list whose content is 1600pt against an 800pt viewport.
+ */
+
+const COMPOSER_TRAVEL = 336;
+const MID_HISTORY = { offset: 400, distanceFromEnd: 400 };
+const AT_END = { offset: 800, distanceFromEnd: 0 };
+
+describe("anchorTargetForKeyboard", () => {
+  it("pushes the offset down by the keyboard's height when the keyboard opens", () => {
+    // This is the whole fix: the viewport lost 336pt off its bottom edge, so
+    // the offset gains 336pt and the bottom of the window stays on the same
+    // message.
+    expect(anchorTargetForKeyboard(COMPOSER_TRAVEL, MID_HISTORY)).toStrictEqual(
+      {
+        kind: "offset",
+        offset: 736,
+      },
+    );
+  });
+
+  it("pulls it back by the same amount when the keyboard closes", () => {
+    const raised = { offset: 736, distanceFromEnd: 736 };
+    expect(anchorTargetForKeyboard(-COMPOSER_TRAVEL, raised)).toStrictEqual({
+      kind: "offset",
+      offset: 400,
+    });
+  });
+
+  it("round-trips: open then close puts the list back where it started", () => {
+    const opened = anchorTargetForKeyboard(COMPOSER_TRAVEL, MID_HISTORY);
+    if (opened?.kind !== "offset") throw new Error("expected an offset target");
+
+    const closed = anchorTargetForKeyboard(-COMPOSER_TRAVEL, {
+      offset: opened.offset,
+      distanceFromEnd: MID_HISTORY.distanceFromEnd + COMPOSER_TRAVEL,
+    });
+
+    expect(closed).toStrictEqual({
+      kind: "offset",
+      offset: MID_HISTORY.offset,
+    });
+  });
+
+  it("asks for the end when the list is already at the end", () => {
+    // Not `offset + delta`: at the end the content padding changes in the same
+    // commit (the bottom safe-area inset is dropped while the keyboard is up),
+    // so the arithmetic overshoots the new maximum offset by exactly that
+    // inset and gets clamped. "Scroll to the end" is exact whatever the
+    // padding does.
+    expect(anchorTargetForKeyboard(COMPOSER_TRAVEL, AT_END)).toStrictEqual({
+      kind: "end",
+    });
+  });
+
+  it("treats a few points short of the end as the end", () => {
+    expect(
+      anchorTargetForKeyboard(COMPOSER_TRAVEL, {
+        offset: 790,
+        distanceFromEnd: 10,
+      }),
+    ).toStrictEqual({ kind: "end" });
+  });
+
+  it("does not go past the top of the list", () => {
+    expect(
+      anchorTargetForKeyboard(-COMPOSER_TRAVEL, {
+        offset: 40,
+        distanceFromEnd: 900,
+      }),
+    ).toStrictEqual({ kind: "offset", offset: 0 });
+  });
+
+  it("ignores sub-point noise", () => {
+    // `keyboardWillChangeFrame` fires for things that are not the keyboard
+    // arriving. Scrolling the list for those is visible jitter.
+    expect(anchorTargetForKeyboard(0, MID_HISTORY)).toBeNull();
+    expect(anchorTargetForKeyboard(0.5, MID_HISTORY)).toBeNull();
+    expect(anchorTargetForKeyboard(-0.5, MID_HISTORY)).toBeNull();
+  });
+
+  it("ignores a delta that is not a number", () => {
+    expect(anchorTargetForKeyboard(Number.NaN, MID_HISTORY)).toBeNull();
+  });
+});
+
+describe("distanceFromEnd", () => {
+  it("is how much content is left below the window", () => {
+    expect(
+      distanceFromEnd({ contentHeight: 1600, layoutHeight: 800, offset: 400 }),
+    ).toBe(400);
+  });
+
+  it("is zero at the end", () => {
+    expect(
+      distanceFromEnd({ contentHeight: 1600, layoutHeight: 800, offset: 800 }),
+    ).toBe(0);
+  });
+
+  it("never goes negative when a bounce overscrolls the end", () => {
+    expect(
+      distanceFromEnd({ contentHeight: 1600, layoutHeight: 800, offset: 860 }),
+    ).toBe(0);
+  });
+});

--- a/apps/mobile/src/views/Chat/hooks/keyboard-anchor.ts
+++ b/apps/mobile/src/views/Chat/hooks/keyboard-anchor.ts
@@ -1,0 +1,82 @@
+/**
+ * Where a chat list has to be scrolled to after the keyboard changes size.
+ *
+ * Separated from the hook, and from React, for the same reason
+ * `keyboard-overlap.ts` is: the interesting part is arithmetic about a
+ * viewport that changed height, and it is only observable by replaying a
+ * sequence of keyboard events — which needs no renderer and no device.
+ *
+ * The problem it solves: `views/Chat` keeps the composer above the IME by
+ * shrinking the screen container (`paddingBottom: keyboardOverlap`). That
+ * shrinks the list's viewport from the BOTTOM while its scroll offset stays
+ * put, so the window onto the conversation is anchored by its top edge: every
+ * row you were reading at the bottom slides in behind the composer. Tap the
+ * field to answer the message in front of you and that message is the first
+ * thing to go.
+ *
+ * WhatsApp anchors the other edge. Keeping the bottom of the window on the
+ * same content while the window loses `delta` points of height means moving
+ * the offset by exactly `delta` — down when the keyboard opens, back up when
+ * it closes. That is the whole rule.
+ */
+
+/**
+ * Ignore sub-point noise. `keyboardWillChangeFrame` fires for things that are
+ * not the keyboard arriving — an autocomplete strip resizing by a fraction of
+ * a point — and scrolling the list for those would be visible jitter.
+ */
+const MIN_DELTA = 1;
+
+/**
+ * How close to the end still counts as "at the end".
+ *
+ * At the end the offset arithmetic and "scroll to the end" agree, but they
+ * fail differently: the arithmetic can overshoot the new maximum offset and be
+ * clamped, and the amount it is clamped by is the bottom safe-area inset,
+ * which `useKeyboardAwareSafeAreaInsets` drops from the content padding in the
+ * same commit. Asking for the end is exact whatever the padding does, so at
+ * the end that is what we ask for.
+ */
+const AT_END_THRESHOLD = 24;
+
+export type ChatScrollMetrics = {
+  /** Current `contentOffset.y`. */
+  offset: number;
+  /** `contentSize.height - layoutMeasurement.height - offset`, never negative. */
+  distanceFromEnd: number;
+};
+
+export type AnchorTarget = { kind: "end" } | { kind: "offset"; offset: number };
+
+/**
+ * The scroll position that keeps the bottom of the visible window on the same
+ * message, given how much the strip below the list just grew or shrank.
+ *
+ * @param delta   the change in occluded bottom height, in dp — keyboard plus
+ *                composer plus its current safe-area inset. Positive when
+ *                more of the screen's bottom just went away. It is also
+ *                exactly how far the composer's top edge travelled, which is
+ *                the edge a reader judges "did I lose my place" against.
+ * @param metrics the list's scroll state BEFORE the change is committed.
+ */
+export const anchorTargetForKeyboard = (
+  delta: number,
+  metrics: ChatScrollMetrics,
+): AnchorTarget | null => {
+  if (!Number.isFinite(delta) || Math.abs(delta) < MIN_DELTA) return null;
+
+  if (metrics.distanceFromEnd <= AT_END_THRESHOLD) return { kind: "end" };
+
+  return { kind: "offset", offset: Math.max(0, metrics.offset + delta) };
+};
+
+/** `distanceFromEnd` from a native scroll event's three measurements. */
+export const distanceFromEnd = ({
+  contentHeight,
+  layoutHeight,
+  offset,
+}: {
+  contentHeight: number;
+  layoutHeight: number;
+  offset: number;
+}) => Math.max(0, contentHeight - layoutHeight - offset);

--- a/apps/mobile/src/views/Chat/hooks/use-chat-list-anchor.ts
+++ b/apps/mobile/src/views/Chat/hooks/use-chat-list-anchor.ts
@@ -1,49 +1,151 @@
+import type { AnchorTarget } from "./keyboard-anchor";
 import type { FlashListRef } from "@shopify/flash-list";
+
+import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
 
 import * as React from "react";
 
+import { anchorTargetForKeyboard, distanceFromEnd } from "./keyboard-anchor";
+
 /**
- * Keeps the conversation list at its newest message until the reader takes
- * over.
+ * The keyboard's own animation is ~250ms on iOS and a window resize on
+ * Android, and the screen container's `paddingBottom` rides that curve through
+ * `LayoutAnimation`. A `scrollTo` issued while it is still in flight is
+ * clamped against the viewport height it has RIGHT NOW, which is still the
+ * tall one — so at the end of a conversation the first attempt lands short by
+ * up to the keyboard's height. Re-asserting the same target once the curve has
+ * finished is what makes it exact, and re-asserting is a no-op when the first
+ * attempt already landed.
+ */
+const SETTLE_MS = 320;
+
+/**
+ * Everything that decides where the conversation list is scrolled to.
  *
+ * Two rules, both about the same edge — the bottom of the thread, where the
+ * newest message is and where you are almost always reading:
+ *
+ * **Open on the newest message.**
  * `maintainVisibleContentPosition.startRenderingFromBottom` decides the
  * position from the FIRST committed layout, and on a chat that is not the
  * final one. A row's height changes after it is measured — the day separator
- * `renderItem` puts above a message is ~40pt and only exists once the row on
- * either side of it is known — so the list can be at the end when FlashList
+ * `renderItem` puts above a message is ~40pt and only exists once the rows on
+ * either side of it are known — so the list can be at the end when FlashList
  * scrolls it there and 40pt short of it a commit later, with the newest
- * message clipped behind the composer. Measured on a fresh install's first
- * open: row 40 at y 731..769 against a composer starting at 745.
+ * message clipped behind the composer. So: re-assert the end on every
+ * content-size change, and stop the moment the reader drags. After that first
+ * drag `autoscrollToBottomThreshold` owns it again, which is the case it is
+ * good at — a new message arriving while you are already at the bottom.
  *
- * `autoscrollToBottomThreshold` is supposed to cover exactly this, but it only
- * re-pins on the commits where `checkBounds` happens to run, which is why it
- * caught the growth sometimes and not always.
+ * **Hold your place when the keyboard moves.**
+ * `views/Chat` keeps the composer above the IME by shrinking the screen
+ * container, which takes the height off the BOTTOM of the list's viewport
+ * while leaving the scroll offset alone: the window onto the conversation is
+ * anchored by its top edge, and every row you were reading at the bottom
+ * slides in behind the composer. Measured before this hook: the anchor row did
+ * not move a single point while the composer rose 301pt, ending 285pt
+ * underneath it. Moving the offset by the same amount the viewport lost keeps
+ * the bottom edge on the same message, which is what WhatsApp does. The
+ * arithmetic is in `keyboard-anchor.ts` and tested there.
  *
- * So: re-assert the end on every content-size change, and stop the moment the
- * reader drags. After that first drag the threshold owns it again — that is
- * the case it is good at, a new message arriving while you are already at the
- * bottom.
+ * `occludedBottom` is the height of the strip along the bottom of the screen
+ * the list cannot use — keyboard plus composer plus whatever safe-area inset
+ * the composer is carrying right now. It is one number rather than the
+ * keyboard's on its own because those two move together and by different
+ * amounts: `useKeyboardAwareSafeAreaInsets` drops the bottom inset while the
+ * IME is up, so the composer shrinks by 34pt in the same commit the keyboard
+ * takes 335. `views/Chat` computes it, rather than this hook reading
+ * `useKeyboardOverlap` again, because that hook drives `LayoutAnimation` from
+ * its listener and a second subscription would configure the next animation
+ * twice.
  */
-export const useChatListAnchor = <TItem>() => {
+export const useChatListAnchor = <TItem>(occludedBottom: number) => {
   const listRef = React.useRef<FlashListRef<TItem>>(null);
   const readerTookOver = React.useRef(false);
+  const metrics = React.useRef({ offset: 0, distanceFromEnd: 0 });
+  const previousOcclusion = React.useRef(occludedBottom);
+  const pending = React.useRef<(() => void) | null>(null);
+
+  const cancelPending = React.useCallback(() => {
+    pending.current?.();
+    pending.current = null;
+  }, []);
 
   const onScrollBeginDrag = React.useCallback(() => {
     readerTookOver.current = true;
-  }, []);
+    // A pending re-assert would fight a reader who starts flicking through the
+    // history the instant the keyboard lands. Their drag wins.
+    cancelPending();
+  }, [cancelPending]);
+
+  const onScroll = React.useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+
+      metrics.current = {
+        offset: contentOffset.y,
+        distanceFromEnd: distanceFromEnd({
+          contentHeight: contentSize.height,
+          layoutHeight: layoutMeasurement.height,
+          offset: contentOffset.y,
+        }),
+      };
+    },
+    [],
+  );
 
   const pinToEnd = React.useCallback(() => {
     if (readerTookOver.current) return;
     void listRef.current?.scrollToEnd({ animated: false });
   }, []);
 
+  React.useEffect(() => {
+    const delta = occludedBottom - previousOcclusion.current;
+    previousOcclusion.current = occludedBottom;
+
+    const target = anchorTargetForKeyboard(delta, metrics.current);
+    if (!target) return;
+
+    cancelPending();
+
+    const apply = (anchor: AnchorTarget) => () => {
+      const list = listRef.current;
+      if (!list) return;
+
+      if (anchor.kind === "end") {
+        void list.scrollToEnd({ animated: false });
+        return;
+      }
+      list.scrollToOffset({ offset: anchor.offset, animated: false });
+    };
+
+    const run = apply(target);
+    run();
+
+    const frame = requestAnimationFrame(run);
+    const timer = setTimeout(run, SETTLE_MS);
+
+    const cancel = () => {
+      cancelAnimationFrame(frame);
+      clearTimeout(timer);
+    };
+    pending.current = cancel;
+
+    return cancel;
+  }, [cancelPending, occludedBottom]);
+
   return {
     listRef,
     /** Spread onto the `FlashList`. */
     listProps: {
+      onScroll,
       onScrollBeginDrag,
       onContentSizeChange: pinToEnd,
       onLoad: pinToEnd,
+      // The anchor arithmetic needs `contentOffset` fresh at the moment the
+      // keyboard event lands, not at the end of a 16ms coalescing window.
+      scrollEventThrottle: 16,
     },
   };
 };

--- a/apps/mobile/src/views/Chat/hooks/use-chat-list-anchor.ts
+++ b/apps/mobile/src/views/Chat/hooks/use-chat-list-anchor.ts
@@ -1,0 +1,49 @@
+import type { FlashListRef } from "@shopify/flash-list";
+
+import * as React from "react";
+
+/**
+ * Keeps the conversation list at its newest message until the reader takes
+ * over.
+ *
+ * `maintainVisibleContentPosition.startRenderingFromBottom` decides the
+ * position from the FIRST committed layout, and on a chat that is not the
+ * final one. A row's height changes after it is measured — the day separator
+ * `renderItem` puts above a message is ~40pt and only exists once the row on
+ * either side of it is known — so the list can be at the end when FlashList
+ * scrolls it there and 40pt short of it a commit later, with the newest
+ * message clipped behind the composer. Measured on a fresh install's first
+ * open: row 40 at y 731..769 against a composer starting at 745.
+ *
+ * `autoscrollToBottomThreshold` is supposed to cover exactly this, but it only
+ * re-pins on the commits where `checkBounds` happens to run, which is why it
+ * caught the growth sometimes and not always.
+ *
+ * So: re-assert the end on every content-size change, and stop the moment the
+ * reader drags. After that first drag the threshold owns it again — that is
+ * the case it is good at, a new message arriving while you are already at the
+ * bottom.
+ */
+export const useChatListAnchor = <TItem>() => {
+  const listRef = React.useRef<FlashListRef<TItem>>(null);
+  const readerTookOver = React.useRef(false);
+
+  const onScrollBeginDrag = React.useCallback(() => {
+    readerTookOver.current = true;
+  }, []);
+
+  const pinToEnd = React.useCallback(() => {
+    if (readerTookOver.current) return;
+    void listRef.current?.scrollToEnd({ animated: false });
+  }, []);
+
+  return {
+    listRef,
+    /** Spread onto the `FlashList`. */
+    listProps: {
+      onScrollBeginDrag,
+      onContentSizeChange: pinToEnd,
+      onLoad: pinToEnd,
+    },
+  };
+};

--- a/apps/mobile/src/views/Chat/index.tsx
+++ b/apps/mobile/src/views/Chat/index.tsx
@@ -40,15 +40,27 @@ const keyExtractor = (message: MessageProps) => String(message.id);
 // which remounts the empty state each time a message arrives.
 const ListEmptyComponent = () => <Empty />;
 
-const ChatMessageList = () => {
+const ChatMessageList = ({ keyboardOverlap }: { keyboardOverlap: number }) => {
   const { dogId } = useLocalSearchParams();
   const { theme } = useUnistyles();
 
   const { messages, hasNextPage, loadMore } = useChatPagination();
 
-  const { listRef, listProps } = useChatListAnchor<MessageProps>();
-
   const insets = useKeyboardAwareSafeAreaInsets();
+
+  // The strip along the bottom of the screen the conversation cannot use —
+  // `screenHeight - composerTop`. All three terms move together and not by the
+  // same amount: the keyboard takes `keyboardOverlap` from the container, and
+  // the composer gives back the bottom safe-area inset at the same time
+  // (`useKeyboardAwareSafeAreaInsets` drops it while the IME is up, because
+  // the home indicator is drawn over the keyboard). Anchoring on the sum is
+  // what keeps a row's distance to the composer's top edge fixed; anchoring on
+  // the keyboard alone slides the whole thread up by that inset — 34pt of
+  // drift on this device, harmless but visible.
+  const occludedBottom = keyboardOverlap + SEND_HEIGHT + insets.bottom;
+
+  const { listRef, listProps } =
+    useChatListAnchor<MessageProps>(occludedBottom);
 
   const MessageLoader = hasNextPage ? (
     <ActivityIndicator color={theme.colors.text} />
@@ -149,6 +161,13 @@ const Chat = () => {
   // on Android, where `behavior` has to be left undefined — so the composer
   // stayed pinned to the bottom of the display, under the IME, and everything
   // typed into it was invisible.
+  //
+  // The list needs the same number: shrinking the container takes the height
+  // off the BOTTOM of its viewport, which is the edge the reader is on, so it
+  // has to move its offset by the same amount to stay on the same message.
+  // Read once and passed down rather than read again inside the list — the
+  // hook drives `LayoutAnimation` from its listener, and two subscriptions
+  // would configure the next animation twice.
   const keyboardOverlap = useKeyboardOverlap();
 
   return (
@@ -167,7 +186,7 @@ const Chat = () => {
         style={styles.background} // Tiling pattern
       >
         <NetworkBoundary>
-          <ChatMessageList />
+          <ChatMessageList keyboardOverlap={keyboardOverlap} />
         </NetworkBoundary>
         <Send />
         <Header />

--- a/apps/mobile/src/views/Chat/index.tsx
+++ b/apps/mobile/src/views/Chat/index.tsx
@@ -15,6 +15,7 @@ import { Header, Message, NextDay, Send } from "@/views/Chat/components";
 
 import { HEADER_HEIGHT } from "./components/Header";
 import { SEND_HEIGHT } from "./components/Send";
+import { useChatListAnchor } from "./hooks/use-chat-list-anchor";
 import { useChatPagination } from "./hooks/use-chat-pagination";
 import { CenteredText, CenteredView, styles } from "./styles";
 
@@ -44,6 +45,8 @@ const ChatMessageList = () => {
   const { theme } = useUnistyles();
 
   const { messages, hasNextPage, loadMore } = useChatPagination();
+
+  const { listRef, listProps } = useChatListAnchor<MessageProps>();
 
   const insets = useKeyboardAwareSafeAreaInsets();
 
@@ -94,6 +97,8 @@ const ChatMessageList = () => {
   // Older messages are at the top, so the loading spinner goes in the
   // header and pagination triggers via onStartReached.
   const flashListProps = {
+    ...listProps,
+    ref: listRef,
     contentContainerStyle,
     data: messages,
     keyExtractor,
@@ -102,7 +107,27 @@ const ChatMessageList = () => {
     renderItem,
     onStartReached: loadMore,
     onStartReachedThreshold: 0.5,
-    maintainVisibleContentPosition: { autoscrollToBottomThreshold: 0.2 },
+    // `startRenderingFromBottom` is what actually opens the conversation on
+    // the newest message. Without it the list mounts at offset 0 — the OLDEST
+    // message — and the only thing that ever moved it was
+    // `autoscrollToBottomThreshold` happening to fire as rows measured and the
+    // content grew past FlashList's estimate. That works on a cold open, where
+    // react-query holds one 20-row page and offset 0 is close enough to the
+    // end to be inside the threshold. Re-enter the same conversation and the
+    // cache holds every page that was paginated in, the list mounts full
+    // height, offset 0 is nowhere near the threshold, nothing fires, and the
+    // chat opens on the first message ever sent. Measured before this line
+    // existed: 12 of 12 warm opens landed on row 1 of 40.
+    //
+    // It sets `initialScrollIndex` to the last row, so the position is decided
+    // by the layout manager on the first committed layout instead of by which
+    // side of a growth heuristic the render happened to land on. The threshold
+    // stays: it is what keeps the view pinned when a NEW message arrives while
+    // you are already at the bottom.
+    maintainVisibleContentPosition: {
+      autoscrollToBottomThreshold: 0.2,
+      startRenderingFromBottom: true,
+    },
   };
 
   return (


### PR DESCRIPTION
Three UX defects Gabriel hit on device, each root-caused, fixed, and gated by a new failing-first regression flow (43/44/45) with pixel/rect-level checks — `assertVisible` can't see any of them (a bubble under the composer is still in the a11y tree; the black-frame fault is invisible to it entirely).

## 1. Chat opened on the oldest message (inconsistent)

FlashList v2 dropped `inverted`; the list mounted at offset 0 and only `autoscrollToBottomThreshold` ever moved it — which wins on a cold single-page open and loses on warm re-opens with cached pages. Measured pre-fix: 0/12 warm re-opens landed on the newest message. Fix: `startRenderingFromBottom` plus an anchor hook that re-asserts the end on content-size changes (day separators measure in late) and stands down the moment the reader drags. Post-fix: 10/10 runs land the newest message within 1pt.

## 2. Keyboard stole your reading position

The container shrinks to lift the composer, taking height off the bottom of the viewport while the offset stays put — so the keyboard covered exactly what you were reading. Fix (WhatsApp behavior): when the usable window loses N points off its bottom, the offset gains N — where N is the composer's top-edge travel, not the keyboard height (the composer gives back the safe-area inset in the same commit; anchoring on the keyboard alone left 34pt of drift). At-end threads pin to the end instead. Measured: 301pt of content shift against 301pt of composer travel, anchor row preserved within a point. 11 unit tests pin the arithmetic.

## 3. "Warp" on the profile photo made half the image black

Not a shared-element transition — there isn't one in the repo. It's the dog-card photo carousel's edge bounce: a 0.5° `rotateY` under `perspective: 100` on a layer with `overflow: hidden` forces offscreen compositing, and on iOS 26 part of the layer comes back empty — measured 98.8% pure black on the first photo's bounce, 49.8% on the last, split by a vertical seam. And the rotation itself never rendered. Fix: a 10dp `translateX` rubber-band — affine, no offscreen pass, and actually visible. Worst black share drops to ~2.7%, which is just the backdrop the nudge reveals.

The carousel edge case was unreachable by every existing flow (the seed gives each dog one photo); the new fixtures seed a 4-photo dog and a 40-message thread, cleaned up by the standard pre-scripts.

## Verification

iOS Release (iPhone 17e): flows 43 (N=10), 44, 45 green; regression subset 30/34/37 green; 71 jest tests, oxlint (direct), oxfmt, tsc clean. Before/after videos per bug in the harness (`.unistyles-migration/chat-ux-fixes/`). Android: fixes are platform-agnostic by construction (cross-platform APIs, affine transform, IME-inset math shared with the shipped keyboard work), but device verification is pending — both emulators are held by running workflows; will follow up with the Android pass before this needs to ship.
