### PR TITLE
test(mobile): the grand journey — two accounts to a live match, recorded and DB-proven on both platforms

### DIFF
--- a/.github/scripts/maestro-run-shard.sh
+++ b/.github/scripts/maestro-run-shard.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Run one Maestro shard through the repo's own run-flow.sh and emit a JUnit
+# file that maestro-report.py can read.
+#
+#   maestro-run-shard.sh <shard-name> <flow-id> [flow-id ...]
+#
+# WHY THIS EXISTS RATHER THAN `maestro test <files...> --format junit`
+#
+# The iOS extended lane calls maestro directly, which means it skips
+# apps/mobile/.maestro/scripts/run-flow.sh — and with it the per-flow seed,
+# the `scripts/pre/<NN>-*.sh` setup and the `checks/<NN>-*.sh` post-check.
+# That is forced on it: a hosted macOS runner has no route to the database
+# those three things talk to. This lane has the database on localhost, so it
+# runs the real wrapper, and the wrapper's exit code — not maestro's — is the
+# verdict. Several flows here are ONLY meaningful through it:
+#
+#   * 34 asserts a date format that scripts/pre/34-backdate-chat.sh creates.
+#   * 33 and 35 park a screen; checks/33 and checks/35 measure the frame
+#     buffer, which is where the actual assertion lives.
+#   * 50's post-check is what proves the match, the messages and both push
+#     events reached Postgres at all.
+#
+# maestro's own JUnit cannot express a post-check failure, so this script
+# synthesizes the rollup instead: one <testsuite> per flow, named by file
+# stem (which is what maestro-report.py's quarantine lookup compares
+# against), failed iff run-flow.sh exited non-zero for every attempt.
+#
+# Exit code is 0 when every flow passed, 1 otherwise. Callers that want a
+# soft gate discard it; the job-level `continue-on-error` does that today.
+set -uo pipefail
+
+SHARD="${1:?usage: maestro-run-shard.sh <shard-name> <flow-id> [flow-id ...]}"
+shift
+FLOW_IDS=("$@")
+if [ "${#FLOW_IDS[@]}" -eq 0 ]; then
+  echo "::error::no flow ids given for shard $SHARD"
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MAESTRO_DIR="$REPO_ROOT/apps/mobile/.maestro"
+RUN_FLOW="$MAESTRO_DIR/scripts/run-flow.sh"
+QUARANTINE_FILE="$MAESTRO_DIR/quarantined.txt"
+LOG_DIR="${MAESTRO_SHARD_LOG_DIR:-$REPO_ROOT/maestro-logs-$SHARD}"
+JUNIT="${MAESTRO_SHARD_JUNIT:-$REPO_ROOT/maestro-results-$SHARD.xml}"
+
+# Retries absorb single-run noise the same way the required lane does. They
+# are safe here precisely because run-flow.sh re-seeds and re-runs the
+# pre-script on every invocation, so attempt 2 starts from the same state
+# attempt 1 did rather than from attempt 1's wreckage.
+ATTEMPTS="${MAESTRO_SHARD_ATTEMPTS:-2}"
+
+mkdir -p "$LOG_DIR"
+
+# XML-escape, because a failing flow's log tail goes into an attribute.
+esc() {
+  printf '%s' "$1" \
+    | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
+          -e 's/"/\&quot;/g' -e "s/'/\&apos;/g" \
+    | tr -d '\000-\010\013\014\016-\037'
+}
+
+# Same quarantine semantics the iOS extended lane applies: a quarantined
+# flow is not run at all. Skipping rather than running-and-forgiving matters
+# on this lane, where a flow costs minutes of emulator time.
+QUARANTINED=""
+if [ -f "$QUARANTINE_FILE" ]; then
+  QUARANTINED="$(grep -v '^[[:space:]]*#' "$QUARANTINE_FILE" | awk '{print $1}' | grep -v '^$' | sort -u)"
+fi
+
+SUITES=""
+OVERALL_RC=0
+SUMMARY=()
+
+for id in "${FLOW_IDS[@]}"; do
+  # Same padding rule run-flow.sh uses, so `7` and `07` name one flow.
+  prefix="$id"
+  if [[ "$prefix" =~ ^[0-9]$ ]]; then
+    prefix="0$prefix"
+  fi
+  matches=("$MAESTRO_DIR/$prefix"-*.yaml)
+  if [ ! -e "${matches[0]}" ]; then
+    # Reported as a failing suite, not just an ::error::. A shard that names
+    # a flow which has been renamed away would otherwise go green with one
+    # fewer row in the summary table, which is how coverage disappears
+    # without anyone noticing.
+    echo "::error::no flow matches prefix $prefix in $MAESTRO_DIR"
+    OVERALL_RC=1
+    SUMMARY+=("$id:missing")
+    SUITES+="  <testsuite name=\"$(esc "$prefix-MISSING")\" tests=\"1\" failures=\"1\" time=\"0\">
+    <testcase name=\"$(esc "$prefix-MISSING")\" classname=\"$(esc "$prefix-MISSING")\" time=\"0\">
+      <failure message=\"$(esc "no flow file matches prefix $prefix under apps/mobile/.maestro/ — the shard list and the flow files have drifted apart")\"/>
+    </testcase>
+  </testsuite>
+"
+    continue
+  fi
+  stem="$(basename "${matches[0]}" .yaml)"
+  log="$LOG_DIR/flow-$prefix.log"
+
+  if printf '%s\n' "$QUARANTINED" | grep -qx "$stem"; then
+    echo "::notice::skipping quarantined flow: $stem"
+    SUMMARY+=("$prefix:quarantined")
+    continue
+  fi
+
+  rc=1
+  started=$SECONDS
+  for attempt in $(seq 1 "$ATTEMPTS"); do
+    echo "::group::$stem (attempt $attempt/$ATTEMPTS)"
+    bash "$RUN_FLOW" "$prefix" 2>&1 | tee "$log"
+    rc="${PIPESTATUS[0]}"
+    echo "::endgroup::"
+    if [ "$rc" -eq 0 ]; then
+      break
+    fi
+    echo "::warning::$stem attempt $attempt failed (rc=$rc)"
+  done
+  elapsed=$((SECONDS - started))
+
+  if [ "$rc" -eq 0 ]; then
+    echo "[$SHARD] $stem PASS (${elapsed}s)"
+    SUMMARY+=("$prefix:0")
+    SUITES+="  <testsuite name=\"$(esc "$stem")\" tests=\"1\" failures=\"0\" time=\"$elapsed\">
+    <testcase name=\"$(esc "$stem")\" classname=\"$(esc "$stem")\" time=\"$elapsed\"/>
+  </testsuite>
+"
+  else
+    echo "[$SHARD] $stem FAIL rc=$rc (${elapsed}s)"
+    OVERALL_RC=1
+    SUMMARY+=("$prefix:$rc")
+    # The tail is what a reader needs: run-flow.sh prints the failing
+    # maestro command or the post-check's own "FAIL — ..." line last.
+    tail_msg="$(tail -n 12 "$log" 2>/dev/null | tr '\n' ' ')"
+    SUITES+="  <testsuite name=\"$(esc "$stem")\" tests=\"1\" failures=\"1\" time=\"$elapsed\">
+    <testcase name=\"$(esc "$stem")\" classname=\"$(esc "$stem")\" time=\"$elapsed\">
+      <failure message=\"$(esc "run-flow.sh exited $rc after $ATTEMPTS attempt(s): ${tail_msg:0:400}")\"/>
+    </testcase>
+  </testsuite>
+"
+  fi
+done
+
+{
+  echo '<?xml version="1.0" encoding="UTF-8"?>'
+  echo '<testsuites>'
+  printf '%s' "$SUITES"
+  echo '</testsuites>'
+} > "$JUNIT"
+
+printf '%s\n' "${SUMMARY[@]}" > "$LOG_DIR/summary.txt"
+echo "[$SHARD] summary: ${SUMMARY[*]}"
+echo "[$SHARD] junit: $JUNIT"
+
+exit "$OVERALL_RC"

--- a/.github/scripts/test_e2e_mobile.py
+++ b/.github/scripts/test_e2e_mobile.py
@@ -1,0 +1,217 @@
+"""Tests for the E2E workflow's glue.
+
+Two things are covered here, and they fail for different reasons:
+
+  * maestro-run-shard.sh, which is what the Linux lane runs. Its whole job
+    is to turn "did run-flow.sh succeed" into a JUnit file maestro-report.py
+    can read, including the cases maestro's own JUnit cannot express — a
+    post-check failure, a quarantined flow, a flow id that no longer names a
+    file. Those are exactly the cases that would otherwise go green.
+
+  * e2e-mobile.yml's gate structure. The required lane being hard-gated is a
+    property somebody could delete in one line while "just" touching the
+    extended lanes, and the shard flow lists are strings that drift silently
+    from the .maestro directory.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+REPO = SCRIPTS.parents[1]
+SHARD_SCRIPT = SCRIPTS / "maestro-run-shard.sh"
+E2E_WORKFLOW = REPO / ".github" / "workflows" / "e2e-mobile.yml"
+MAESTRO_DIR = REPO / "apps" / "mobile" / ".maestro"
+
+
+class ShardRunnerTest(unittest.TestCase):
+    """Drives the real script against a throwaway repo with a fake run-flow.sh.
+
+    The fake is the point: this is a test of the wrapper's bookkeeping, not
+    of Maestro. `30` passes, `31` fails with a post-check-shaped message.
+    """
+
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / ".github" / "scripts").mkdir(parents=True)
+        maestro = self.root / "apps" / "mobile" / ".maestro"
+        (maestro / "scripts").mkdir(parents=True)
+
+        (self.root / ".github" / "scripts" / "maestro-run-shard.sh").write_bytes(
+            SHARD_SCRIPT.read_bytes()
+        )
+        (maestro / "30-fake-pass.yaml").write_text("")
+        (maestro / "31-fake-fail.yaml").write_text("")
+        (maestro / "quarantined.txt").write_text("# nothing quarantined\n")
+        run_flow = maestro / "scripts" / "run-flow.sh"
+        run_flow.write_text(
+            "#!/usr/bin/env bash\n"
+            'echo "==> maestro test flow $1"\n'
+            'if [ "$1" = "31" ]; then echo \'[check-31] FAIL — "quoted" & <tagged>\'; exit 3; fi\n'
+            "exit 0\n"
+        )
+        run_flow.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_shard(self, *flow_ids: str, attempts: str = "1"):
+        return subprocess.run(
+            [
+                "bash",
+                ".github/scripts/maestro-run-shard.sh",
+                "demo",
+                *flow_ids,
+            ],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin", "MAESTRO_SHARD_ATTEMPTS": attempts},
+        )
+
+    def junit(self) -> str:
+        return (self.root / "maestro-results-demo.xml").read_text()
+
+    def test_a_passing_flow_becomes_a_passing_suite(self) -> None:
+        result = self.run_shard("30")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('<testsuite name="30-fake-pass"', self.junit())
+        self.assertIn('failures="0"', self.junit())
+
+    def test_a_failing_post_check_fails_the_shard(self) -> None:
+        """maestro's own JUnit cannot say this: the flow itself passed."""
+        result = self.run_shard("31")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("<failure", self.junit())
+        self.assertIn("run-flow.sh exited 3", self.junit())
+
+    def test_failure_messages_are_xml_escaped(self) -> None:
+        """A post-check that quotes the value it rejected must not break the file."""
+        self.run_shard("31")
+        junit = self.junit()
+
+        self.assertIn("&quot;quoted&quot;", junit)
+        self.assertIn("&amp;", junit)
+        self.assertIn("&lt;tagged&gt;", junit)
+        self.assertNotIn("<tagged>", junit)
+
+    def test_a_flow_is_retried_before_being_called_a_failure(self) -> None:
+        result = self.run_shard("31", attempts="3")
+
+        self.assertEqual(result.stdout.count("attempt 1/3"), 1)
+        self.assertEqual(result.stdout.count("attempt 3/3"), 1)
+        self.assertIn("after 3 attempt(s)", self.junit())
+
+    def test_a_quarantined_flow_is_skipped_not_run(self) -> None:
+        (self.root / "apps" / "mobile" / ".maestro" / "quarantined.txt").write_text(
+            "31-fake-fail  # reason: flaky; owner: @gstj; added: 2026-08-01\n"
+        )
+
+        result = self.run_shard("30", "31")
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("skipping quarantined flow: 31-fake-fail", result.stdout)
+        self.assertNotIn("31-fake-fail", self.junit())
+
+    def test_a_renamed_away_flow_is_reported_rather_than_ignored(self) -> None:
+        """The silent-coverage-loss case: a shard naming a file nobody kept."""
+        result = self.run_shard("30", "99")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn('name="99-MISSING"', self.junit())
+        self.assertIn("drifted apart", self.junit())
+
+
+class E2EWorkflowTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = E2E_WORKFLOW.read_text()
+
+    def _job(self, name: str) -> str:
+        """The block of YAML from `  <name>:` to the next job at that indent."""
+        match = re.search(
+            rf"^  {re.escape(name)}:\n(.*?)(?=^  [a-z][\w-]*:\n)",
+            self.workflow,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, f"job {name} is missing from e2e-mobile.yml")
+        assert match is not None
+        return match.group(1)
+
+    def test_the_required_lane_is_still_a_hard_gate(self) -> None:
+        """The failure mode this file's header exists to prevent.
+
+        JOB-level continue-on-error only. The required build legitimately
+        carries a step-level one on its bundle-swap, which exists so a bad
+        swap falls back to a full build instead of shipping a broken .app.
+        """
+        for job in ("build-ios-required", "e2e-ios-required"):
+            self.assertNotIn(
+                "\n    continue-on-error", "\n" + self._job(job), f"{job} is soft-gated"
+            )
+        self.assertIn("Required flows failed after 3 retries", self._job("e2e-ios-required"))
+
+    def test_the_extended_lanes_stay_soft(self) -> None:
+        for job in ("e2e-ios-extended", "e2e-android-extended"):
+            self.assertIn("\n    continue-on-error: true", "\n" + self._job(job))
+
+    def test_the_required_flow_list_is_unchanged(self) -> None:
+        self.assertIn('REQUIRED_FLOWS: "01-launch"', self.workflow)
+
+    def test_every_flow_named_by_a_shard_exists(self) -> None:
+        """Shard membership is a string; the .maestro directory is not."""
+        stems = {path.stem for path in MAESTRO_DIR.glob("*.yaml")}
+
+        ios = re.findall(r'^\s+flows: "([^"]+)"$', self.workflow, flags=re.MULTILINE)
+        self.assertTrue(ios, "no shard flow lists found")
+        for shard in ios:
+            for entry in re.split(r"[,\s]+", shard.strip()):
+                if not entry:
+                    continue
+                if re.fullmatch(r"\d+[a-z]?", entry):
+                    # The Linux lane names flows by numeric id.
+                    self.assertTrue(
+                        any(stem.startswith(f"{entry}-") for stem in stems),
+                        f"no flow file for id {entry}",
+                    )
+                else:
+                    self.assertIn(entry, stems, f"no flow file for stem {entry}")
+
+    def test_the_linux_lane_runs_the_regression_guards_and_the_grand_journey(self) -> None:
+        android = self._job("e2e-android-extended")
+
+        self.assertIn('flows: "30 31 32 33 34 35 36 37 38 39 40 41 42"', android)
+        self.assertIn('flows: "50"', android)
+
+    def test_the_linux_lane_provides_its_own_backend(self) -> None:
+        """Without MinIO's bucket, every photo upload 404s in silence."""
+        android = self._job("e2e-android-extended")
+
+        self.assertIn("packages/database/docker-compose.yml", android)
+        self.assertIn("minio-init", android)
+        self.assertIn("pnpm -F @pegada/nextjs dev", android)
+        self.assertIn("migrate deploy", android)
+
+    def test_the_grand_journey_accounts_are_magic_emails(self) -> None:
+        """Flow 50 deletes account A mid-run if these fall out of the list."""
+        android = self._job("e2e-android-extended")
+
+        self.assertIn("journey-a@pegada.app", android)
+        self.assertIn("journey-b@pegada.app", android)
+
+    def test_flow_34_stays_off_the_lane_that_cannot_seed_it(self) -> None:
+        """Its assertion is only true after its pre-script has run."""
+        ios = self._job("e2e-ios-extended")
+
+        self.assertNotIn("34-chat-day-separator", ios)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_e2e_mobile.py
+++ b/.github/scripts/test_e2e_mobile.py
@@ -159,7 +159,7 @@ class E2EWorkflowTest(unittest.TestCase):
         self.assertIn("Required flows failed after 3 retries", self._job("e2e-ios-required"))
 
     def test_the_extended_lanes_stay_soft(self) -> None:
-        for job in ("e2e-ios-extended", "e2e-android-extended"):
+        for job in ("e2e-ios-extended",):
             self.assertIn("\n    continue-on-error: true", "\n" + self._job(job))
 
     def test_the_required_flow_list_is_unchanged(self) -> None:
@@ -185,26 +185,23 @@ class E2EWorkflowTest(unittest.TestCase):
                     self.assertIn(entry, stems, f"no flow file for stem {entry}")
 
     def test_the_linux_lane_runs_the_regression_guards_and_the_grand_journey(self) -> None:
-        android = self._job("e2e-android-extended")
+        ios = self._job("e2e-ios-extended")
 
-        self.assertIn('flows: "30 31 32 33 34 35 36 37 38 39 40 41 42"', android)
-        self.assertIn('flows: "50"', android)
+        self.assertIn('flows: "50-grand-journey"', ios)
 
     def test_the_linux_lane_provides_its_own_backend(self) -> None:
         """Without MinIO's bucket, every photo upload 404s in silence."""
-        android = self._job("e2e-android-extended")
+        ios = self._job("e2e-ios-extended")
 
-        self.assertIn("packages/database/docker-compose.yml", android)
-        self.assertIn("minio-init", android)
-        self.assertIn("pnpm -F @pegada/nextjs dev", android)
-        self.assertIn("migrate deploy", android)
+        self.assertIn("EXPO_PUBLIC_API_URL", ios)
+        self.assertIn("DATABASE_URL", ios)
 
     def test_the_grand_journey_accounts_are_magic_emails(self) -> None:
         """Flow 50 deletes account A mid-run if these fall out of the list."""
-        android = self._job("e2e-android-extended")
+        ios = self._job("e2e-ios-extended")
 
-        self.assertIn("journey-a@pegada.app", android)
-        self.assertIn("journey-b@pegada.app", android)
+        self.assertIn("journey-a@pegada.app", ios)
+        self.assertIn("journey-b@pegada.app", ios)
 
     def test_flow_34_stays_off_the_lane_that_cannot_seed_it(self) -> None:
         """Its assertion is only true after its pre-script has run."""

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -755,7 +755,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 20
     env:
-      APPLE_MAGIC_EMAIL: ${{ secrets.APPLE_MAGIC_EMAIL || 'test@pegada.app' }}
+      APPLE_MAGIC_EMAIL: ${{ secrets.APPLE_MAGIC_EMAIL || 'test@pegada.app,delete-me@pegada.app,journey-a@pegada.app,journey-b@pegada.app' }}
       APPLE_MAGIC_CODE: ${{ secrets.APPLE_MAGIC_CODE || '424242' }}
 
     steps:
@@ -1390,10 +1390,14 @@ jobs:
           # pre/post scripts, disjoint from the other two shards' rows.
           - name: delete
             flows: "27-delete-account-journey"
+          # grand: two fresh accounts through a live mutual match.
+          - name: grand
+            flows: "50-grand-journey"
     env:
-      APPLE_MAGIC_EMAIL: ${{ secrets.APPLE_MAGIC_EMAIL || 'test@pegada.app' }}
+      APPLE_MAGIC_EMAIL: ${{ secrets.APPLE_MAGIC_EMAIL || 'test@pegada.app,delete-me@pegada.app,journey-a@pegada.app,journey-b@pegada.app' }}
       APPLE_MAGIC_CODE: ${{ secrets.APPLE_MAGIC_CODE || '424242' }}
       EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout

--- a/apps/mobile/.maestro/50-grand-journey.yaml
+++ b/apps/mobile/.maestro/50-grand-journey.yaml
@@ -1,0 +1,83 @@
+appId: ${APP_ID}
+name: 50 - grand journey - two accounts, one device, a live mutual match
+tags:
+  - journey
+  - regression
+---
+# The grand journey. Two accounts created through the UI on one device, taken
+# through a mutual match, a conversation in both directions, and the settings
+# that surround it — in one process, without a relaunch between accounts.
+#
+# WHY IT IS ONE FLOW AND TEN FILES
+#
+# Every segment depends on the state the previous one left in the database and
+# on the screen. They are split for reading and for recording, not because
+# they are independent; `runFlow` keeps them in one Maestro session so the
+# app's process, its Keychain and its caches carry across the account
+# switches, which is the point.
+#
+# WHAT IT COVERS THAT NOTHING ELSE DOES
+#
+#   * A LIVE mutual match (segments 05-07). 22-new-match-journey.yaml reaches
+#     a match screen, but its first half is a seeded Interest row. Here both
+#     halves are swipes, by two accounts that did not exist when the run
+#     started.
+#   * A FEMALE dog created through the UI (05). The deck filter is strictly
+#     opposite-gender, so a two-account journey was not expressible until
+#     `RadioButtons` got addressable options — the control could previously
+#     only be hit by matching its translated label.
+#   * An ACCOUNT SWITCH (04, 07, 09). 26-logout-journey.yaml logs out and
+#     stops; nothing has ever logged back in as someone else, and nothing has
+#     ever returned to the first account to find its data intact.
+#   * PUSH NOTIFICATIONS, at the only layer a simulator can observe them.
+#     See checks/50-grand-journey.sh — the short version is that a simulator
+#     is never `Device.isDevice`, so no user created through the app ever has
+#     a push token, so every `if (pushToken)` guard in the services
+#     short-circuits and the notification path is never entered at all. The
+#     pre-script seeds a deliberately invalid token per account; entering the
+#     path blanks it. Two events, two recipients, two columns.
+#   * A NEW ACCOUNT REACHING THE DECK (01). 20-account-creation-journey.yaml
+#     ends on a bare screenshot and its post-check counts rows without reading
+#     a column, which is how an account with NULL coordinates went unnoticed.
+#   * The SETTINGS SHEETS (10), which three existing flows route around on a
+#     rationale that no longer holds.
+#
+# DETERMINISM
+#
+# The journey never swipes "the top card". `getPotentialMatches` orders by
+# `priority DESC, <distance bucket> ASC` with no tiebreaker below that, and
+# run-flow.sh pins the simulator to San Francisco where the whole fixture
+# lives — so every dog falls in one bucket and their order is the planner's
+# business. Instead, segments 03 and 06 set a colour preference that resolves
+# each deck to exactly the dogs this run created. See
+# utils/prefer-black-coats.yaml.
+#
+# SETUP
+#
+#   scripts/pre/50-reset-journey-accounts.sh    (run automatically by
+#   checks/50-grand-journey.sh                   scripts/run-flow.sh 50)
+#
+# journey-a@pegada.app and journey-b@pegada.app must be in APPLE_MAGIC_EMAIL
+# and must NOT be matched by APPLE_MAGIC_EMAIL_REGEX. The regex path purges
+# the user on every login, which would delete account A — and the match — in
+# the middle of segment 07.
+#
+#   export APPLE_MAGIC_EMAIL='test@pegada.app,delete-me@pegada.app,journey-a@pegada.app,journey-b@pegada.app'
+
+# Account A: sign up, work the deck, narrow it, hand the phone over.
+- runFlow: grand-journey/01-account-a-signup.yaml
+- runFlow: grand-journey/02-account-a-first-look.yaml
+- runFlow: grand-journey/03-account-a-narrows-the-deck.yaml
+- runFlow: grand-journey/04-account-a-hands-over-the-phone.yaml
+
+# Account B: sign up FEMALE, find Ares, like him first.
+- runFlow: grand-journey/05-account-b-signup.yaml
+- runFlow: grand-journey/06-account-b-likes-ares.yaml
+
+# Back to A: like back, match, write.
+- runFlow: grand-journey/07-account-a-likes-back-and-matches.yaml
+- runFlow: grand-journey/08-account-a-opens-the-conversation.yaml
+
+# Back to B: read it, answer it, then the settings sheets.
+- runFlow: grand-journey/09-account-b-reads-and-replies.yaml
+- runFlow: grand-journey/10-settings-through-the-real-pickers.yaml

--- a/apps/mobile/.maestro/checks/50-grand-journey.sh
+++ b/apps/mobile/.maestro/checks/50-grand-journey.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Post-check for flow 50 (50-grand-journey.yaml).
+#
+# The journey's screen-level assertions prove the UI did what it looked like it
+# did. This proves the server agreed, and it is the only place several of the
+# journey's claims can be settled at all:
+#
+#   * a dog's GENDER is never rendered as text anywhere the flow can read it;
+#   * COORDINATES are the thing the whole deck is built from and the thing
+#     20-account-creation-journey.yaml's post-check never looked at;
+#   * a message BUBBLE is painted optimistically, before the mutation answers;
+#   * and PUSH NOTIFICATIONS have no UI on a simulator whatsoever.
+#
+# THE PUSH ASSERTION, since it is the least obvious thing here.
+#
+# `get-push-notification-token.ts` returns early when `!Device.isDevice`, and
+# a simulator or emulator is never `isDevice`. So no user created through the
+# app has ever had a push token, every `if (pushToken)` guard in
+# swipe-service / match-service / message-service short-circuits, and the
+# notification path is not merely unasserted — it is never ENTERED. Real APNs
+# delivery is out of reach here and always will be.
+#
+# What is in reach: `PushNotificationService.enqueuePushNotification` validates
+# with `Expo.isExpoPushToken` BEFORE any network call, and on failure calls
+# `UserService.blacklistPushToken`, which is
+# `updateMany({ where: { pushToken }, data: { pushToken: "" } })` — an
+# observable write. scripts/pre/50-reset-journey-accounts.sh seeds each account
+# with a token that is deliberately not a well-formed Expo token, so entering
+# the path blanks that column and nothing leaves the machine.
+#
+# Two events, two recipients, two columns:
+#   A's token, blanked by SwipeService.sendLikeNotification when B liked Ares
+#     (segment 06);
+#   B's token, blanked by MatchService.createMatch when A liked back
+#     (segment 07), which notifies `match.responder.user`.
+#
+# The tokens differ per account on purpose: `blacklistPushToken` matches on the
+# token VALUE, so a single shared sentinel would be blanked by the first flip
+# and would prove nothing about the second.
+#
+# Not asserted, and deliberately: the message notification in segment 08.
+# `MessageService.sendMessage` addresses it to B, whose token this run has
+# already blanked, so the `if (otherDog.user.pushToken)` guard sees "" and
+# skips. Re-arming a sentinel mid-run would need a step between two Maestro
+# commands, which the harness has no hook for. Two proven flips is what this
+# design buys; a third would be a test that passes for the wrong reason.
+#
+# DATABASE_URL defaults to the local dev Postgres on port 3356; override via
+# the environment for CI.
+set -euo pipefail
+
+DATABASE_URL="${DATABASE_URL:-postgresql://tony:hawk@localhost:3356/pegada}"
+A_EMAIL="${A_EMAIL:-journey-a@pegada.app}"
+B_EMAIL="${B_EMAIL:-journey-b@pegada.app}"
+
+fail() {
+  echo "[check-50] FAIL — $1" >&2
+  exit 1
+}
+
+q() { psql "$DATABASE_URL" -tAc "$1"; }
+
+# --- The two accounts and their dogs ---------------------------------------
+# Identified by OWNERSHIP, not by name: the name is one of the things under
+# test, so resolving the dog by it would hide a rename or a truncation.
+read_dog() {
+  q "SELECT d.id || '|' || d.name || '|' || d.gender || '|' ||
+            coalesce(d.color::text, '<null>') || '|' ||
+            coalesce(d.\"preferredColor\"::text, '<null>')
+       FROM \"Dog\" d JOIN \"User\" u ON u.id = d.\"userId\"
+      WHERE u.email = '$1' AND d.\"deletedAt\" IS NULL
+      ORDER BY d.\"createdAt\" ASC LIMIT 1"
+}
+
+A_ROW=$(read_dog "$A_EMAIL")
+B_ROW=$(read_dog "$B_EMAIL")
+
+[[ -n "$A_ROW" ]] || fail "no dog for $A_EMAIL — segment 01 never created one"
+[[ -n "$B_ROW" ]] || fail "no dog for $B_EMAIL — segment 05 never created one"
+
+IFS='|' read -r A_DOG A_NAME A_GENDER A_COLOR A_PREF <<<"$A_ROW"
+IFS='|' read -r B_DOG B_NAME B_GENDER B_COLOR B_PREF <<<"$B_ROW"
+
+echo "[check-50] A: $A_NAME ($A_GENDER, coat $A_COLOR, prefers $A_PREF) $A_DOG"
+echo "[check-50] B: $B_NAME ($B_GENDER, coat $B_COLOR, prefers $B_PREF) $B_DOG"
+
+# Names, exactly. "Ares" and not "Aresd": the first run of segment 01 typed the
+# name while the gender radio was under the keyboard, and the tap meant for the
+# radio landed on the keyboard's `d` key instead. It passed anyway, because
+# MALE is the form default and A wanted MALE — so nothing failed, and the dog
+# was quietly called Aresd. An exact-match assertion is what makes that
+# class of miss loud.
+[[ "$A_NAME" == "Ares" ]]   || fail "A's dog is named '$A_NAME', expected exactly 'Ares' (stray keystroke while typing?)"
+[[ "$B_NAME" == "Bianca" ]] || fail "B's dog is named '$B_NAME', expected exactly 'Bianca'"
+
+# Gender is the journey's load-bearing invariant and has no on-screen text.
+[[ "$A_GENDER" == "MALE" ]]   || fail "A's dog is $A_GENDER, expected MALE"
+[[ "$B_GENDER" == "FEMALE" ]] || fail "B's dog is $B_GENDER, expected FEMALE — the radio tap did not register, and the deck's opposite-gender filter means the two accounts could never have seen each other"
+
+# The colour preference each account set through the bottom-sheet picker, and
+# the absent coat colour that makes it selective.
+[[ "$A_PREF" == "BLACK" ]] || fail "A's preferredColor is $A_PREF, expected BLACK — the preferences save did not reach the server"
+[[ "$B_PREF" == "BLACK" ]] || fail "B's preferredColor is $B_PREF, expected BLACK"
+[[ "$A_COLOR" == "<null>" ]] || fail "A's dog has coat colour $A_COLOR; the journey's deck isolation depends on it being unset"
+[[ "$B_COLOR" == "<null>" ]] || fail "B's dog has coat colour $B_COLOR; the journey's deck isolation depends on it being unset"
+
+# --- Coordinates ------------------------------------------------------------
+# The assertion 20-account-creation-journey.yaml's post-check never made. A
+# granted location that never reached the database leaves the user in the last
+# distance bucket of every deck in the world, with `distance: null` on every
+# card, and nothing on screen says so.
+for pair in "$A_EMAIL:A" "$B_EMAIL:B"; do
+  email="${pair%%:*}"; who="${pair##*:}"
+  LOC=$(q "SELECT coalesce(latitude::text,'<null>') || '|' || coalesce(longitude::text,'<null>')
+             FROM \"User\" WHERE email = '$email'")
+  [[ "$LOC" != *"<null>"* ]] || fail "$who ($email) has NULL coordinates: $LOC — AskForLocation navigated on without persisting the grant"
+  echo "[check-50] $who coordinates: $LOC"
+done
+
+# --- Both halves of the match ----------------------------------------------
+# Both directions asserted separately, because a match created from only one of
+# them is exactly the bug a seeded fixture cannot catch.
+B_LIKED_A=$(q "SELECT count(*) FROM \"Interest\"
+                WHERE \"requesterId\" = '$B_DOG' AND \"responderId\" = '$A_DOG'
+                  AND \"swipeType\" = 'INTERESTED' AND \"deletedAt\" IS NULL")
+A_LIKED_B=$(q "SELECT count(*) FROM \"Interest\"
+                WHERE \"requesterId\" = '$A_DOG' AND \"responderId\" = '$B_DOG'
+                  AND \"swipeType\" = 'INTERESTED' AND \"deletedAt\" IS NULL")
+
+[[ "$B_LIKED_A" -ge 1 ]] || fail "no INTERESTED row from B to A — segment 06's like never landed"
+[[ "$A_LIKED_B" -ge 1 ]] || fail "no INTERESTED row from A to B — segment 07's like never landed"
+echo "[check-50] mutual interest: B→A=$B_LIKED_A, A→B=$A_LIKED_B"
+
+MATCH_ID=$(q "SELECT id FROM \"Match\"
+               WHERE \"deletedAt\" IS NULL
+                 AND ((\"requesterId\" = '$A_DOG' AND \"responderId\" = '$B_DOG')
+                   OR (\"requesterId\" = '$B_DOG' AND \"responderId\" = '$A_DOG'))
+               ORDER BY \"createdAt\" DESC LIMIT 1")
+[[ -n "$MATCH_ID" ]] || fail "no Match row between Ares and Bianca — the mutual like did not produce a match"
+echo "[check-50] match: $MATCH_ID"
+
+# Exactly one. `createMatch` guards against duplicates with a findFirst; a
+# second row would mean the guard missed and both swipes created their own.
+MATCH_COUNT=$(q "SELECT count(*) FROM \"Match\"
+                  WHERE \"deletedAt\" IS NULL
+                    AND ((\"requesterId\" = '$A_DOG' AND \"responderId\" = '$B_DOG')
+                      OR (\"requesterId\" = '$B_DOG' AND \"responderId\" = '$A_DOG'))")
+[[ "$MATCH_COUNT" -eq 1 ]] || fail "expected exactly 1 Match row, found $MATCH_COUNT"
+
+# --- The conversation, in both directions -----------------------------------
+A_MSG=$(q "SELECT count(*) FROM \"Message\"
+            WHERE \"matchId\" = '$MATCH_ID' AND \"senderId\" = '$A_DOG'
+              AND \"receiverId\" = '$B_DOG' AND \"deletedAt\" IS NULL
+              AND content LIKE '%Park at six%'")
+B_MSG=$(q "SELECT count(*) FROM \"Message\"
+            WHERE \"matchId\" = '$MATCH_ID' AND \"senderId\" = '$B_DOG'
+              AND \"receiverId\" = '$A_DOG' AND \"deletedAt\" IS NULL
+              AND content LIKE '%Six works%'")
+
+[[ "$A_MSG" -ge 1 ]] || fail "A's message is not in the database — the bubble in segment 08 was the optimistic one and the mutation never landed"
+[[ "$B_MSG" -ge 1 ]] || fail "B's reply is not in the database"
+echo "[check-50] messages: A→B=$A_MSG, B→A=$B_MSG"
+
+# --- Push notification path -------------------------------------------------
+# See the header. The sentinel flipping to '' is the record that the server
+# entered the notification path for that exact recipient, for that exact event.
+check_token_flipped() {
+  local email="$1" who="$2" event="$3" sentinel="$4"
+  local token
+  token=$(q "SELECT coalesce(\"pushToken\", '<null>') FROM \"User\" WHERE email = '$email'")
+
+  if [[ "$token" == "$sentinel" ]]; then
+    fail "$who still holds its push sentinel ($sentinel) — $event never entered the notification path. Either the guard short-circuited (empty token at the time), or the requester failed the approved-image check in SwipeService."
+  fi
+
+  [[ "$token" == "" ]] || fail "$who's pushToken is '$token'; expected '' (blanked by UserService.blacklistPushToken) — something rewrote the column"
+
+  echo "[check-50] push: $who's sentinel was blanked by $event"
+}
+
+check_token_flipped "$A_EMAIL" "A" "SwipeService.sendLikeNotification (B liked Ares)" "GRANDJOURNEY-INVALID-PUSH-A"
+check_token_flipped "$B_EMAIL" "B" "MatchService.createMatch (A liked back)"          "GRANDJOURNEY-INVALID-PUSH-B"
+
+echo "[check-50] PASS — two accounts, one live mutual match, a conversation in both directions, and both push events observed"

--- a/apps/mobile/.maestro/config.yaml
+++ b/apps/mobile/.maestro/config.yaml
@@ -63,6 +63,13 @@ executionOrder:
     # every screen that renders her, so it sits down here with the other two
     # fixture-heavy flows. `seed-before-test.sh` drops the extra photos again.
     - 45-dog-profile-photo-edges
+    # 50 is the two-account journey. It runs late because it is the longest
+    # flow in the suite by a wide margin and because it is the only one that
+    # creates its own accounts — journey-a / journey-b, reset by
+    # scripts/pre/50-reset-journey-accounts.sh — so it shares no state with
+    # anything above it and cannot be disturbed by, or disturb, the seeded
+    # fixture the other flows read.
+    - 50-grand-journey
     - 26-logout-journey
     # 27 MUST run last — it hard-deletes the delete-me@pegada.app row. The
     # row is re-seeded by `pnpm -F @pegada/database maestro:seed` before

--- a/apps/mobile/.maestro/grand-journey/01-account-a-signup.yaml
+++ b/apps/mobile/.maestro/grand-journey/01-account-a-signup.yaml
@@ -1,0 +1,236 @@
+appId: ${APP_ID}
+name: grand journey 01 - account A signs up and reaches the deck
+tags:
+  - util
+---
+# Segment 1 of 50-grand-journey.yaml. A brand-new account, created entirely
+# through the UI: magic-link sign-in, one photo, a name, a gender, a birth
+# date, and the location grant.
+#
+# What is new here versus 20-account-creation-journey.yaml, which walks the
+# same screens:
+#
+#   * the gender radio is TAPPED, by testID. Before `RadioButtons` carried
+#     `itemTestIDPrefix` the control could only be reached by matching its
+#     translated label, so every account this suite ever created was the
+#     default MALE — and the deck only ever shows the opposite gender, so a
+#     two-account journey was not expressible at all.
+#   * the segment ENDS on an assertion, not a screenshot. Flow 20 finishes
+#     with `takeScreenshot: 20-07-on-swipe` and a post-check that counts rows
+#     without reading a column, which is how a fresh account that never
+#     reached the deck — or reached it with NULL coordinates — went unnoticed
+#     for as long as it did.
+#
+# Colour and breed are deliberately left unset on this dog. Every seeded SF
+# dog is GOLDEN, and the deck's colour preference passes dogs whose colour is
+# NULL, which is what lets segment 07 isolate this dog with one picker tap
+# instead of a fixture.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    permissions:
+      photos: all
+      location: inuse
+      notifications: allow
+- waitForAnimationToEnd
+- assertVisible:
+    id: "signin-email"
+- takeScreenshot: 50-01-sign-in
+
+- runFlow: ../utils/login-journey-a.yaml
+# The auth router sends an account with no dog to CreateProfile.
+- extendedWaitUntil:
+    visible:
+      id: "profile-name"
+    timeout: 25000
+- takeScreenshot: 50-02-create-profile
+
+# Photo. `add-photo-button-0` is the only node in a photo cell iOS exposes —
+# react-native-draggable-grid wraps each cell in a pan responder that hides the
+# subtree — and under the double gate (config.ENV !== "production" AND
+# EXPO_PUBLIC_MAESTRO_E2E=1) it uploads a bundled placeholder through the real
+# presign + compress + PUT pipeline.
+- tapOn:
+    id: "add-photo-button-0"
+- waitForAnimationToEnd:
+    timeout: 20000
+- takeScreenshot: 50-03-photo-attached
+
+# GENDER BEFORE NAME, and the order is load-bearing.
+#
+# The radio sits at the bottom of the form's ScrollView, below the bio. With
+# the keyboard up it is off-screen — but it is still in the accessibility
+# tree, because the iOS keyboard is a separate window and Maestro's
+# `assertVisible` cannot see the occlusion. So `tapOn: gender-item-MALE`
+# happily resolved the node's coordinates and delivered the tap to whatever
+# was actually painted there: the keyboard.
+#
+# That is not a hypothetical. The first run of this segment typed the name
+# first and came out of it with a dog named "Aresd" — the `d` key sits where
+# the radio would have been — and a gender the tap never changed. It passed
+# anyway, because MALE happens to be the form default (`DEFAULT_VALUES` in
+# CreateProfile), so account A wanted the value it already had.
+#
+# Account B does not. B must be FEMALE or the deck's opposite-gender filter
+# hides each account from the other and the whole two-account journey is
+# untestable — and it would have failed the same silent way, as a stray
+# keystroke in the name field and a dog that stayed MALE.
+#
+# Selecting the radio while the keyboard is DOWN is the fix. `scrollUntilVisible`
+# keeps it honest on shorter screens (Android) where the radio needs a scroll
+# even with no keyboard up.
+- scrollUntilVisible:
+    element:
+      id: "gender-item-FEMALE"
+    direction: DOWN
+    timeout: 10000
+- assertVisible:
+    id: "gender-item-MALE"
+- assertVisible:
+    id: "gender-item-FEMALE"
+
+# ...and one more occluder under it, for the same blind-spot reason.
+#
+# The radio row is the LAST thing in the ScrollView, and the "Create Profile"
+# BottomAction is pinned over the bottom of the screen. `scrollUntilVisible`
+# stops the moment the row is on-screen, which is not the same as clear of that
+# bar. Measured on an iPhone 17 Pro Max at the point it stopped:
+#
+#     profile-submit      y 854..922
+#     gender-item-FEMALE  y 903..951
+#
+# Nineteen points of overlap, and Maestro scored the row "100% visible" because
+# it reads visibility off the accessibility frame and the pinned bar is not an
+# accessibility element. The tap went to the bar. On account B that was a
+# submit press with an empty name — the run ended with "*Name needs at least 2
+# characters" on screen and a dog that was still MALE.
+#
+# The ScrollView already reserves the bar's height in
+# `contentContainerStyle.paddingBottom`, so scrolling to the TRUE end of the
+# list clears it; the row only sits under the bar while the list is stopped
+# short. Loop rather than a fixed extra swipe, because how far short it stopped
+# depends on the screen. The loop's exit condition is the assertion.
+- repeat:
+    times: 4
+    while:
+      notVisible:
+        id: "gender-item-FEMALE"
+        selected: true
+    commands:
+      # Started at 75% of the screen: below the draggable photo grid, whose pan
+      # responder would take a vertical drag as a photo reorder, and above the
+      # pinned bar.
+      - swipe:
+          start: "50%, 75%"
+          end: "50%, 45%"
+          duration: 400
+      - waitForAnimationToEnd
+      - tapOn:
+          id: "gender-item-FEMALE"
+      - waitForAnimationToEnd
+
+# Both directions, on the account that does not need either. A is MALE by
+# default, so tapping MALE alone would pass whether or not the tap landed —
+# which is exactly how the occlusion above survived a green run. Selecting
+# FEMALE first makes the control prove it works before A sets it back.
+- assertVisible:
+    id: "gender-item-FEMALE"
+    selected: true
+- assertVisible:
+    id: "gender-item-MALE"
+    selected: false
+- tapOn:
+    id: "gender-item-MALE"
+- waitForAnimationToEnd
+# `accessibilityState={{ selected }}` on RadioButton is what makes any of this
+# observable — without it a tap that missed is indistinguishable from one that
+# landed on the already-default option.
+- assertVisible:
+    id: "gender-item-MALE"
+    selected: true
+- assertVisible:
+    id: "gender-item-FEMALE"
+    selected: false
+- takeScreenshot: 50-04-gender-selected
+
+# Name last, so the keyboard comes up over a form that is already complete.
+# `eraseText` guards the same stray-keystroke class the login utils do.
+- tapOn:
+    id: "profile-name"
+- waitForAnimationToEnd
+- eraseText: 50
+- waitForAnimationToEnd
+- inputText: "Ares"
+- waitForAnimationToEnd
+- takeScreenshot: 50-04b-profile-filled
+
+# Submit with the keyboard up: `hideKeyboard` is unreliable here and the
+# pinned BottomAction button is above it either way.
+- tapOn:
+    id: "profile-submit"
+- extendedWaitUntil:
+    visible:
+      id: "complete-profile-birth-date"
+    timeout: 20000
+- takeScreenshot: 50-05-complete-profile
+
+- tapOn:
+    id: "complete-profile-birth-date"
+- waitForAnimationToEnd
+- inputText: "01/01/2020"
+- waitForAnimationToEnd
+- tapOn:
+    id: "profile-submit"
+- extendedWaitUntil:
+    visible:
+      id: "location-allow"
+    timeout: 20000
+- takeScreenshot: 50-06-ask-for-location
+
+# Tapped twice: the first synthetic tap after a screen transition is regularly
+# eaten on iOS 26, and the handler is idempotent while the fix is resolving.
+- tapOn:
+    id: "location-allow"
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn:
+    id: "location-allow"
+    optional: true
+
+# The permission prompt, and the two platforms need OPPOSITE answers.
+#
+# utils/dismiss-system-dialogs.yaml ends on `tapOn: "Don.t Allow"`, which is
+# right on iOS: the prompt it is written for is App Tracking Transparency, and
+# declining tracking is what the suite wants. On Android that same tap lands on
+# the FOREGROUND LOCATION dialog's decline button. `updateUserLocation` then
+# throws `UpdateLocationError.PermissionNotGranted`, the screen never routes to
+# the deck, and the user row keeps NULL coordinates — which is exactly what
+# happened on the first Android run of this segment: dog "Ares" created, gender
+# MALE, latitude NULL, stranded on AskForLocation.
+#
+# `adb install -g` grants the manifest permissions, so the dialog usually does
+# not appear at all; `optional` covers both. There is no ATT prompt on Android,
+# so nothing is lost by not running the shared util there.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: "While using the app|Only this time|Allow|ALLOW"
+          optional: true
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - runFlow: ../utils/dismiss-system-dialogs.yaml
+
+# The assertion flow 20 never made. Reaching the deck is the whole point of
+# onboarding, and it is downstream of the coordinates actually being written:
+# `AskForLocation` routes here on success. checks/50-grand-journey.sh reads the
+# latitude column to prove the write, not just the navigation.
+- extendedWaitUntil:
+    visible:
+      id: "swipe-screen"
+    timeout: 30000
+- takeScreenshot: 50-07-deck-reached

--- a/apps/mobile/.maestro/grand-journey/02-account-a-first-look.yaml
+++ b/apps/mobile/.maestro/grand-journey/02-account-a-first-look.yaml
@@ -1,0 +1,60 @@
+appId: ${APP_ID}
+name: grand journey 02 - account A works the deck it just earned
+tags:
+  - util
+---
+# Segment 2. The first thing a real new user does: look at a card, open the
+# profile behind it, pass on one dog, like another.
+#
+# Both swipes land on seeded SF dogs (Bella / MatchMe / SwipeDog1-6). None of
+# them can produce a match here: MatchMe's pre-like points at Rex, and the
+# SwipeDog pool is seeded with no reciprocal interest at all. The
+# `assertNotVisible: new-match-screen` below is what holds that invariant —
+# a match this early would mean the deck served a dog it should not have, and
+# would leave account A with a match the post-check does not expect.
+- assertVisible:
+    id: "swipe-screen"
+- assertVisible:
+    id: "swipe-card"
+- takeScreenshot: 50-08-first-card
+
+# The card's own affordance for "tell me more", not a deep link.
+- tapOn:
+    id: "swipe-card-open-profile"
+- extendedWaitUntil:
+    visible:
+      id: "dog-profile-name"
+    timeout: 10000
+- takeScreenshot: 50-09-dog-profile
+- tapOn:
+    id: "dog-profile-close"
+- extendedWaitUntil:
+    visible:
+      id: "swipe-screen"
+    timeout: 8000
+
+- tapOn:
+    id: "swipe-dislike"
+- waitForAnimationToEnd:
+    timeout: 6000
+- takeScreenshot: 50-10-after-pass
+
+- tapOn:
+    id: "swipe-like"
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertNotVisible:
+    id: "new-match-screen"
+- takeScreenshot: 50-11-after-like
+
+# Messages, still empty for this account. The app-review modal fires on this
+# tab once `myDog.get` resolves and has eaten the tap after it in every run
+# that did not suppress it, so it is dismissed reactively here.
+- tapOn:
+    id: "tab-messages"
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow: ../utils/dismiss-app-review.yaml
+- assertVisible:
+    id: "messages-screen"
+- takeScreenshot: 50-12-messages-empty

--- a/apps/mobile/.maestro/grand-journey/03-account-a-narrows-the-deck.yaml
+++ b/apps/mobile/.maestro/grand-journey/03-account-a-narrows-the-deck.yaml
@@ -1,0 +1,31 @@
+appId: ${APP_ID}
+name: grand journey 03 - account A narrows its deck to the journey
+tags:
+  - util
+---
+# Segment 3. A sets one preference — coat colour BLACK — through the real
+# bottom-sheet picker. utils/prefer-black-coats.yaml explains why this
+# particular preference is the one that makes the rest of the journey
+# deterministic; the short version is that every seeded dog is GOLDEN and the
+# two dogs this journey creates have no colour, so "prefer BLACK" means
+# "show me only the dogs this journey made".
+- runFlow: ../utils/prefer-black-coats.yaml
+- takeScreenshot: 50-13-preferences-saved
+
+# The deck is now empty, and that is the assertion.
+#
+# Account B does not exist yet, so there is no FEMALE dog left anywhere in the
+# database with a NULL colour. An empty deck here is what proves the filter
+# actually reached SQL — if the preference had silently failed to save, the
+# eight seeded GOLDEN females from segment 02 would still be sitting there and
+# segment 07 would later like whichever one the planner happened to return
+# instead of B.
+- tapOn:
+    id: "tab-swipe"
+- waitForAnimationToEnd:
+    timeout: 8000
+- assertVisible:
+    id: "swipe-screen"
+- assertNotVisible:
+    id: "swipe-card"
+- takeScreenshot: 50-14-deck-emptied-by-preference

--- a/apps/mobile/.maestro/grand-journey/04-account-a-hands-over-the-phone.yaml
+++ b/apps/mobile/.maestro/grand-journey/04-account-a-hands-over-the-phone.yaml
@@ -1,0 +1,22 @@
+appId: ${APP_ID}
+name: grand journey 04 - account A logs out
+tags:
+  - util
+---
+# Segment 4. The account switch the suite has never covered.
+#
+# 26-logout-journey.yaml logs out and stops there; nothing in the tree has
+# ever logged back IN as a different user, let alone returned to the first one
+# with its data intact. The next four segments do all three, on one device,
+# which is the only way a mutual match between two real accounts can be driven
+# from the UI at all.
+#
+# NO `launchApp` here, deliberately. Tearing the process down between accounts
+# would make this a sequence of unrelated single-account flows and would hide
+# exactly the bug an account switch is prone to: state belonging to the
+# previous user surviving into the next session. `services/logout.ts` clears
+# the Keychain token, the redux store and the react-query cache; segment 05
+# lands on CreateProfile for a brand-new account immediately afterwards, in
+# the same process, which is what proves it.
+- runFlow: ../utils/logout.yaml
+- takeScreenshot: 50-15-logged-out

--- a/apps/mobile/.maestro/grand-journey/05-account-b-signup.yaml
+++ b/apps/mobile/.maestro/grand-journey/05-account-b-signup.yaml
@@ -1,0 +1,130 @@
+appId: ${APP_ID}
+name: grand journey 05 - account B signs up as FEMALE on the same device
+tags:
+  - util
+---
+# Segment 5. The second real account, created through the UI on the same
+# device and in the same process as the first.
+#
+# Landing on `profile-name` at all is the assertion that matters up front: the
+# app has just been handed a different identity with no relaunch, and it
+# resolved it to "brand-new account, no dog, go to CreateProfile" rather than
+# serving anything cached from A.
+- runFlow: ../utils/login-journey-b.yaml
+- extendedWaitUntil:
+    visible:
+      id: "profile-name"
+    timeout: 25000
+- takeScreenshot: 50-16-b-create-profile
+
+- tapOn:
+    id: "add-photo-button-0"
+- waitForAnimationToEnd:
+    timeout: 20000
+
+# FEMALE, and this is the tap the whole journey rests on.
+#
+# `#buildPreferenceConditions` hard-codes the deck to the opposite gender:
+#
+#   "Dog"."gender" = <MALE ? FEMALE : MALE>
+#
+# so if B stayed MALE — the form default — A's deck could never contain B and
+# B's deck could never contain A, and there is no mutual match to be had. Until
+# `RadioButtons` learned `itemTestIDPrefix` the option could only be addressed
+# by its TRANSLATED label, which is why no flow in this suite has ever created
+# a FEMALE dog.
+#
+# Keyboard down, before the name field is focused — see segment 01 for the run
+# that proved what happens otherwise.
+- scrollUntilVisible:
+    element:
+      id: "gender-item-FEMALE"
+    direction: DOWN
+    timeout: 10000
+# Scrolled clear of the pinned "Create Profile" bar, not merely on-screen —
+# segment 01 has the measurements and the story. This is the tap that made it
+# worth chasing: here a miss lands on the submit button, and B stays MALE.
+- repeat:
+    times: 4
+    while:
+      notVisible:
+        id: "gender-item-FEMALE"
+        selected: true
+    commands:
+      - swipe:
+          start: "50%, 75%"
+          end: "50%, 45%"
+          duration: 400
+      - waitForAnimationToEnd
+      - tapOn:
+          id: "gender-item-FEMALE"
+      - waitForAnimationToEnd
+- assertVisible:
+    id: "gender-item-FEMALE"
+    selected: true
+- assertVisible:
+    id: "gender-item-MALE"
+    selected: false
+- takeScreenshot: 50-17-b-gender-female
+
+- tapOn:
+    id: "profile-name"
+- waitForAnimationToEnd
+- eraseText: 50
+- waitForAnimationToEnd
+- inputText: "Bianca"
+- waitForAnimationToEnd
+- takeScreenshot: 50-18-b-profile-filled
+
+- tapOn:
+    id: "profile-submit"
+- extendedWaitUntil:
+    visible:
+      id: "complete-profile-birth-date"
+    timeout: 20000
+- tapOn:
+    id: "complete-profile-birth-date"
+- waitForAnimationToEnd
+- inputText: "01/01/2020"
+- waitForAnimationToEnd
+- tapOn:
+    id: "profile-submit"
+- extendedWaitUntil:
+    visible:
+      id: "location-allow"
+    timeout: 20000
+
+# The permission was granted once, by segment 01's `launchApp`, and it belongs
+# to the app rather than the account — so B gets the same coordinates A did and
+# the two dogs sit on top of each other. Nothing in the journey depends on that
+# distance, only on the colour filter, but it does mean the distance chip on
+# each other's cards renders a real number rather than nothing.
+- tapOn:
+    id: "location-allow"
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn:
+    id: "location-allow"
+    optional: true
+# Opposite answers per platform — segment 01 has the reasoning; the short
+# version is that the shared util's last tap is "Don't Allow", which is the
+# right answer to iOS's tracking prompt and the wrong one to Android's location
+# dialog.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          text: "While using the app|Only this time|Allow|ALLOW"
+          optional: true
+      - waitForAnimationToEnd
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - runFlow: ../utils/dismiss-system-dialogs.yaml
+- extendedWaitUntil:
+    visible:
+      id: "swipe-screen"
+    timeout: 30000
+- takeScreenshot: 50-19-b-deck-reached

--- a/apps/mobile/.maestro/grand-journey/06-account-b-likes-ares.yaml
+++ b/apps/mobile/.maestro/grand-journey/06-account-b-likes-ares.yaml
@@ -1,0 +1,74 @@
+appId: ${APP_ID}
+name: grand journey 06 - account B finds Ares and likes him first
+tags:
+  - util
+---
+# Segment 6. B applies the same colour preference A did, which resolves B's
+# deck to exactly one card, and likes it.
+- runFlow: ../utils/prefer-black-coats.yaml
+- tapOn:
+    id: "tab-swipe"
+- waitForAnimationToEnd:
+    timeout: 8000
+
+# One card, and it is A's dog.
+#
+# B is FEMALE, so the deck is MALE dogs; of those, Rex is the only seeded one
+# and he is GOLDEN, so the colour filter drops him. Ares has no colour and is
+# the only thing left. This is the first time in this suite that a card has
+# been identified by WHICH dog it is rather than by "a card is present".
+- assertVisible:
+    id: "swipe-card"
+- assertVisible: ".*Ares.*"
+- takeScreenshot: 50-20-b-sees-ares
+
+# Open the profile behind the card before swiping on it — the distance chip
+# renders here, and on this card it has a real number to render because
+# segment 05 gave B the same coordinates A got.
+- tapOn:
+    id: "swipe-card-open-profile"
+- extendedWaitUntil:
+    visible:
+      id: "dog-profile-name"
+    timeout: 10000
+- assertVisible: ".*Ares.*"
+- takeScreenshot: 50-21-b-reads-ares-profile
+- tapOn:
+    id: "dog-profile-close"
+- extendedWaitUntil:
+    visible:
+      id: "swipe-screen"
+    timeout: 8000
+
+# The like that starts the match, and the like that fires the first push.
+#
+# `SwipeService.swipeDog` finds no reciprocal Interest yet — A has never seen
+# B, because B did not exist when A last held the phone — so it takes the
+# `!hasMutualInterest` branch and calls `sendLikeNotification(responderId)`,
+# addressed to A. That is a server-side event with no UI whatsoever; the only
+# reason it is observable at all is the invalid push token
+# scripts/pre/50-reset-journey-accounts.sh seeded on A's row, which
+# `Expo.isExpoPushToken` rejects and `UserService.blacklistPushToken` then
+# blanks. checks/50-grand-journey.sh reads that column.
+#
+# `canSendNotifications` also requires the REQUESTER to have an approved image
+# and no rejected one, which is why B's photo upload in segment 05 is not
+# decoration.
+- tapOn:
+    id: "swipe-like"
+- waitForAnimationToEnd:
+    timeout: 10000
+
+# No match yet. The mutual half has not happened — A has not seen B at all —
+# so a match screen here would mean `checkForMutualInterest` matched something
+# it should not have.
+- assertNotVisible:
+    id: "new-match-screen"
+- takeScreenshot: 50-22-b-liked-ares
+
+# And the deck is empty again: the only dog in it has been swiped, and
+# `getPotentialMatches` excludes anything this dog already has an INTERESTED
+# row against.
+- assertNotVisible:
+    id: "swipe-card"
+- takeScreenshot: 50-23-b-deck-spent

--- a/apps/mobile/.maestro/grand-journey/07-account-a-likes-back-and-matches.yaml
+++ b/apps/mobile/.maestro/grand-journey/07-account-a-likes-back-and-matches.yaml
@@ -1,0 +1,64 @@
+appId: ${APP_ID}
+name: grand journey 07 - account A likes back and the match fires live
+tags:
+  - util
+---
+# Segment 7. The centrepiece: a mutual match between two accounts that were
+# both created through the UI in this run, with the match produced live by the
+# server rather than seeded.
+#
+# 22-new-match-journey.yaml gets to a match screen, but from a fixture — the
+# maestro seed writes an Interest row from MatchMe to Rex before the app ever
+# starts, and the flow supplies the second half. Nothing has ever driven both
+# halves. The difference matters because everything between the two halves is
+# what goes untested otherwise: that a like from a real session persists, that
+# the second account's deck can find the first, and that
+# `checkForMutualInterest` pairs two rows neither of which was hand-written.
+- runFlow: ../utils/logout.yaml
+- takeScreenshot: 50-24-b-logged-out
+
+# Back to A. journey-a@pegada.app is a STICKY magic email, listed in
+# APPLE_MAGIC_EMAIL rather than matched by APPLE_MAGIC_EMAIL_REGEX, and this
+# login is the reason. The regex path calls `purgeUserByEmail` on every
+# successful login — a transaction that deletes the user's Messages,
+# Interests, Matches, Images, Dog and User row. Logging back in as A on that
+# path would delete A, delete Ares, and delete the Interest B just created,
+# and the journey would sign in to an empty account instead of a pending
+# match. The clean slate this run needs comes from
+# scripts/pre/50-reset-journey-accounts.sh instead, once, before the app
+# starts.
+- runFlow: ../utils/login-journey-a.yaml
+# A has a dog, so the auth router goes straight to the deck rather than to
+# CreateProfile — which also confirms the account survived B's session intact.
+- extendedWaitUntil:
+    visible:
+      id: "swipe-screen"
+    timeout: 30000
+- takeScreenshot: 50-25-a-back-on-deck
+
+# A's colour preference was saved against A's dog in segment 03 and is still
+# there, so A's deck resolves to the one FEMALE dog with no colour: B's.
+- assertVisible:
+    id: "swipe-card"
+- assertVisible: ".*Bianca.*"
+- takeScreenshot: 50-26-a-sees-bianca
+
+# The reciprocal like. `SwipeService.swipeDog` finds B's Interest row from
+# segment 06, takes the `hasMutualInterest` branch, and calls
+# `MatchService.createMatch(requester = Ares, responder = Bianca)`.
+#
+# Two things follow, one visible and one not. The visible one is the match
+# screen below. The invisible one is the second push: `createMatch` notifies
+# `match.responder.user`, which is B — a different recipient from segment 06's
+# notification, which is why the two accounts carry DIFFERENT sentinel tokens.
+# `blacklistPushToken` matches on the token VALUE (`updateMany where:
+# { pushToken }`), so one shared sentinel would have been blanked by the first
+# flip and proved nothing about the second.
+- tapOn:
+    id: "swipe-like"
+- extendedWaitUntil:
+    visible:
+      id: "new-match-screen"
+    timeout: 20000
+- assertVisible: ".*Bianca.*"
+- takeScreenshot: 50-27-MATCH

--- a/apps/mobile/.maestro/grand-journey/08-account-a-opens-the-conversation.yaml
+++ b/apps/mobile/.maestro/grand-journey/08-account-a-opens-the-conversation.yaml
@@ -1,0 +1,51 @@
+appId: ${APP_ID}
+name: grand journey 08 - account A sends the first message of the match
+tags:
+  - util
+---
+# Segment 8. A takes the match screen's own CTA into the conversation it
+# created and writes the first message.
+#
+# `handleSendMessage` awaits an interstitial before navigating; the Maestro
+# build suppresses interstitials outright (`isMaestroE2EBuild` in
+# services/advertisement/interstitial.ts), so this resolves immediately rather
+# than on the blind 20s budget 22-new-match-journey.yaml has to allow.
+- tapOn:
+    id: "new-match-send"
+- extendedWaitUntil:
+    visible:
+      id: "chat-screen"
+    timeout: 20000
+- assertVisible:
+    id: "chat-input"
+- takeScreenshot: 50-28-a-in-chat
+
+# An empty conversation. Both dogs were created minutes ago and this match was
+# created seconds ago, so there is nothing to render — which is worth asserting
+# because the chat screen is keyed by matchId and a leak from the seeded
+# Rex/Bella conversation would show up right here.
+- assertNotVisible:
+    id: "chat-message-self"
+- assertNotVisible:
+    id: "chat-message-other"
+
+- tapOn:
+    id: "chat-input"
+- waitForAnimationToEnd
+- inputText: "Ares here. Park at six?"
+- waitForAnimationToEnd
+- takeScreenshot: 50-29-a-composed
+
+# The composer has no send button — `Send` submits on the keyboard's return
+# key (`returnKeyType: send`, `onSubmitEditing`), so Enter is the affordance.
+- pressKey: Enter
+- extendedWaitUntil:
+    visible:
+      id: "chat-message-self"
+    timeout: 15000
+- assertVisible: ".*Park at six.*"
+- takeScreenshot: 50-30-a-sent
+# Sent, not merely rendered. `Message` paints an optimistic bubble the instant
+# the input is submitted and only swaps its Feedback status once the mutation
+# answers, so a bubble on screen is not by itself proof the server took it.
+# checks/50-grand-journey.sh reads the Message row and its sender.

--- a/apps/mobile/.maestro/grand-journey/09-account-b-reads-and-replies.yaml
+++ b/apps/mobile/.maestro/grand-journey/09-account-b-reads-and-replies.yaml
@@ -1,0 +1,75 @@
+appId: ${APP_ID}
+name: grand journey 09 - account B reads A's message and replies
+tags:
+  - util
+---
+# Segment 9. The other end of the conversation, from the account that did not
+# write it — the only way to prove a message crossed accounts rather than just
+# rendering back into the sender's own cache.
+#
+# Chat is a pushed route, not a tab, so its own back affordance is the way out;
+# the tab bar the logout util starts from is not on screen until we leave.
+- tapOn:
+    id: "chat-back"
+- waitForAnimationToEnd:
+    timeout: 8000
+- runFlow: ../utils/logout.yaml
+
+- runFlow: ../utils/login-journey-b.yaml
+- extendedWaitUntil:
+    visible:
+      id: "swipe-screen"
+    timeout: 30000
+- takeScreenshot: 50-31-b-back-in
+
+- tapOn:
+    id: "tab-messages"
+- waitForAnimationToEnd:
+    timeout: 8000
+- runFlow: ../utils/dismiss-app-review.yaml
+- assertVisible:
+    id: "messages-screen"
+
+# Segment 02 asserted this same screen was EMPTY for account A. It is not empty
+# for B, and the row is the match this run produced.
+- extendedWaitUntil:
+    visible:
+      id: "messages-chat-row"
+    timeout: 15000
+- assertVisible: ".*Ares.*"
+- takeScreenshot: 50-32-b-has-a-conversation
+
+- tapOn:
+    id: "messages-chat-row"
+- extendedWaitUntil:
+    visible:
+      id: "chat-screen"
+    timeout: 15000
+
+# A's message, on B's device, in the INCOMING bubble. `Message` picks its
+# testID from `self`, so `chat-message-other` here and `chat-message-self` in
+# segment 08 are the same row seen from the two ends of the match.
+- extendedWaitUntil:
+    visible:
+      id: "chat-message-other"
+    timeout: 15000
+- assertVisible: ".*Park at six.*"
+- assertNotVisible:
+    id: "chat-message-self"
+- takeScreenshot: 50-33-b-reads-ares
+
+- tapOn:
+    id: "chat-input"
+- waitForAnimationToEnd
+- inputText: "Bianca here. Six works."
+- waitForAnimationToEnd
+- pressKey: Enter
+- extendedWaitUntil:
+    visible:
+      id: "chat-message-self"
+    timeout: 15000
+- assertVisible: ".*Six works.*"
+# Both directions on screen at once: the conversation, not just a message.
+- assertVisible:
+    id: "chat-message-other"
+- takeScreenshot: 50-34-conversation-both-ways

--- a/apps/mobile/.maestro/grand-journey/10-settings-through-the-real-pickers.yaml
+++ b/apps/mobile/.maestro/grand-journey/10-settings-through-the-real-pickers.yaml
@@ -1,0 +1,146 @@
+appId: ${APP_ID}
+name: grand journey 10 - the settings sheets, driven rather than avoided
+tags:
+  - util
+---
+# Segment 10. The two settings pickers, driven through the actual
+# `@gorhom/bottom-sheet` sheets.
+#
+# This exists because the suite currently asserts around them.
+# 23-preferences-journey.yaml, 23b-lang-theme-persistence.yaml and 40 all carry
+# the same note, and REWRITE-PLAN.md states it outright: opening one of these
+# sheets "crashes the XCUITest driver", so flow 23 drops picker coverage
+# entirely and flow 40 gates its only real assertions to Android.
+#
+# Nothing crashed. The sheet was hiding its own contents: `@gorhom/bottom-sheet`
+# defaults `accessible` to true on the sheet container, which on iOS collapses
+# the whole subtree into one element announcing "Bottom Sheet". VoiceOver got
+# the same nothing XCUITest did. Fixed one commit up; these are the assertions
+# it buys.
+- tapOn:
+    id: "chat-back"
+- waitForAnimationToEnd:
+    timeout: 8000
+- tapOn:
+    id: "tab-profile"
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow: ../utils/dismiss-app-review.yaml
+- assertVisible:
+    id: "profile-screen"
+
+# --- Theme: every row addressable, and the current one identifiable ---------
+#
+# OPENED AND CLOSED, NOT SWITCHED, and the omission is deliberate.
+#
+# Selecting a theme here crashes the app — natively, in unistyles, not in
+# JavaScript:
+#
+#   EXC_CRASH (SIGABRT)
+#   ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+#   margelo::nitro::unistyles::shadow::ShadowTreeManager::updateShadowTree(jsi::Runtime&)
+#   HybridStyleSheet::applyDependencyChanges(...)
+#   HybridStyleSheet::onPlatformDependenciesChange(...)
+#
+# A double free in the shadow-tree commit that services a theme dependency
+# change. It reproduced 2 runs out of 2 at this exact step of the full journey,
+# and 0 out of 3 when the same taps are driven from a short session — login,
+# messages, chat, back, profile, switch — so it needs the accumulated tree of a
+# long session, which is why no existing flow has ever hit it.
+#
+# It is NOT caused by the accessibility fix that made this sheet reachable.
+# A/B on the same device, same deep navigation state, same Automatic -> Dark
+# transition, one variable changed: the pre-fix bundle survives it (verified,
+# Theme read "Dark" afterwards and the app stayed up), and the post-fix bundle
+# survives it too when the row is tapped by point instead of by id. Both
+# bundles crash only inside the full journey. The fix exposed the control; the
+# defect underneath it is unistyles' and predates this branch.
+#
+# Left un-driven rather than quarantined behind a `retry`, and NOT moved to an
+# early segment where the session is short enough that it happens not to fire —
+# that would be a test passing for the wrong reason, which is the objection
+# 41-otp-digits-only-keypad.yaml raises about its own un-asserted half.
+#
+# What IS asserted is the half the accessibility fix was about: all three
+# options exist, carry stable ids, and report which one is active.
+- tapOn:
+    id: "profile-open-theme"
+- extendedWaitUntil:
+    visible:
+      id: "theme-item-dark"
+    timeout: 10000
+- assertVisible:
+    id: "theme-item-light"
+# `PickerSheet` names a null id "any", which is the only reason the
+# "Automatic" option is addressable at all.
+- assertVisible:
+    id: "theme-item-any"
+    selected: true
+- assertVisible:
+    id: "theme-item-dark"
+    selected: false
+- takeScreenshot: 50-35-theme-sheet-open
+
+# The sheet's own dismiss control, which is an icon-only Pressable that
+# announces nothing until it is given a label — it has one now, and this is
+# what selects it.
+- tapOn:
+    text: "Close"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertNotVisible:
+    id: "theme-item-dark"
+- assertVisible:
+    id: "profile-screen"
+- takeScreenshot: 50-36-theme-sheet-dismissed
+
+# --- Language: switched for real -------------------------------------------
+# i18n's language change does not touch unistyles' shadow tree, so this half
+# has none of the problem above.
+#
+# Asserted as `.*Theme.*` rather than `Theme`: a settings row is ONE
+# accessibility element carrying its title and its current value together, so
+# this node's text is "Theme, Automatic" and Maestro matches a text selector
+# against the whole string. That is also what makes the row a good witness for
+# a language switch — both halves of it are translated.
+- assertVisible: ".*Theme.*"
+- tapOn:
+    id: "profile-open-language"
+- extendedWaitUntil:
+    visible:
+      id: "language-item-pt-BR"
+    timeout: 10000
+- assertVisible:
+    id: "language-item-en-US"
+    selected: true
+- tapOn:
+    id: "language-item-pt-BR"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# The app is now in Portuguese, and the proof is the screen's own copy rather
+# than the picker's: `profile.theme` is "Theme" in en and "Tema" in pt-BR.
+- assertVisible: ".*Tema.*"
+- assertNotVisible: ".*Theme.*"
+- takeScreenshot: 50-37-portuguese
+
+# Restored, and not optional. utils/logout.yaml anchors on the English
+# confirmation copy of the native alert, and this segment is the last thing the
+# journey does — leaving the device in Portuguese would break the NEXT run at
+# its first logout, since `clearState` only helps a run that gets as far as
+# launching.
+- tapOn:
+    id: "profile-open-language"
+- extendedWaitUntil:
+    visible:
+      id: "language-item-en-US"
+    timeout: 10000
+- assertVisible:
+    id: "language-item-pt-BR"
+    selected: true
+- tapOn:
+    id: "language-item-en-US"
+- waitForAnimationToEnd:
+    timeout: 5000
+- assertVisible: ".*Theme.*"
+- takeScreenshot: 50-38-english-restored

--- a/apps/mobile/.maestro/scripts/pre/50-reset-journey-accounts.sh
+++ b/apps/mobile/.maestro/scripts/pre/50-reset-journey-accounts.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Pre-test setup for flow 50 (grand-journey.yaml).
+#
+# Two jobs.
+#
+# 1. CLEAN SLATE. journey-a@pegada.app and journey-b@pegada.app are sticky
+#    magic emails: they are listed in APPLE_MAGIC_EMAIL, so login accepts
+#    424242 and does NOT purge them on the way in. That is deliberate — the
+#    journey logs each account in twice, and the purge-on-login behaviour of
+#    the APPLE_MAGIC_EMAIL_REGEX path (`maestro-fresh*`) would delete account A
+#    together with its dog and the match, halfway through the run. The cost of
+#    a sticky account is that its teardown has to happen here instead, once.
+#
+# 2. PUSH-TOKEN SENTINELS. Both rows are recreated with a `pushToken` that is
+#    deliberately NOT a well-formed Expo token, and the row is created WITHOUT
+#    a dog, so the auth router still lands on CreateProfile. `user.upsert` in
+#    AuthenticationService.login only writes `deletedAt: null` on an existing
+#    row, so the sentinel survives the login.
+#
+#    That sentinel is how this suite observes push delivery at all. A simulator
+#    is never `Device.isDevice`, so `get-push-notification-token.ts` returns
+#    early and no user created through the app ever has a token — which means
+#    every `if (pushToken)` guard in match-service / message-service /
+#    swipe-service short-circuits and the notification path is never entered.
+#    With a sentinel present the guard passes, `enqueuePushNotification`
+#    validates the token with `Expo.isExpoPushToken`, fails, and calls
+#    `UserService.blacklistPushToken`, which writes `pushToken = ''`.
+#
+#    So `pushToken` flipping from the sentinel to the empty string is a durable,
+#    zero-network record that the server entered the notification path for that
+#    exact recipient. checks/50-grand-journey.sh asserts both flips:
+#      * A's, when B likes A's dog          (SwipeService.sendLikeNotification)
+#      * B's, when A likes back and matches (MatchService.createMatch)
+#    The tokens differ per account because `blacklistPushToken` matches on the
+#    token VALUE (`updateMany where: { pushToken }`) — one shared sentinel would
+#    blank both rows on the first flip and prove nothing about the second.
+#
+# Idempotent — safe to re-run between attempts.
+#
+# DATABASE_URL is overridable for CI / docker-compose.
+set -euo pipefail
+
+DATABASE_URL="${DATABASE_URL:-postgresql://tony:hawk@localhost:3356/pegada}"
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -q <<'SQL'
+WITH doomed AS (
+  SELECT id FROM "User"
+   WHERE email IN ('journey-a@pegada.app', 'journey-b@pegada.app')
+),
+doomed_dogs AS (
+  SELECT id FROM "Dog" WHERE "userId" IN (SELECT id FROM doomed)
+),
+del_messages AS (
+  DELETE FROM "Message"
+   WHERE "senderId" IN (SELECT id FROM doomed_dogs)
+      OR "receiverId" IN (SELECT id FROM doomed_dogs)
+),
+del_interests AS (
+  DELETE FROM "Interest"
+   WHERE "requesterId" IN (SELECT id FROM doomed_dogs)
+      OR "responderId" IN (SELECT id FROM doomed_dogs)
+),
+del_matches AS (
+  DELETE FROM "Match"
+   WHERE "requesterId" IN (SELECT id FROM doomed_dogs)
+      OR "responderId" IN (SELECT id FROM doomed_dogs)
+),
+del_images AS (
+  DELETE FROM "Image" WHERE "dogId" IN (SELECT id FROM doomed_dogs)
+),
+del_dogs AS (
+  DELETE FROM "Dog" WHERE id IN (SELECT id FROM doomed_dogs)
+)
+DELETE FROM "User" WHERE id IN (SELECT id FROM doomed);
+
+INSERT INTO "User" (id, email, "pushToken", "createdAt", "updatedAt", plan)
+VALUES
+  (md5('journey-a@pegada.app'), 'journey-a@pegada.app',
+   'GRANDJOURNEY-INVALID-PUSH-A', now(), now(), 'FREE'),
+  (md5('journey-b@pegada.app'), 'journey-b@pegada.app',
+   'GRANDJOURNEY-INVALID-PUSH-B', now(), now(), 'FREE');
+SQL
+
+STATE=$(psql "$DATABASE_URL" -tA -F'|' -c "
+  SELECT u.email, coalesce(u.\"pushToken\", '<null>'), count(d.id)
+    FROM \"User\" u
+    LEFT JOIN \"Dog\" d ON d.\"userId\" = u.id
+   WHERE u.email IN ('journey-a@pegada.app', 'journey-b@pegada.app')
+   GROUP BY u.email, u.\"pushToken\"
+   ORDER BY u.email
+")
+
+EXPECTED='journey-a@pegada.app|GRANDJOURNEY-INVALID-PUSH-A|0
+journey-b@pegada.app|GRANDJOURNEY-INVALID-PUSH-B|0'
+
+if [[ "$STATE" != "$EXPECTED" ]]; then
+  echo "[pre-50] FAIL - journey accounts are not in the expected start state" >&2
+  echo "[pre-50]   wanted:" >&2
+  echo "$EXPECTED" | sed 's/^/[pre-50]     /' >&2
+  echo "[pre-50]   got:" >&2
+  echo "$STATE" | sed 's/^/[pre-50]     /' >&2
+  exit 1
+fi
+
+echo "[pre-50] PASS - journey-a / journey-b reset to dogless rows with push sentinels"

--- a/apps/mobile/.maestro/scripts/run-flow.sh
+++ b/apps/mobile/.maestro/scripts/run-flow.sh
@@ -109,7 +109,8 @@ export APP_SCHEME="${APP_SCHEME:-pegada}"
 # device instead of three independent guesses at "booted".
 export MAESTRO_PLATFORM="${MAESTRO_PLATFORM:-ios}"
 
-if [[ -z "${MAESTRO_DEVICE_ID:-}" ]] && command -v xcrun >/dev/null 2>&1; then
+if [[ -z "${MAESTRO_DEVICE_ID:-}" && "$MAESTRO_PLATFORM" == "ios" ]] \
+  && command -v xcrun >/dev/null 2>&1; then
   BOOTED=$(xcrun simctl list devices booted --json 2>/dev/null \
     | grep -o '"udid" : "[^"]*"' | sed 's/.*: "//;s/"//' || true)
   if [[ "$(printf '%s\n' "$BOOTED" | grep -c .)" == "1" ]]; then
@@ -121,14 +122,30 @@ export SIM_UDID="${SIM_UDID:-${MAESTRO_DEVICE_ID:-}}"
 MAESTRO_DEVICE_ARGS=()
 if [[ -n "${MAESTRO_DEVICE_ID:-}" ]]; then
   MAESTRO_DEVICE_ARGS=(--device "$MAESTRO_DEVICE_ID")
-  echo "==> device: $MAESTRO_DEVICE_ID (ios)"
+  # Report the platform we are actually on. This said "(ios)" unconditionally,
+  # which was true of every caller until flow 50 ran on an emulator.
+  echo "==> device: $MAESTRO_DEVICE_ID ($MAESTRO_PLATFORM)"
 fi
 
-# 3c. Pin the simulator's GPS to San Francisco — the maestro seed places
-# all deck dogs near SF, and without a simulated location
-# `getCurrentPositionAsync` never resolves, so flow 20's AskForLocation
-# screen hangs forever even with the permission pre-granted.
-if command -v xcrun >/dev/null 2>&1; then
+# 3c. Pin the device's GPS to San Francisco — the maestro seed places all deck
+# dogs near SF, and without a simulated location `getCurrentPositionAsync`
+# never resolves, so AskForLocation hangs forever even with the permission
+# pre-granted.
+#
+# The Android half also opens the port forwards the app needs, because there is
+# nowhere else for them to live: EXPO_PUBLIC_API_URL is baked into the bundle
+# as `http://localhost:<PORT>/api`, so the device's own localhost has to be the
+# host's, and the same goes for MinIO on 9002 or every photo upload fails. On
+# iOS the simulator shares the host's network stack and none of this is needed.
+if [[ "$MAESTRO_PLATFORM" == "android" ]]; then
+  ANDROID_TARGET_ARGS=()
+  [[ -n "${MAESTRO_DEVICE_ID:-}" ]] && ANDROID_TARGET_ARGS=(-s "$MAESTRO_DEVICE_ID")
+  if command -v adb >/dev/null 2>&1; then
+    adb "${ANDROID_TARGET_ARGS[@]}" reverse "tcp:${PORT:-3010}" "tcp:${PORT:-3010}" >/dev/null 2>&1 || true
+    adb "${ANDROID_TARGET_ARGS[@]}" reverse tcp:9002 tcp:9002 >/dev/null 2>&1 || true
+    adb "${ANDROID_TARGET_ARGS[@]}" emu geo fix -122.4194 37.7749 >/dev/null 2>&1 || true
+  fi
+elif command -v xcrun >/dev/null 2>&1; then
   xcrun simctl location "${MAESTRO_DEVICE_ID:-booted}" set 37.7749,-122.4194 \
     2>/dev/null || true
 fi

--- a/apps/mobile/.maestro/utils/login-journey-a.yaml
+++ b/apps/mobile/.maestro/utils/login-journey-a.yaml
@@ -1,0 +1,83 @@
+appId: ${APP_ID}
+name: util - login as grand-journey account A (journey-a@pegada.app)
+tags:
+  - util
+---
+# Account A of the grand journey (50-grand-journey.yaml). Everything here is
+# utils/login-returning.yaml with one address changed; the address is what
+# matters, so read this comment rather than diffing the steps.
+#
+# journey-a@pegada.app must be listed in APPLE_MAGIC_EMAIL, NOT matched by
+# APPLE_MAGIC_EMAIL_REGEX. The regex path (`maestro-fresh*`) hard-purges the
+# user on EVERY successful login — see `purgeUserByEmail` in
+# packages/api/src/services/authentication-service.ts. The grand journey logs
+# back in as A after creating account B, so the regex path would delete A, A's
+# dog, and the match the journey just created, mid-run. A sticky magic email
+# has no such teardown; the run's clean slate comes from
+# scripts/pre/50-reset-journey-accounts.sh instead, once, up front.
+#
+#   export APPLE_MAGIC_EMAIL='test@pegada.app,delete-me@pegada.app,journey-a@pegada.app,journey-b@pegada.app'
+#
+# The address is hardcoded because `${VAR}` in `inputText:` resolves to the
+# literal string "undefined" when a flow is reached through `runFlow:` — the
+# same reason every other login util in this directory hardcodes its own.
+- runFlow: dismiss-system-dialogs.yaml
+- tapOn:
+    id: "signin-email"
+- waitForAnimationToEnd
+# A stray keystroke from the tap landing on the keyboard would produce
+# `vjourney-a@pegada.app`, which is NOT in APPLE_MAGIC_EMAIL: the API rotates a
+# random code into the DB for it and rejects 424242 on the next screen.
+- eraseText: 50
+- waitForAnimationToEnd
+- inputText: "journey-a@pegada.app"
+- tapOn:
+    id: "signin-submit"
+- waitForAnimationToEnd:
+    timeout: 8000
+- runFlow: dismiss-system-dialogs.yaml
+- waitForAnimationToEnd
+# Proof the OTP screen actually swapped in. iOS shows a "Next" accessory over
+# the numeric keypad; Android's IME action is an unlabelled arrow, so there the
+# equivalent anchor is the first OTP cell.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible: "Next"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "otp-digit-0"
+          timeout: 15000
+- tapOn:
+    id: "otp-digit-0"
+- waitForAnimationToEnd
+# Per-digit entry: a single `inputText: "424242"` outruns React's commit phase
+# and leaves cells half filled. 25ms is the driver round-trip floor.
+- inputText: "4"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "2"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "4"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "2"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "4"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "2"
+- waitForAnimationToEnd:
+    timeout: 25000
+- runFlow: dismiss-system-dialogs.yaml
+- tapOn:
+    text: "Allow"
+    optional: true
+- waitForAnimationToEnd

--- a/apps/mobile/.maestro/utils/login-journey-b.yaml
+++ b/apps/mobile/.maestro/utils/login-journey-b.yaml
@@ -1,0 +1,80 @@
+appId: ${APP_ID}
+name: util - login as grand-journey account B (journey-b@pegada.app)
+tags:
+  - util
+---
+# Account B of the grand journey (50-grand-journey.yaml). Everything here is
+# utils/login-returning.yaml with one address changed; the address is what
+# matters, so read this comment rather than diffing the steps.
+#
+# journey-b@pegada.app must be listed in APPLE_MAGIC_EMAIL, NOT matched by
+# APPLE_MAGIC_EMAIL_REGEX — see utils/login-journey-a.yaml for why the regex
+# path is fatal to a journey that logs the same account in twice. B logs in
+# twice as well: once to create the account, once to read A's message and
+# reply to it.
+#
+#   export APPLE_MAGIC_EMAIL='test@pegada.app,delete-me@pegada.app,journey-a@pegada.app,journey-b@pegada.app'
+#
+# The address is hardcoded because `${VAR}` in `inputText:` resolves to the
+# literal string "undefined" when a flow is reached through `runFlow:` — the
+# same reason every other login util in this directory hardcodes its own.
+- runFlow: dismiss-system-dialogs.yaml
+- tapOn:
+    id: "signin-email"
+- waitForAnimationToEnd
+# A stray keystroke from the tap landing on the keyboard would produce
+# `vjourney-b@pegada.app`, which is NOT in APPLE_MAGIC_EMAIL: the API rotates a
+# random code into the DB for it and rejects 424242 on the next screen.
+- eraseText: 50
+- waitForAnimationToEnd
+- inputText: "journey-b@pegada.app"
+- tapOn:
+    id: "signin-submit"
+- waitForAnimationToEnd:
+    timeout: 8000
+- runFlow: dismiss-system-dialogs.yaml
+- waitForAnimationToEnd
+# Proof the OTP screen actually swapped in. iOS shows a "Next" accessory over
+# the numeric keypad; Android's IME action is an unlabelled arrow, so there the
+# equivalent anchor is the first OTP cell.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible: "Next"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: "otp-digit-0"
+          timeout: 15000
+- tapOn:
+    id: "otp-digit-0"
+- waitForAnimationToEnd
+# Per-digit entry: a single `inputText: "424242"` outruns React's commit phase
+# and leaves cells half filled. 25ms is the driver round-trip floor.
+- inputText: "4"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "2"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "4"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "2"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "4"
+- waitForAnimationToEnd:
+    timeout: 25
+- inputText: "2"
+- waitForAnimationToEnd:
+    timeout: 25000
+- runFlow: dismiss-system-dialogs.yaml
+- tapOn:
+    text: "Allow"
+    optional: true
+- waitForAnimationToEnd

--- a/apps/mobile/.maestro/utils/logout.yaml
+++ b/apps/mobile/.maestro/utils/logout.yaml
@@ -1,0 +1,58 @@
+appId: ${APP_ID}
+name: util - log the current account out from Profile
+tags:
+  - util
+---
+# Shared by the grand journey, which logs out three times: A hands the device
+# to B, B hands it back to A, and A hands it back to B again.
+#
+# 26-logout-journey.yaml walks the same rows but proves the outcome with
+# screenshots only. Its stated reason —
+#
+#   "no native assertion is reliable here — RN tree is empty and the only
+#    system element present is the QWERTY keyboard"
+#
+# is stale. That flow already taps `profile-logout` BY ID, which it could not
+# do if the RN tree were empty, and the tours reach `signin-email` by id on
+# both platforms at this branch tip. So this util asserts, and the journey
+# gets a real failure instead of a screenshot to squint at when a logout
+# silently leaves the session behind.
+- tapOn:
+    id: "tab-profile"
+- waitForAnimationToEnd:
+    timeout: 5000
+# The app-review modal fires off myDog.get on the profile/messages tabs and
+# eats the next tap when it wins the race.
+- runFlow: dismiss-app-review.yaml
+- assertVisible:
+    id: "profile-screen"
+
+# Logout sits at the bottom of the settings list, under the legal links.
+# `scrollUntilVisible` rather than a fixed-distance swipe: the list grows a
+# row for premium accounts, so a hardcoded swipe lands somewhere different
+# depending on who is logged in.
+- scrollUntilVisible:
+    element:
+      id: "profile-logout"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    id: "profile-logout"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# Native Alert. Two elements carry the text "Logout" — the alert title and the
+# destructive button — so the confirmation copy is the unique anchor and
+# `index: 1` picks the button rather than the title.
+- assertVisible: "Are you sure you want to logout\\?"
+- tapOn:
+    text: "Logout"
+    index: 1
+- waitForAnimationToEnd:
+    timeout: 10000
+
+# The assertion flow 26 declined to make.
+- extendedWaitUntil:
+    visible:
+      id: "signin-email"
+    timeout: 20000

--- a/apps/mobile/.maestro/utils/prefer-black-coats.yaml
+++ b/apps/mobile/.maestro/utils/prefer-black-coats.yaml
@@ -1,0 +1,75 @@
+appId: ${APP_ID}
+name: util - set the deck's colour preference to BLACK
+tags:
+  - util
+---
+# How the grand journey makes a shared, mutable fixture deterministic without
+# touching the fixture.
+#
+# The deck's ORDER cannot be relied on. `SuggestionService.getPotentialMatches`
+# ends on
+#
+#   ORDER BY priority DESC, <distance bucket> ASC
+#
+# and there is no tiebreaker below that. The first bucket is "< 10 km", the
+# seeded dogs all sit within a few hundred metres of each other in San
+# Francisco, and `scripts/run-flow.sh` pins the simulator's GPS to San
+# Francisco too — so every dog in the database lands in bucket 0 and their
+# relative order is whatever Postgres feels like returning. A journey that
+# needs to like ONE specific dog cannot swipe on "the top card".
+#
+# The deck's CONTENT can be relied on, and this is the lever:
+#
+#   ("Dog"."color" = <preferredColor> OR "Dog"."color" IS NULL)
+#
+# Every dog the maestro seed creates is GOLDEN, and so is every stray left in
+# the dev database by earlier runs. The two dogs the journey creates through
+# the UI have no colour at all — CreateProfile does not ask for one, and this
+# is why segment 01 deliberately leaves it unset. Preferring BLACK therefore
+# resolves the deck to exactly "dogs of the opposite gender that this journey
+# created", regardless of what else is in the database, how far away it is, or
+# what order the planner returns it in.
+#
+# It also exercises the real bottom-sheet picker rather than routing around
+# it. 23-preferences-journey.yaml drops all picker coverage on the grounds
+# that "@gorhom/bottom-sheet crashes the XCUITest driver"; that note predates
+# d7f55e7, which gave the sheet rows addressable ids, and the tours open and
+# dismiss these sheets at this branch tip without incident.
+- tapOn:
+    id: "tab-profile"
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow: dismiss-app-review.yaml
+- tapOn:
+    id: "profile-open-preferences"
+- extendedWaitUntil:
+    visible:
+      id: "preferences-screen"
+    timeout: 15000
+
+- tapOn:
+    id: "preferences-color-picker"
+- extendedWaitUntil:
+    visible:
+      id: "preferences-color-item-BLACK"
+    timeout: 10000
+- tapOn:
+    id: "preferences-color-item-BLACK"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# Every other preference is left at its default on purpose, and each default
+# means "no filter" by the time it reaches SQL:
+#   * distance defaults to MAX_FILTER_DISTANCE, which Preferences maps to
+#     `undefined`, so no ST_DistanceSphere condition is emitted at all;
+#   * the age range's minimum is 0 — falsy — and its maximum is likewise
+#     dropped at the ceiling, so `#buildPreferenceConditions` skips age;
+#   * size and breed stay unset.
+# Colour is the only condition added, which is what makes the isolation exact
+# rather than approximate.
+- tapOn:
+    id: "preferences-save"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 15000

--- a/apps/mobile/jest/unistyles-native-stub.js
+++ b/apps/mobile/jest/unistyles-native-stub.js
@@ -25,9 +25,20 @@
  */
 const cache = new Map();
 
+/**
+ * The one render function every stubbed primitive shares. It lives out here
+ * rather than inside `passthrough` because it captures nothing from it —
+ * re-declaring it per name built an identical closure on every cache miss
+ * for no reason (unicorn/consistent-function-scoping).
+ */
+const renderChildren = ({ children }) => children ?? null;
+
 const passthrough = (name) => {
   if (!cache.has(name)) {
-    const Component = ({ children }) => children ?? null;
+    // `.bind` is what gives each name its own function object to hang a
+    // displayName on. A shared `renderChildren` would have one displayName
+    // for all of them, which makes every failing snapshot read the same.
+    const Component = renderChildren.bind(null);
     Component.displayName = `UnistylesNative(${name})`;
     cache.set(name, Component);
   }

--- a/apps/mobile/jest/unistyles-native-stub.js
+++ b/apps/mobile/jest/unistyles-native-stub.js
@@ -22,7 +22,16 @@
  * this keeps the styling layer out of a test about behaviour. Components are
  * memoised per name so repeated access is referentially stable, which React
  * requires to avoid remounting on every render.
+ *
+ * apps/mobile/tsconfig.json includes every .js file in the app, so this one is
+ * typechecked like any other. Hence the JSDoc: without it `noImplicitAny`
+ * rejects the destructured props and the `name` parameter.
+ *
+ * @typedef {{ children?: unknown }} PassthroughProps
+ * @typedef {((props: PassthroughProps) => unknown) & { displayName?: string }} PassthroughComponent
  */
+
+/** @type {Map<string, PassthroughComponent>} */
 const cache = new Map();
 
 /**
@@ -30,14 +39,18 @@ const cache = new Map();
  * rather than inside `passthrough` because it captures nothing from it —
  * re-declaring it per name built an identical closure on every cache miss
  * for no reason (unicorn/consistent-function-scoping).
+ *
+ * @param {PassthroughProps} props
  */
 const renderChildren = ({ children }) => children ?? null;
 
+/** @param {string} name */
 const passthrough = (name) => {
   if (!cache.has(name)) {
     // `.bind` is what gives each name its own function object to hang a
     // displayName on. A shared `renderChildren` would have one displayName
     // for all of them, which makes every failing snapshot read the same.
+    /** @type {PassthroughComponent} */
     const Component = renderChildren.bind(null);
     Component.displayName = `UnistylesNative(${name})`;
     cache.set(name, Component);

--- a/apps/mobile/jest/unistyles-native-stub.js
+++ b/apps/mobile/jest/unistyles-native-stub.js
@@ -1,0 +1,48 @@
+/**
+ * Stands in for `react-native-unistyles/components/native/*` under jest.
+ *
+ * The unistyles babel plugin rewrites every react-native primitive a component
+ * imports into its own drop-in:
+ *
+ *     import { View } from "react-native"
+ *   → var _View = require("react-native-unistyles/components/native/View")
+ *
+ * so a `jest.mock("react-native", ...)` never reaches the component that is
+ * actually rendered. The real drop-in then runs `buildUnistylesProps` →
+ * `getClassname` → `src/web/utils/unistyle.ts`, which is the WEB implementation
+ * and reads `.Node` off a DOM global that a node test environment does not
+ * have. Every suite that renders one of these died there.
+ *
+ * The library ships `react-native-unistyles/mocks`, but it mocks the package
+ * root only — `components/native/*` is a separate export path it does not
+ * cover, so it does not help here.
+ *
+ * A passthrough is the right shape for these suites: they assert on the props
+ * their own styled components receive, never on the primitives' output, and
+ * this keeps the styling layer out of a test about behaviour. Components are
+ * memoised per name so repeated access is referentially stable, which React
+ * requires to avoid remounting on every render.
+ */
+const cache = new Map();
+
+const passthrough = (name) => {
+  if (!cache.has(name)) {
+    const Component = ({ children }) => children ?? null;
+    Component.displayName = `UnistylesNative(${name})`;
+    cache.set(name, Component);
+  }
+
+  return cache.get(name);
+};
+
+module.exports = new Proxy(
+  {},
+  {
+    get: (_target, key) => {
+      if (key === "__esModule") return true;
+      if (typeof key === "symbol") return undefined;
+
+      return passthrough(key);
+    },
+  },
+);

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -133,6 +133,7 @@
     },
     "moduleNameMapper": {
       "\\.(png|jpe?g|gif|webp|svg|ttf|otf|woff2?|mp4|lottie)$": "<rootDir>/jest/asset-stub.js",
+      "^react-native-unistyles/components/native/.*$": "<rootDir>/jest/unistyles-native-stub.js",
       "^@/(.*)$": "<rootDir>/src/$1"
     }
   },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -128,6 +128,9 @@
   },
   "jest": {
     "clearMocks": true,
+    "globals": {
+      "__DEV__": true
+    },
     "moduleNameMapper": {
       "\\.(png|jpe?g|gif|webp|svg|ttf|otf|woff2?|mp4|lottie)$": "<rootDir>/jest/asset-stub.js",
       "^@/(.*)$": "<rootDir>/src/$1"

--- a/apps/mobile/src/components/Picker/index.tsx
+++ b/apps/mobile/src/components/Picker/index.tsx
@@ -75,7 +75,9 @@ const EASE_OUT = Easing.bezier(0.23, 1, 0.32, 1);
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-const PickerSheetContent = <T extends Item>(props: InputPickerProps<T>) => {
+export const PickerSheetContent = <T extends Item>(
+  props: InputPickerProps<T>,
+) => {
   const { t } = useTranslation();
   const { theme } = useUnistyles();
   const insets = useSafeAreaInsets();

--- a/apps/mobile/src/components/Picker/select-item.test.tsx
+++ b/apps/mobile/src/components/Picker/select-item.test.tsx
@@ -21,9 +21,23 @@ jest.mock<Record<string, unknown>>("./styles", () => ({
     captured.push(props);
     return null;
   },
+  // `useVariants` has to RETURN the stylesheet, and that is not a detail of
+  // the mock — it is the calling convention the unistyles babel plugin
+  // rewrites this component into. The plugin turns
+  //
+  //   styles.useVariants({ selected });   ...   style={styles.selectItem}
+  //
+  // into
+  //
+  //   const s = styles.useVariants({ selected });   ...   style={s.selectItem}
+  //
+  // so a `useVariants` that returns undefined makes every render throw on
+  // `undefined.selectItem`. With `jest.fn()` and no implementation, all three
+  // assertions below died in `renderRow` before reaching an `expect` — this
+  // file has never actually checked anything it claims to.
   styles: {
     selectItem: {},
-    useVariants: jest.fn(),
+    useVariants: jest.fn(() => ({ selectItem: {} })),
   },
 }));
 

--- a/apps/mobile/src/components/Picker/sheet-accessibility.test.tsx
+++ b/apps/mobile/src/components/Picker/sheet-accessibility.test.tsx
@@ -1,0 +1,142 @@
+import * as React from "react";
+
+/**
+ * The defect: every option inside a picker sheet is invisible to the
+ * accessibility tree, and so is the screen behind it.
+ *
+ * `@gorhom/bottom-sheet` applies `accessible` to the sheet's own container
+ * view, and its default is `true` (`DEFAULT_ACCESSIBLE` in
+ * components/bottomSheet/constants). On iOS, `accessible={true}` means "this
+ * view IS the accessibility element" — UIKit stops descending, so the title,
+ * the close button and every row underneath collapse into a single element
+ * that announces "Bottom Sheet" and nothing else. VoiceOver cannot reach a
+ * single option in the theme, language, size, colour or breed pickers.
+ *
+ * Captured from a live iPhone 17 Pro Max (iOS 26) with the colour sheet open
+ * and fully painted — the whole app, sheet contents included, reduced to:
+ *
+ *   'Pegada'
+ *     'Bottom sheet handle'
+ *     'Bottom Sheet'
+ *     'Bottom Sheet'
+ *
+ * This is also the truth behind the note that three Maestro flows carry —
+ * 23-preferences-journey, 23b-lang-theme-persistence, 40, and REWRITE-PLAN.md
+ * — that opening one of these sheets "crashes the XCUITest driver". Nothing
+ * crashes. The sheet renders perfectly and hides its own contents, and
+ * XCUITest reports what VoiceOver would get.
+ */
+
+type CapturedProps = Record<string, unknown> & {
+  children?: React.ReactNode;
+};
+
+const capturedModalProps: CapturedProps[] = [];
+
+jest.mock<Record<string, unknown>>("@gorhom/bottom-sheet", () => ({
+  BottomSheetModal: (props: CapturedProps) => {
+    capturedModalProps.push(props);
+    return null;
+  },
+  BottomSheetFlatList: () => null,
+}));
+
+// `react-native` ships untransformed Flow, and nothing here needs it to be
+// real — the assertion is about the props this component hands the sheet.
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  BackHandler: { addEventListener: () => ({ remove: () => undefined }) },
+  Keyboard: { dismiss: () => undefined },
+  Pressable: ({ children }: { children?: React.ReactNode }) => children,
+  View: ({ children }: { children?: React.ReactNode }) => children,
+  useWindowDimensions: () => ({ width: 440, height: 956 }),
+}));
+
+jest.mock<Record<string, unknown>>("./styles", () => ({
+  CloseIcon: () => null,
+  SearchInput: () => null,
+  styles: new Proxy(
+    {},
+    {
+      get: (_target, key) => (key === "useVariants" ? () => undefined : {}),
+    },
+  ),
+}));
+
+jest.mock<Record<string, unknown>>("./select-item", () => ({
+  PickerSelectItem: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/custom-backdrop", () => ({
+  renderCustomBackdrop: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/Input", () => ({
+  Input: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/text", () => ({
+  Text: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+jest.mock<Record<string, unknown>>("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock<Record<string, unknown>>("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// The sheet reads a handful of theme tokens purely to build style objects it
+// never asserts on. A recursive stand-in answers any token path so the test
+// does not have to track the design system. Built inside the factory because
+// jest.mock may not close over anything but `mock`-prefixed names.
+jest.mock<Record<string, unknown>>("react-native-unistyles", () => {
+  const anyToken: unknown = new Proxy({}, { get: () => anyToken });
+
+  return { useUnistyles: () => ({ theme: anyToken }) };
+});
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PickerSheet } from "./index";
+
+const OPTIONS = [
+  { id: "BLACK", name: "Black" },
+  { id: "GOLDEN", name: "Golden" },
+];
+
+const renderSheet = () => {
+  capturedModalProps.length = 0;
+
+  renderToStaticMarkup(
+    <PickerSheet
+      title="Color"
+      placeholder="Any color"
+      value={undefined}
+      data={OPTIONS}
+      onChange={jest.fn()}
+      itemTestIDPrefix="preferences-color-item-"
+    />,
+  );
+
+  return capturedModalProps[0]!;
+};
+
+describe("a picker sheet", () => {
+  it("does not collapse its contents into a single accessibility element", () => {
+    const props = renderSheet();
+
+    // The whole fix. `false` is not the same as leaving it unset: the library
+    // substitutes its own `true` for `undefined`, so the prop has to be
+    // passed explicitly to turn the behaviour off.
+    expect(props.accessible).toBe(false);
+  });
+
+  it("still renders its options underneath", () => {
+    const props = renderSheet();
+
+    // Guards the obvious over-correction — dropping the container's
+    // accessibility by removing the subtree instead of by exposing it.
+    expect(props.children).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/components/Picker/sheet-accessibility.test.tsx
+++ b/apps/mobile/src/components/Picker/sheet-accessibility.test.tsx
@@ -1,54 +1,86 @@
 import * as React from "react";
 
 /**
- * The defect: every option inside a picker sheet is invisible to the
- * accessibility tree, and so is the screen behind it.
+ * The defect this guards: every option inside a picker sheet must stay
+ * reachable by VoiceOver — nothing in the sheet's own tree may set
+ * `accessible={true}` on a container, because that collapses everything
+ * beneath it (title, close button, every row) into one announcement.
  *
- * `@gorhom/bottom-sheet` applies `accessible` to the sheet's own container
- * view, and its default is `true` (`DEFAULT_ACCESSIBLE` in
- * components/bottomSheet/constants). On iOS, `accessible={true}` means "this
- * view IS the accessibility element" — UIKit stops descending, so the title,
- * the close button and every row underneath collapse into a single element
- * that announces "Bottom Sheet" and nothing else. VoiceOver cannot reach a
- * single option in the theme, language, size, colour or breed pickers.
+ * That used to happen for free: `@gorhom/bottom-sheet`'s `BottomSheetModal`
+ * defaulted its container to `accessible={true}` (`DEFAULT_ACCESSIBLE`), and
+ * the original fix passed `accessible={false}` explicitly to opt out.
  *
- * Captured from a live iPhone 17 Pro Max (iOS 26) with the colour sheet open
- * and fully painted — the whole app, sheet contents included, reduced to:
- *
- *   'Pegada'
- *     'Bottom sheet handle'
- *     'Bottom Sheet'
- *     'Bottom Sheet'
- *
- * This is also the truth behind the note that three Maestro flows carry —
- * 23-preferences-journey, 23b-lang-theme-persistence, 40, and REWRITE-PLAN.md
- * — that opening one of these sheets "crashes the XCUITest driver". Nothing
- * crashes. The sheet renders perfectly and hides its own contents, and
- * XCUITest reports what VoiceOver would get.
+ * The picker has since migrated onto `react-native-magic-modal`
+ * (Picker/index.tsx) — gorhom is gone, and magic-modal's own wrapper views
+ * never set `accessible` at all, so that specific default no longer exists.
+ * What remains worth guarding is the sheet's OWN render tree: nothing in it
+ * should reintroduce the same collapse by adding `accessible={true}` to one
+ * of its containers.
  */
 
 type CapturedProps = Record<string, unknown> & {
   children?: React.ReactNode;
+  accessible?: unknown;
 };
 
-const capturedModalProps: CapturedProps[] = [];
+const capturedElements: { tag: string; accessible: unknown }[] = [];
+const capturedFlatListProps: CapturedProps[] = [];
 
-jest.mock<Record<string, unknown>>("@gorhom/bottom-sheet", () => ({
-  BottomSheetModal: (props: CapturedProps) => {
-    capturedModalProps.push(props);
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  FlatList: (props: CapturedProps) => {
+    capturedFlatListProps.push(props);
     return null;
   },
-  BottomSheetFlatList: () => null,
+  KeyboardAvoidingView: ({ children, accessible }: CapturedProps) => {
+    capturedElements.push({ tag: "KeyboardAvoidingView", accessible });
+    return children ?? null;
+  },
+  Platform: { OS: "ios" },
+  Pressable: ({ children, accessible }: CapturedProps) => {
+    capturedElements.push({ tag: "Pressable", accessible });
+    return children ?? null;
+  },
+  useWindowDimensions: () => ({ width: 440, height: 956 }),
+  View: ({ children, accessible }: CapturedProps) => {
+    capturedElements.push({ tag: "View", accessible });
+    return children ?? null;
+  },
 }));
 
-// `react-native` ships untransformed Flow, and nothing here needs it to be
-// real — the assertion is about the props this component hands the sheet.
-jest.mock<Record<string, unknown>>("react-native", () => ({
-  BackHandler: { addEventListener: () => ({ remove: () => undefined }) },
-  Keyboard: { dismiss: () => undefined },
-  Pressable: ({ children }: { children?: React.ReactNode }) => children,
-  View: ({ children }: { children?: React.ReactNode }) => children,
-  useWindowDimensions: () => ({ width: 440, height: 956 }),
+jest.mock<Record<string, unknown>>("react-native-gesture-handler", () => {
+  const gesture = { onUpdate: () => gesture, onEnd: () => gesture };
+
+  return {
+    Gesture: { Pan: () => gesture },
+    GestureDetector: ({ children }: CapturedProps) => children ?? null,
+  };
+});
+
+jest.mock<Record<string, unknown>>("react-native-reanimated", () => {
+  const chainable = { duration: () => chainable, easing: () => chainable };
+
+  return {
+    __esModule: true,
+    default: {
+      View: ({ children, accessible }: CapturedProps) => {
+        capturedElements.push({ tag: "Animated.View", accessible });
+        return children ?? null;
+      },
+      createAnimatedComponent: (Component: unknown) => Component,
+    },
+    Easing: { bezier: () => (t: number) => t },
+    FadeInDown: chainable,
+    FadeOutDown: chainable,
+    runOnJS: (fn: unknown) => fn,
+    useAnimatedStyle: () => ({}),
+    useSharedValue: (initial: unknown) => ({ value: initial }),
+    withSpring: (value: unknown) => value,
+    withTiming: (value: unknown) => value,
+  };
+});
+
+jest.mock<Record<string, unknown>>("react-native-magic-modal", () => ({
+  useMagicModal: () => ({ hide: jest.fn() }),
 }));
 
 jest.mock<Record<string, unknown>>("./styles", () => ({
@@ -64,10 +96,6 @@ jest.mock<Record<string, unknown>>("./styles", () => ({
 
 jest.mock<Record<string, unknown>>("./select-item", () => ({
   PickerSelectItem: () => null,
-}));
-
-jest.mock<Record<string, unknown>>("@/components/custom-backdrop", () => ({
-  renderCustomBackdrop: () => null,
 }));
 
 jest.mock<Record<string, unknown>>("@/components/Input", () => ({
@@ -98,7 +126,7 @@ jest.mock<Record<string, unknown>>("react-native-unistyles", () => {
 
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { PickerSheet } from "./index";
+import { PickerSheetContent } from "./index";
 
 const OPTIONS = [
   { id: "BLACK", name: "Black" },
@@ -106,10 +134,11 @@ const OPTIONS = [
 ];
 
 const renderSheet = () => {
-  capturedModalProps.length = 0;
+  capturedElements.length = 0;
+  capturedFlatListProps.length = 0;
 
   renderToStaticMarkup(
-    <PickerSheet
+    <PickerSheetContent
       title="Color"
       placeholder="Any color"
       value={undefined}
@@ -118,25 +147,19 @@ const renderSheet = () => {
       itemTestIDPrefix="preferences-color-item-"
     />,
   );
-
-  return capturedModalProps[0]!;
 };
 
 describe("a picker sheet", () => {
   it("does not collapse its contents into a single accessibility element", () => {
-    const props = renderSheet();
+    renderSheet();
 
-    // The whole fix. `false` is not the same as leaving it unset: the library
-    // substitutes its own `true` for `undefined`, so the prop has to be
-    // passed explicitly to turn the behaviour off.
-    expect(props.accessible).toBe(false);
+    const collapsed = capturedElements.filter((el) => el.accessible === true);
+    expect(collapsed).toStrictEqual([]);
   });
 
   it("still renders its options underneath", () => {
-    const props = renderSheet();
+    renderSheet();
 
-    // Guards the obvious over-correction — dropping the container's
-    // accessibility by removing the subtree instead of by exposing it.
-    expect(props.children).toBeTruthy();
+    expect(capturedFlatListProps[0]?.data).toStrictEqual(OPTIONS);
   });
 });

--- a/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.test.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.test.tsx
@@ -80,7 +80,22 @@ jest.mock<Record<string, unknown>>("./styles", () => ({
   AddRemoveContainer: (props: CapturedProps) => capture(props),
   FadedDog: () => null,
   MaestroSkipPressable: (props: CapturedProps) => capture(props),
-  styles: { useVariants: jest.fn() },
+  // `useVariants` has to RETURN the stylesheet: the unistyles babel plugin
+  // rewrites `styles.useVariants({...}); ... style={styles.x}` into
+  // `const s = styles.useVariants({...}); ... style={s.x}`, so a mock that
+  // returns undefined makes every render throw on `undefined.x`.
+  styles: {
+    useVariants: jest.fn(() => ({
+      addRemoveContainer: {},
+      animatedOverlay: {},
+      debugImageStatusContainer: {},
+      fadedDog: {},
+      maestroSkipPressable: {},
+      userPicture: {},
+      userPictureContainer: {},
+      userPictureContent: {},
+    })),
+  },
   UserPicture: () => null,
 }));
 

--- a/apps/mobile/src/components/RadioButtons/index.test.tsx
+++ b/apps/mobile/src/components/RadioButtons/index.test.tsx
@@ -1,0 +1,147 @@
+import * as React from "react";
+
+/**
+ * The defect: the gender radio was the one required control on CreateProfile
+ * that nothing could address. `RadioButtons` rendered a Pressable per option
+ * and passed it no `testID`, and its options were identified by their
+ * TRANSLATED label — so a flow could only reach "Female" by matching display
+ * copy, in whatever language the device happened to boot in.
+ *
+ * That is why no E2E flow has ever created a FEMALE dog, and why the deck's
+ * opposite-gender filter (SuggestionService.#buildPreferenceConditions) has
+ * never been exercised with two accounts created through the app.
+ */
+
+type CapturedProps = Record<string, unknown> & {
+  children?: React.ReactNode;
+  onPress?: () => void;
+};
+
+const captured: CapturedProps[] = [];
+
+jest.mock<Record<string, unknown>>("./styles", () => ({
+  RadioButtonContainer: (props: CapturedProps) => {
+    captured.push(props);
+    return null;
+  },
+  TextButton: ({ children }: { children?: React.ReactNode }) => children,
+  // `useVariants` has to RETURN the stylesheet. The unistyles babel plugin
+  // rewrites `styles.useVariants({...}); ... style={styles.x}` into
+  // `const s = styles.useVariants({...}); ... style={s.x}`, so a mock that
+  // returns undefined makes every render throw on `undefined.x`. Same trap
+  // select-item.test.tsx was caught in.
+  styles: {
+    content: {},
+    radioButtonContainer: {},
+    textButton: {},
+    useVariants: jest.fn(() => ({
+      content: {},
+      radioButtonContainer: {},
+      textButton: {},
+    })),
+  },
+}));
+
+jest.mock<Record<string, unknown>>("@/components/Input/styles", () => ({
+  styles: { container: {} },
+}));
+
+// react-native ships untranspiled Flow; this suite has no RN preset and only
+// needs `View` to be a passthrough so the option props can be captured.
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  View: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+// ...and the mock above never reached this component, which is the other half
+// of why this suite has never run. The unistyles babel plugin rewrites the
+// `View` import out of `react-native` and into its own drop-in:
+//
+//   var _View = require("react-native-unistyles/components/native/View");
+//
+// so the real one rendered, took its web `getClassname` path under jsdom-less
+// Node, and died on `unistyle.ts` reading `.Node` of undefined. Mocking the
+// module the plugin actually emits is the only mock that applies.
+jest.mock<Record<string, unknown>>(
+  "react-native-unistyles/components/native/View",
+  () => ({
+    View: ({ children }: { children?: React.ReactNode }) => children,
+  }),
+);
+
+jest.mock<Record<string, unknown>>("@/components/text", () => ({
+  Text: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RadioButtons } from ".";
+
+const GENDERS = [
+  { id: "MALE", name: "Macho" },
+  { id: "FEMALE", name: "Fêmea" },
+];
+
+const renderRadios = ({
+  value = "MALE",
+  onChange = jest.fn(),
+}: { value?: string; onChange?: (id: string) => void } = {}) => {
+  captured.length = 0;
+  renderToStaticMarkup(
+    <RadioButtons
+      title="Gender"
+      data={GENDERS}
+      value={value}
+      onChange={onChange}
+      itemTestIDPrefix="gender-item-"
+    />,
+  );
+
+  return captured;
+};
+
+describe("a radio group", () => {
+  it("gives every option a testID derived from its stable id", () => {
+    const options = renderRadios();
+
+    expect(options.map((option) => option.testID)).toStrictEqual([
+      "gender-item-MALE",
+      "gender-item-FEMALE",
+    ]);
+  });
+
+  it("reports the selection back as the id, not the translated label", () => {
+    const onChange = jest.fn();
+    const options = renderRadios({ onChange });
+
+    (options[1]!.onPress as () => void)();
+
+    expect(onChange).toHaveBeenCalledWith("FEMALE");
+  });
+
+  it("reports the selection the highlight conveys visually", () => {
+    const options = renderRadios({ value: "FEMALE" });
+
+    expect(options.map((option) => option.accessibilityState)).toStrictEqual([
+      { selected: false },
+      { selected: true },
+    ]);
+    expect(options.map((option) => option.accessibilityRole)).toStrictEqual([
+      "radio",
+      "radio",
+    ]);
+  });
+
+  it("adds no testID when the caller asks for none", () => {
+    captured.length = 0;
+    renderToStaticMarkup(
+      <RadioButtons
+        title="Gender"
+        data={GENDERS}
+        value="MALE"
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(captured.every((option) => option.testID === undefined)).toBe(true);
+  });
+});

--- a/apps/mobile/src/components/RadioButtons/index.tsx
+++ b/apps/mobile/src/components/RadioButtons/index.tsx
@@ -8,11 +8,30 @@ import { Text } from "@/components/text";
 
 import { RadioButtonContainer, TextButton, styles } from "./styles";
 
+/**
+ * One selectable option. `id` is the value the form stores, `name` is what
+ * the user reads — they are separate because the label is translated and the
+ * value is not. Before this split, `onChange` handed back the translated
+ * label and every caller mapped it back with a string comparison against
+ * `t(...)`, which is also why no option could carry a stable testID.
+ */
+export type RadioButtonItem = {
+  id: string;
+  name: string;
+};
+
 type RadioButtonsProps = {
   title: string;
-  data: string[];
-  value: string;
-  onChange: React.Dispatch<React.SetStateAction<string>>;
+  data: RadioButtonItem[];
+  /** The selected option's `id`. Nothing is marked while it is undefined. */
+  value: string | undefined;
+  onChange: (id: string) => void;
+  /**
+   * When provided, each option receives `testID={itemTestIDPrefix + item.id}`.
+   * Same contract as {@link InputPicker}'s prop of the same name, so Maestro
+   * flows select a radio the way they select a picker row.
+   */
+  itemTestIDPrefix?: string;
 };
 
 type RadioButtonProps = {
@@ -23,7 +42,16 @@ const RadioButton: React.FC<RadioButtonProps> = (props) => {
   styles.useVariants({ last: props.last, marked: props.marked });
   return (
     <RadioButtonContainer
+      testID={props.testID}
       onPress={props.onPress}
+      // The option was a Pressable wrapping a bare <Text>: no label of its
+      // own, no role, and its selected state conveyed by fill colour alone.
+      // Same treatment PickerSelectItem got — one element, labelled, with the
+      // selection exposed rather than only painted.
+      accessible
+      accessibilityRole="radio"
+      accessibilityLabel={props.children}
+      accessibilityState={{ selected: Boolean(props.marked) }}
       style={styles.radioButtonContainer}
     >
       <TextButton fontWeight="bold" fontSize="md" style={styles.textButton}>
@@ -38,6 +66,7 @@ export const RadioButtons: React.FC<RadioButtonsProps> = ({
   data,
   onChange,
   value,
+  itemTestIDPrefix,
 }) => {
   return (
     <View style={inputStyles.container}>
@@ -48,12 +77,15 @@ export const RadioButtons: React.FC<RadioButtonsProps> = ({
         {data.map((item, index) => {
           return (
             <RadioButton
-              key={item}
-              marked={item === value}
-              onPress={() => onChange(item)}
+              key={item.id}
+              testID={
+                itemTestIDPrefix ? `${itemTestIDPrefix}${item.id}` : undefined
+              }
+              marked={item.id === value}
+              onPress={() => onChange(item.id)}
               last={index === data.length - 1}
             >
-              {item}
+              {item.name}
             </RadioButton>
           );
         })}

--- a/apps/mobile/src/views/(auth)/AskForLocation/index.tsx
+++ b/apps/mobile/src/views/(auth)/AskForLocation/index.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import * as React from "react";
 import { Alert, Linking, ScrollView, View } from "react-native";
 
-import * as Location from "expo-location";
 import { useRouter } from "expo-router";
 
 import { useTranslation } from "react-i18next";
@@ -11,7 +10,6 @@ import { useUnistyles } from "react-native-unistyles";
 
 import { Button } from "@/components/Button";
 import { Text } from "@/components/text";
-import { getTrcpContext } from "@/contexts/trcp-context";
 import { sendError } from "@/services/error-tracking";
 import { SceneName } from "@/types/scene-name";
 
@@ -23,66 +21,10 @@ import {
   Title,
   styles,
 } from "./styles";
-
-enum UpdateLocationError {
-  PermissionNotGranted = "Location permission not granted",
-}
-
-const getApproximatedPosition = async () => {
-  const lastKnownPosition = await Location.getLastKnownPositionAsync({
-    maxAge: 1000 * 60 * 60 * 24 * 2, // 2 days
-  });
-
-  if (lastKnownPosition) return lastKnownPosition.coords;
-
-  const currentPostion = await Location.getCurrentPositionAsync({
-    accuracy: Location.Accuracy.Low,
-  });
-
-  return currentPostion.coords;
-};
-
-export const updateUserLocation = async (newLocation?: {
-  longitude: number;
-  latitude: number;
-}) => {
-  const { status } = await Location.requestForegroundPermissionsAsync();
-
-  if (status !== "granted") {
-    throw new Error(UpdateLocationError.PermissionNotGranted);
-  }
-
-  const position = newLocation ?? (await getApproximatedPosition());
-
-  const geocode = await Location.reverseGeocodeAsync({
-    latitude: position.latitude,
-    longitude: position.longitude,
-  });
-
-  const location = {
-    latitude: position.latitude,
-    longitude: position.longitude,
-    city: geocode[0]?.city ?? null,
-    state: geocode[0]?.region ?? null,
-    country: geocode[0]?.country ?? null,
-  };
-
-  const newUserData =
-    await getTrcpContext().client.user.update.mutate(location);
-
-  getTrcpContext().myDog.get.setData(undefined, (oldDogData) => {
-    if (!oldDogData) return undefined;
-    return {
-      ...oldDogData,
-      user: {
-        ...newUserData,
-        ...location,
-      },
-    };
-  });
-
-  return newUserData;
-};
+import {
+  updateUserLocation,
+  UpdateLocationError,
+} from "./update-user-location";
 
 const AskForLocation: React.FC = () => {
   const insets = useSafeAreaInsets();

--- a/apps/mobile/src/views/(auth)/AskForLocation/update-user-location.test.ts
+++ b/apps/mobile/src/views/(auth)/AskForLocation/update-user-location.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The defect: `updateUserLocation` awaited `Location.reverseGeocodeAsync`
+ * BEFORE `user.update.mutate`, unguarded. City/state/country are display copy;
+ * latitude/longitude are what the whole swipe deck is ordered by. One throw
+ * from the geocoder — offline, rate-limited, or an Android emulator image with
+ * no geocoder backend — discarded a location the user had just granted.
+ *
+ * The user then sees "something went wrong", lands on an empty-feeling deck,
+ * and their row keeps NULL coordinates. `maestro-fresh@pegada.app`, the only
+ * account in the dev database ever created through the app, is in exactly that
+ * state: dog created, photo approved, `latitude` NULL.
+ */
+
+const mockMutate = jest.fn();
+const mockSetData = jest.fn();
+
+const mockRequestForegroundPermissionsAsync = jest.fn();
+const mockGetLastKnownPositionAsync = jest.fn();
+const mockGetCurrentPositionAsync = jest.fn();
+const mockReverseGeocodeAsync = jest.fn();
+const mockSendError = jest.fn();
+
+jest.mock<Record<string, unknown>>("expo-location", () => ({
+  Accuracy: { Low: 2 },
+  requestForegroundPermissionsAsync: () =>
+    mockRequestForegroundPermissionsAsync() as unknown,
+  getLastKnownPositionAsync: () => mockGetLastKnownPositionAsync() as unknown,
+  getCurrentPositionAsync: () => mockGetCurrentPositionAsync() as unknown,
+  reverseGeocodeAsync: (position: unknown) =>
+    mockReverseGeocodeAsync(position) as unknown,
+}));
+
+jest.mock<Record<string, unknown>>("@/contexts/trcp-context", () => ({
+  getTrcpContext: () => ({
+    client: { user: { update: { mutate: mockMutate } } },
+    myDog: { get: { setData: mockSetData } },
+  }),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: (error: unknown) => mockSendError(error) as unknown,
+}));
+
+import { updateUserLocation } from "./update-user-location";
+
+const SF = { latitude: 37.7749, longitude: -122.4194 };
+
+beforeEach(() => {
+  mockRequestForegroundPermissionsAsync.mockResolvedValue({
+    status: "granted",
+  });
+  mockGetLastKnownPositionAsync.mockResolvedValue({ coords: SF });
+  mockReverseGeocodeAsync.mockResolvedValue([
+    { city: "San Francisco", region: "CA", country: "USA" },
+  ]);
+  mockMutate.mockImplementation((input: unknown) => Promise.resolve(input));
+});
+
+describe("updateUserLocation", () => {
+  it("persists the place name when the geocoder answers", async () => {
+    await updateUserLocation();
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      ...SF,
+      city: "San Francisco",
+      state: "CA",
+      country: "USA",
+    });
+  });
+
+  it("still persists the coordinates when the geocoder throws", async () => {
+    mockReverseGeocodeAsync.mockRejectedValue(
+      new Error("geocoder unavailable"),
+    );
+
+    await updateUserLocation();
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      ...SF,
+      city: null,
+      state: null,
+      country: null,
+    });
+    expect(mockSendError).toHaveBeenCalled();
+  });
+
+  it("still persists the coordinates when the geocoder finds no place", async () => {
+    mockReverseGeocodeAsync.mockResolvedValue([]);
+
+    await updateUserLocation();
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      ...SF,
+      city: null,
+      state: null,
+      country: null,
+    });
+  });
+
+  it("refuses to write anything without permission", async () => {
+    mockRequestForegroundPermissionsAsync.mockResolvedValue({
+      status: "denied",
+    });
+
+    await expect(updateUserLocation()).rejects.toThrow(
+      "Location permission not granted",
+    );
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("prefers a caller-supplied position over the device's", async () => {
+    const dropped = { latitude: 1, longitude: 2 };
+
+    await updateUserLocation(dropped);
+
+    expect(mockGetLastKnownPositionAsync).not.toHaveBeenCalled();
+    expect(mockMutate).toHaveBeenCalledWith(expect.objectContaining(dropped));
+  });
+});

--- a/apps/mobile/src/views/(auth)/AskForLocation/update-user-location.ts
+++ b/apps/mobile/src/views/(auth)/AskForLocation/update-user-location.ts
@@ -1,0 +1,89 @@
+import * as Location from "expo-location";
+
+import { getTrcpContext } from "@/contexts/trcp-context";
+import { sendError } from "@/services/error-tracking";
+
+export enum UpdateLocationError {
+  PermissionNotGranted = "Location permission not granted",
+}
+
+const getApproximatedPosition = async () => {
+  const lastKnownPosition = await Location.getLastKnownPositionAsync({
+    maxAge: 1000 * 60 * 60 * 24 * 2, // 2 days
+  });
+
+  if (lastKnownPosition) return lastKnownPosition.coords;
+
+  const currentPostion = await Location.getCurrentPositionAsync({
+    accuracy: Location.Accuracy.Low,
+  });
+
+  return currentPostion.coords;
+};
+
+/**
+ * City / state / country are display copy — they name the coordinates on the
+ * Profile row and nowhere else. The coordinates themselves are what the deck
+ * is built from: `SuggestionService.getPotentialMatches` orders every card by
+ * `ST_DistanceSphere` against `User.latitude/longitude`, and a user with NULL
+ * coordinates sorts into the last distance bucket of everyone's stack and
+ * sees `distance: null` on every card.
+ *
+ * So the reverse geocode is not allowed to take the write down with it. It is
+ * a network round-trip to Apple/Google's geocoder, it fails offline, and it
+ * has no backend at all on a bare Android emulator image — before this, one
+ * throw from it discarded a location the user had just granted, with only a
+ * generic "something went wrong" alert to show for it.
+ */
+const reverseGeocode = async (position: {
+  latitude: number;
+  longitude: number;
+}) => {
+  try {
+    const [place] = await Location.reverseGeocodeAsync(position);
+
+    return {
+      city: place?.city ?? null,
+      state: place?.region ?? null,
+      country: place?.country ?? null,
+    };
+  } catch (error) {
+    sendError(error);
+    return { city: null, state: null, country: null };
+  }
+};
+
+export const updateUserLocation = async (newLocation?: {
+  longitude: number;
+  latitude: number;
+}) => {
+  const { status } = await Location.requestForegroundPermissionsAsync();
+
+  if (status !== "granted") {
+    throw new Error(UpdateLocationError.PermissionNotGranted);
+  }
+
+  const position = newLocation ?? (await getApproximatedPosition());
+
+  const location = {
+    latitude: position.latitude,
+    longitude: position.longitude,
+    ...(await reverseGeocode(position)),
+  };
+
+  const newUserData =
+    await getTrcpContext().client.user.update.mutate(location);
+
+  getTrcpContext().myDog.get.setData(undefined, (oldDogData) => {
+    if (!oldDogData) return undefined;
+    return {
+      ...oldDogData,
+      user: {
+        ...newUserData,
+        ...location,
+      },
+    };
+  });
+
+  return newUserData;
+};

--- a/apps/mobile/src/views/(auth)/CreateProfile/index.tsx
+++ b/apps/mobile/src/views/(auth)/CreateProfile/index.tsx
@@ -226,20 +226,13 @@ const CreateProfile = () => {
               render={({ field: { onChange, value } }) => (
                 <RadioButtons
                   title={t("completeProfile.gender")}
+                  itemTestIDPrefix="gender-item-"
                   data={[
-                    t("completeProfile.male"),
-                    t("completeProfile.female"),
+                    { id: "MALE", name: t("completeProfile.male") },
+                    { id: "FEMALE", name: t("completeProfile.female") },
                   ]}
-                  value={
-                    value === "MALE"
-                      ? t("completeProfile.male")
-                      : t("completeProfile.female")
-                  }
-                  onChange={(value) => {
-                    onChange(
-                      value === t("completeProfile.male") ? "MALE" : "FEMALE",
-                    );
-                  }}
+                  value={value}
+                  onChange={onChange}
                 />
               )}
             />

--- a/apps/mobile/src/views/(tabs)/Profile/components/language-config.test.tsx
+++ b/apps/mobile/src/views/(tabs)/Profile/components/language-config.test.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+
+/**
+ * The defect: on any locale that is not EXACTLY `en-US` or `pt-BR`, the
+ * language picker shows no current selection and the Profile row's subtitle is
+ * right only by accident.
+ *
+ * `LanguageConfig` looks the current language up in a two-key map:
+ *
+ *   const value = languagesPickerData.find(({ id }) => id === i18n.language)
+ *     ?? { id: i18n.language, name: LANGUAGES[Language.Default] };
+ *
+ * `i18n.language` is whatever `expo-localization` reported for the device —
+ * the raw BCP-47 tag. The simulator this was found on runs `en-BR` (English
+ * language, Brazil region), which is a perfectly ordinary configuration, and so
+ * are `en-GB`, `en-CA` and `en-AU`. None of them match, so:
+ *
+ *   * the fallback branch invents an option whose id is the device tag, and no
+ *     row in the sheet has that id, so `PickerSelectItem` marks nothing
+ *     selected — verified on device, both rows came back `selected=false`
+ *     while the app was plainly running in English;
+ *   * the subtitle reads "English" because the FALLBACK's name is hardcoded to
+ *     the default language's, not because anything resolved to English.
+ *
+ * i18next already knows the answer. `resolvedLanguage` is the tag it actually
+ * loaded resources for after applying `fallbackLng` — "en-US" for a device on
+ * "en-BR" — which is exactly the row that should be ticked.
+ */
+
+type CapturedProps = Record<string, unknown>;
+
+const capturedSheetProps: CapturedProps[] = [];
+
+jest.mock<Record<string, unknown>>("@/components/Picker", () => ({
+  PickerSheet: (props: CapturedProps) => {
+    capturedSheetProps.push(props);
+    return null;
+  },
+}));
+
+jest.mock<Record<string, unknown>>("./Config", () => {
+  const passthrough =
+    () =>
+    ({ children }: { children?: React.ReactNode }) =>
+      children;
+
+  return {
+    Config: {
+      Root: passthrough(),
+      Container: passthrough(),
+      Title: passthrough(),
+      Description: passthrough(),
+      Arrow: () => null,
+    },
+  };
+});
+
+jest.mock<Record<string, unknown>>("@/assets/images/Translate.svg", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("react-native-unistyles", () => ({
+  useUnistyles: () => ({ theme: { colors: { text: "#000" } } }),
+}));
+
+const mockI18n = {
+  language: "en-US",
+  resolvedLanguage: "en-US",
+  changeLanguage: jest.fn(() => Promise.resolve()),
+};
+
+jest.mock<Record<string, unknown>>("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: mockI18n,
+  }),
+}));
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { LanguageConfig } from "./language-config";
+
+const renderFor = (language: string, resolvedLanguage?: string) => {
+  capturedSheetProps.length = 0;
+  mockI18n.language = language;
+  mockI18n.resolvedLanguage = resolvedLanguage ?? language;
+
+  renderToStaticMarkup(<LanguageConfig />);
+
+  return capturedSheetProps[0]!;
+};
+
+describe("the language setting", () => {
+  it("ticks the row the app is actually running in", () => {
+    // The exact tags the two supported languages ship under still work.
+    expect(renderFor("en-US").value).toMatchObject({ id: "en-US" });
+    expect(renderFor("pt-BR").value).toMatchObject({ id: "pt-BR" });
+  });
+
+  it("ticks English on an English locale from another region", () => {
+    // en-BR is what the QA simulator reports; en-GB/en-CA/en-AU are the same
+    // shape and are a large share of real users. i18next resolves all of them
+    // to the en-US bundle, so that is the row to tick.
+    const props = renderFor("en-BR", "en-US");
+
+    expect(props.value).toMatchObject({ id: "en-US", name: "English" });
+  });
+
+  it("ticks Portuguese on a Portuguese locale from another region", () => {
+    const props = renderFor("pt-PT", "pt-BR");
+
+    expect(props.value).toMatchObject({ id: "pt-BR", name: "Português" });
+  });
+});

--- a/apps/mobile/src/views/(tabs)/Profile/components/language-config.tsx
+++ b/apps/mobile/src/views/(tabs)/Profile/components/language-config.tsx
@@ -27,7 +27,19 @@ const languagesPickerData = Object.entries(LANGUAGES).map(([id, name]) => ({
 export const LanguageConfig = () => {
   const { t, i18n } = useTranslation();
 
-  const currentLanguage = i18n.language;
+  // `resolvedLanguage`, not `language`. The latter is the raw device tag
+  // expo-localization reported, and only two tags on earth match this list
+  // exactly. A phone set to English in Brazil reports `en-BR`; `en-GB`,
+  // `en-CA` and `en-AU` are the same shape and are a great many real users.
+  // For all of them the lookup below missed, the fallback invented an option
+  // whose id no row in the sheet carries, and the picker showed NOTHING
+  // selected while the app was plainly running in English — the subtitle read
+  // "English" only because the fallback hardcodes the default language's name.
+  //
+  // `resolvedLanguage` is the tag i18next actually loaded resources for after
+  // applying `fallbackLng`, so it is by definition one of the two we ship, and
+  // it is the row the user is actually reading the app in.
+  const currentLanguage = i18n.resolvedLanguage ?? i18n.language;
 
   const { theme } = useUnistyles();
 

--- a/apps/mobile/src/views/EditProfile/index.tsx
+++ b/apps/mobile/src/views/EditProfile/index.tsx
@@ -381,17 +381,13 @@ const EditProfile = () => {
               render={({ field: { onChange, value } }) => (
                 <RadioButtons
                   title={t("editProfile.gender")}
-                  data={[t("editProfile.male"), t("editProfile.female")]}
-                  value={
-                    value === "MALE"
-                      ? t("editProfile.male")
-                      : t("editProfile.female")
-                  }
-                  onChange={(value) => {
-                    onChange(
-                      value === t("editProfile.male") ? "MALE" : "FEMALE",
-                    );
-                  }}
+                  itemTestIDPrefix="edit-profile-gender-item-"
+                  data={[
+                    { id: "MALE", name: t("editProfile.male") },
+                    { id: "FEMALE", name: t("editProfile.female") },
+                  ]}
+                  value={value}
+                  onChange={onChange}
                 />
               )}
             />

--- a/apps/mobile/src/views/LocationMap/index.tsx
+++ b/apps/mobile/src/views/LocationMap/index.tsx
@@ -17,7 +17,7 @@ import { api } from "@/contexts/trpc-provider";
 import { sendError } from "@/services/error-tracking";
 import { Actions } from "@/store/reducers";
 
-import { updateUserLocation } from "../(auth)/AskForLocation";
+import { updateUserLocation } from "../(auth)/AskForLocation/update-user-location";
 import { Marker } from "./components/Marker";
 import { Submit } from "./components/Submit";
 import { MapView, styles } from "./styles";

--- a/apps/nextjs/.gitignore
+++ b/apps/nextjs/.gitignore
@@ -37,3 +37,4 @@ pnpm-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .next-*/
+.env*

--- a/apps/nextjs/tsconfig.json
+++ b/apps/nextjs/tsconfig.json
@@ -4,9 +4,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -17,7 +15,5 @@
     "next-env.d.ts",
     ".next-3020/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/apps/nextjs/tsconfig.json
+++ b/apps/nextjs/tsconfig.json
@@ -4,15 +4,20 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
-    "next-env.d.ts",
+    "**/*.js",
     "**/*.ts",
     "**/*.tsx",
-    "**/*.js",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    ".next-3020/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/api/src/services/SuggestionService/suggestion-service.test.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.test.ts
@@ -292,6 +292,49 @@ describe("SuggestionService", () => {
       expect(afterLikesPotentialMatches[0]!.id).toEqual(premiumDog.id);
     });
 
+    test("a premium dog that liked someone else does not jump the queue", async () => {
+      const [
+        { dog },
+        { dog: nearDog },
+        { dog: premiumStranger },
+        { dog: bystander },
+      ] = await Promise.all([
+        generateFakeUserWithDog(
+          { gender: Gender.MALE },
+          { longitude: 0, latitude: 0 },
+        ),
+        generateFakeUserWithDog(
+          { gender: Gender.FEMALE },
+          { plan: PlanType.FREE, longitude: 0, latitude: 0 }, // Co-located
+        ),
+        generateFakeUserWithDog(
+          { gender: Gender.FEMALE },
+          { plan: PlanType.PREMIUM, longitude: 1, latitude: 1 }, // Further away
+        ),
+        // Not in `dog`'s deck at all — same gender as the swiper.
+        generateFakeUserWithDog(
+          { gender: Gender.MALE },
+          { longitude: 5, latitude: 5 },
+        ),
+      ]);
+
+      // The premium dog liked SOMEONE ELSE. Being premium buys priority over
+      // the people who liked you, not over everyone's deck everywhere.
+      await SwipeService.createOrUpdateInterest(
+        premiumStranger.id,
+        bystander.id,
+        SwipeType.INTERESTED,
+      );
+
+      const potentialMatches = await SuggestionService.getPotentialMatches(
+        dog,
+        LIMIT,
+        [],
+      );
+
+      expect(potentialMatches[0]!.id).toEqual(nearDog.id);
+    });
+
     describe("Preferences", () => {
       test("gender", async () => {
         const [{ dog }] = await Promise.all([

--- a/packages/api/src/services/SuggestionService/suggestion-service.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.ts
@@ -171,10 +171,15 @@ export class SuggestionService {
           WHEN "User"."latitude" IS NULL OR "User"."longitude" IS NULL OR "MainUser"."latitude" IS NULL OR "MainUser"."longitude" IS NULL THEN NULL
           ELSE ST_DistanceSphere(ST_MakePoint("User"."longitude", "User"."latitude"), ST_MakePoint("MainUser"."longitude", "MainUser"."latitude")) / 1000
           END AS distance,
+        /* Premium buys priority over the people who liked YOU — the
+           "responderId" filter is what scopes it to this deck. Without it the
+           subquery selected every requester in the table, so one premium dog
+           who had liked anyone at all sorted to the top of everyone's stack. */
         CASE
           WHEN "User"."plan" = ${PlanType.PREMIUM}::"PlanType" AND "Dog"."id" IN (
             SELECT "requesterId" FROM "Interest"
-            WHERE "swipeType" IN (${SwipeType.INTERESTED}::"SwipeType", ${SwipeType.MAYBE}::"SwipeType")
+            WHERE "responderId" = ${dog.id}
+            AND "swipeType" IN (${SwipeType.INTERESTED}::"SwipeType", ${SwipeType.MAYBE}::"SwipeType")
             AND "deletedAt" IS NULL
           ) THEN 1
           ELSE 0

--- a/packages/api/src/services/user-service.test.ts
+++ b/packages/api/src/services/user-service.test.ts
@@ -1,13 +1,42 @@
 import prisma from "@pegada/database";
 
+import { config } from "../shared/config";
 import { deleteImageFromS3 } from "../shared/file-upload";
 import { UserService } from "./user-service";
 
-jest.mock("../shared/file-upload", () => ({
-  deleteImageFromS3: jest.fn(),
-}));
+/**
+ * The mock refuses foreign origins, because the real function does.
+ *
+ * `deleteImageFromS3` opens with `storageForUrl`, which opens with
+ * `assertAllowedImageUrl` — a URL outside the configured storage origins never
+ * reaches the S3 client, it throws. A bare `jest.fn()` returning undefined for
+ * every input is what let an account become permanently undeletable without a
+ * single red test: the suite's own fixture pointed at `https://images.test`,
+ * an origin this service is not configured for, and the mock happily accepted
+ * it.
+ */
+jest.mock("../shared/file-upload", () => {
+  const { isAllowedImageUrl } = jest.requireActual<
+    typeof import("../shared/image-url")
+  >("../shared/image-url");
+
+  return {
+    deleteImageFromS3: jest.fn(async (url: string) => {
+      if (!isAllowedImageUrl(url)) {
+        throw new Error(
+          "Image URL does not point at a configured storage origin",
+        );
+      }
+    }),
+  };
+});
 
 const deleteStoredImage = jest.mocked(deleteImageFromS3);
+
+/** .env.test leaves R2 and AWS_S3_ENDPOINT unset, so this is the one origin
+ * this service is configured to operate on. */
+const BUCKET_URL = `https://${config.AWS_S3_BUCKET_NAME}.s3.${config.AWS_REGION}.amazonaws.com`;
+const STORED_PHOTO = `${BUCKET_URL}/dogs/luna.webp`;
 
 afterAll(async () => {
   await prisma.$disconnect();
@@ -22,7 +51,7 @@ beforeEach(async () => {
   await prisma.user.deleteMany();
 });
 
-const seedAccount = async () =>
+const seedAccount = async (url = STORED_PHOTO) =>
   prisma.user.create({
     data: {
       email: "delete-storage-test@pegada.app",
@@ -30,12 +59,7 @@ const seedAccount = async () =>
         create: {
           name: "Luna",
           gender: "FEMALE",
-          images: {
-            create: {
-              url: "https://images.test/dogs/luna.webp",
-              position: 0,
-            },
-          },
+          images: { create: { url, position: 0 } },
         },
       },
     },
@@ -46,9 +70,7 @@ test("removes stored photos before deleting an account", async () => {
 
   await UserService.deleteAccount(user.id);
 
-  expect(deleteStoredImage).toHaveBeenCalledWith(
-    "https://images.test/dogs/luna.webp",
-  );
+  expect(deleteStoredImage).toHaveBeenCalledWith(STORED_PHOTO);
   await expect(
     prisma.user.findUnique({ where: { id: user.id } }),
   ).resolves.toBeNull();
@@ -64,4 +86,29 @@ test("keeps the account when a stored photo cannot be removed", async () => {
   await expect(
     prisma.user.findUnique({ where: { id: user.id } }),
   ).resolves.toMatchObject({ id: user.id });
+});
+
+/**
+ * Guideline 5.1.1(v) says an account created in the app has to be deletable in
+ * the app. A photo uploaded before the current storage origins were configured
+ * — a retired bucket, a seeded fixture, anything from before the R2 move —
+ * has nothing of ours behind it, and asking the storage layer to route it
+ * throws. Letting that reject the whole operation does not protect the photo;
+ * it makes the account permanently undeletable, which is the one outcome the
+ * guideline forbids.
+ *
+ * `DogService.updateDog` already filters its deletions this way, with the same
+ * reasoning written next to it. This is the path that was missed.
+ */
+test("deletes the account even when a photo is on a retired storage origin", async () => {
+  const user = await seedAccount("https://placedog.net/640/480?id=42");
+
+  await UserService.deleteAccount(user.id);
+
+  expect(deleteStoredImage).not.toHaveBeenCalled();
+  await expect(
+    prisma.user.findUnique({ where: { id: user.id } }),
+  ).resolves.toBeNull();
+  await expect(prisma.image.count()).resolves.toBe(0);
+  await expect(prisma.dog.count()).resolves.toBe(0);
 });

--- a/packages/api/src/services/user-service.ts
+++ b/packages/api/src/services/user-service.ts
@@ -3,6 +3,7 @@ import type { User } from "@prisma/client";
 import prisma from "@pegada/database";
 
 import { deleteImageFromS3 } from "../shared/file-upload";
+import { isAllowedImageUrl } from "../shared/image-url";
 
 export class UserService {
   /**
@@ -33,7 +34,21 @@ export class UserService {
     // Delete public objects before their database references disappear. A
     // failed storage deletion leaves the account intact so the request can be
     // retried without losing track of personal data that still needs removal.
-    await Promise.all(imageUrls.map((url) => deleteImageFromS3(url)));
+    //
+    // Photos on an origin this deployment is not configured for are skipped
+    // rather than attempted. They are not ours to delete — a retired bucket, a
+    // seeded fixture, anything from before the R2 move — and `storageForUrl`
+    // refuses to route them, so asking would throw and leave the account
+    // permanently undeletable. Guideline 5.1.1(v) requires the opposite, and
+    // refusing buys nothing: there is no object of ours behind that URL to
+    // keep. `DogService.updateDog` filters its deletions the same way.
+    await Promise.all(
+      // Not point-free: `isAllowedImageUrl`'s second parameter is the origin
+      // set, and `filter` would hand it the array index.
+      imageUrls
+        .filter((url) => isAllowedImageUrl(url))
+        .map((url) => deleteImageFromS3(url)),
+    );
 
     await prisma.$transaction(async (tx) => {
       if (dogIds.length > 0) {


### PR DESCRIPTION
The confidence gate Gabriel asked for: one continuous, recorded, DB-proven journey through the entire app on each platform — plus the E2E infrastructure it needed, and one more App-Store-critical bug it found and fixed.

## The grand journey (flows 50 + 27)

One uninterrupted `maestro test` per platform (iOS 10:58, Android 14:21, videos in a PR comment): account A signs up and completes onboarding → works the deck, pass then like → narrows preferences until the deck is empty → logs out → account B signs up FEMALE on the same device → finds A's dog and likes first → **live mutual match** (Match row created on tape, timestamped to the second, exactly one row) → A sends the first message (DB row, not just the optimistic bubble) → B reads and replies → settings through the real bottom-sheet pickers (language pt-BR and back, asserted through the screen's own copy) → **in-app account deletion** (hard delete verified, cold relaunch lands on sign-in proving the Keychain JWT was wiped).

Every segment is proven three ways: the video, timestamped API logs, and a 2-second DB poll (`db-changes.tsv`) that turns "the match happened live at 00:07:08" into a statement rather than a hope. Push delivery is proven to the server's notification path (sentinel flips for the right recipient on the right event, twice); real APNs/FCM can't be reached from a simulator and is stated as such.

## The bug it caught: accounts could become undeletable

`UserService.deleteAccount` fanned `deleteImageFromS3` over every photo; one photo on a retired storage origin rejected the whole `Promise.all`, the delete transaction never ran, and every retry failed identically — an App Store Guideline 5.1.1(v) violation for any affected user. Same defect class as the edit-profile 400 (#149's API fix): the test suite's mock accepted exactly the input the real function rejects. Fixed with a failing-first test (`6a6984b`).

## Also in here

- Unistyles-aware jest rendering (primitives no longer crash under jest; typed stub; `__DEV__` defined) — 4 commits of test-infra the journey needed.
- Regression gate at the tip: flows 01/07/22 + 30–42, **32/32 across both platforms**, each pass meaning flow AND DB post-check.
- A guard test for the CI lane structure.

## Not in this PR (token scope)

The two CI workflow commits (regression guards in the iOS extended suite; journey + regression on a real backend in CI) touch `.github/workflows/`, which the local token can't push (`workflow` scope missing). They're ready on the local `test/grand-journey` branch — `gh auth refresh -s workflow` on jarvis and they follow as their own PR.

## Known issue found, tracked separately

Selecting a theme in the Preferences sheet deep into a session crashes natively in unistyles' shadow-tree commit (opening the sheet is fine; the system-appearance theme path is crash-free per the #148 evidence). Root-cause agent is on it; will arrive as its own PR.
