### PR TITLE
fix(mobile): native crash selecting a theme — unistyles use-after-free in shadow-tree commit

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -23,6 +23,47 @@ release that depends on brace-expansion 5.
 
 # react-native-unistyles Patch (3.3.0)
 
+Two unrelated things, one file because pnpm patches a package, not a defect.
+
+## 1. A shadow-tree commit that frees nodes React already destroyed
+
+Selecting a theme deep into a session aborted the process:
+
+    EXC_CRASH (SIGABRT)
+    ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+    std::unique_ptr<folly::dynamic>::operator=
+    margelo::nitro::unistyles::shadow::ShadowTreeManager::updateShadowTree
+    HybridStyleSheet::applyDependencyChanges
+    HybridStyleSheet::onPlatformDependenciesChange
+
+`ShadowTrafficController` keys its pending updates on raw
+`const ShadowNodeFamily*`, and `updateShadowTree` writes through every one of
+them — `const_cast`, then assign `nativeProps_DEPRECATED`, which frees whatever
+`unique_ptr` it finds at that address. Two things let a key outlive its family:
+
+* Nothing drains the map. `getUpdates()` handed out a reference and only
+  `restore()` empties it — and `restore()` has no callers anywhere in the
+  package. A family that received one update stayed a key for the rest of the
+  process, and every later commit walked it again.
+* Not every unmount reaches `unlink`. `ShadowRegistry.remove` routes a node
+  unmounting inside a suspended boundary to `suspend` instead, and this app
+  puts every screen under a `Suspense` (`NetworkBoundary`, `useSuspenseQuery`).
+  A subtree deleted while its boundary was showing a fallback never reported
+  its death at all.
+
+So the map accumulates addresses of families Fabric has freed, and the first
+theme change after enough of them writes through one. A short session has too
+few; the crash needs a long one, which is why it only ever showed up in the
+grand journey.
+
+The patch drains the map on commit, skips families the registry no longer
+tracks or has parked in suspension, and drops a suspended family's pending
+update at the moment it suspends. It is upstream PR #1191, which fixes issue
+[#1179](https://github.com/jpudysz/react-native-unistyles/issues/1179) and is
+closed unmerged for want of a reproduction. Drop it when a release carries it.
+
+## 2. A transform-origin parser that only exists on react-native's main
+
 `cxx/converters/TransformOriginConverter.cpp` calls
 `facebook::react::parseUnprocessedTransformOriginString`, which exists only on
 react-native's `main` branch. No published release declares it, including the

--- a/patches/react-native-unistyles@3.3.0.patch
+++ b/patches/react-native-unistyles@3.3.0.patch
@@ -33,3 +33,120 @@ index 27437fbd2d92bbe26acfc1151bd44573cad4006c..46fb94ba8875ee83fa11a809a2d9697e
  
  namespace margelo::nitro::unistyles::converters {
  
+diff --git a/cxx/core/UnistylesRegistry.cpp b/cxx/core/UnistylesRegistry.cpp
+index 7960fd72c580a526ed52cba3d1fc7505cb45c7e0..ef83f71f1b7271d716d45705dd57423cf93b7121 100644
+--- a/cxx/core/UnistylesRegistry.cpp
++++ b/cxx/core/UnistylesRegistry.cpp
+@@ -122,6 +122,10 @@ void core::UnistylesRegistry::suspendShadowNode(const ShadowNodeFamily* shadowNo
+     this->trafficController.withLock([this, shadowNodeFamily](){
+         if (this->_shadowRegistry.contains(shadowNodeFamily)) {
+             this->_suspendedFamilies.insert(shadowNodeFamily);
++            // A pending update must not survive the suspension. Suspension is
++            // where a family stops being reachable by `unlink`, so anything
++            // still queued for it is the last thing that will ever name it.
++            this->trafficController.removeShadowNode(shadowNodeFamily);
+         }
+     });
+ }
+@@ -130,6 +134,10 @@ bool core::UnistylesRegistry::isSuspended(const ShadowNodeFamily* family) const
+     return _suspendedFamilies.count(family) > 0;
+ }
+ 
++bool core::UnistylesRegistry::isActiveUnistylesFamily(const ShadowNodeFamily* family) const noexcept {
++    return _shadowRegistry.count(family) > 0 && _suspendedFamilies.count(family) == 0;
++}
++
+ std::shared_ptr<core::StyleSheet> core::UnistylesRegistry::addStyleSheet(jsi::Runtime& rt, core::StyleSheetType type, jsi::Object&& rawValue) {
+     int tag = _nextStyleSheetTag.fetch_add(1);
+ 
+@@ -145,6 +153,14 @@ core::DependencyMap core::UnistylesRegistry::buildDependencyMap(std::vector<Unis
+     std::unordered_set<UnistyleDependency> uniqueDependencies(deps.begin(), deps.end());
+ 
+     for (const auto& [family, unistyles] : this->_shadowRegistry) {
++        // Suspended families keep their registry entry so a re-link can reuse
++        // it, but they must not be queued for a commit: the tree they belong to
++        // may already be gone. Without this the filter in ShadowTreeManager
++        // would drop them one by one on every dependency change, forever.
++        if (this->_suspendedFamilies.count(family) > 0) {
++            continue;
++        }
++
+         bool hasAnyOfDependencies = false;
+ 
+         // Check if any dependency matches
+diff --git a/cxx/core/UnistylesRegistry.h b/cxx/core/UnistylesRegistry.h
+index f501232918f26154836965dc3130dd6c119e3365..509aa8bad94de455afac6856dc3b0e504188a6a9 100644
+--- a/cxx/core/UnistylesRegistry.h
++++ b/cxx/core/UnistylesRegistry.h
+@@ -44,6 +44,9 @@ struct UnistylesRegistry: public StyleSheetRegistry {
+     void unlinkShadowNodeWithUnistyles(const ShadowNodeFamily*);
+     void suspendShadowNode(const ShadowNodeFamily*);
+     bool isSuspended(const ShadowNodeFamily*) const noexcept;
++    // Linked, and not parked in suspension. Read it under the traffic
++    // controller's lock — link/unlink/suspend all mutate what it reads.
++    bool isActiveUnistylesFamily(const ShadowNodeFamily*) const noexcept;
+     std::shared_ptr<core::StyleSheet> addStyleSheet(jsi::Runtime& rt, core::StyleSheetType type, jsi::Object&& rawValue);
+     DependencyMap buildDependencyMap(std::vector<UnistyleDependency>& deps);
+     void shadowLeafUpdateFromUnistyle(jsi::Runtime& rt, Unistyle::Shared unistyle, jsi::Value& maybePressableId);
+diff --git a/cxx/shadowTree/ShadowTrafficController.h b/cxx/shadowTree/ShadowTrafficController.h
+index aafbecedd3a209c25dcb6055acad19bf377cb2f3..95c43d82586105eadaf9d60a3e084efad7d15560 100644
+--- a/cxx/shadowTree/ShadowTrafficController.h
++++ b/cxx/shadowTree/ShadowTrafficController.h
+@@ -20,9 +20,21 @@ struct ShadowTrafficController {
+         this->_canCommit = true;
+     }
+ 
+-    inline shadow::ShadowLeafUpdates& getUpdates() {
++    // Drains the pending updates instead of lending them out.
++    //
++    // `getUpdates()` returned a reference and nothing ever cleared
++    // `_unistylesUpdates` — `restore()` is the only thing that empties it and
++    // it has no callers anywhere in this package. So every family that ever
++    // received an update stayed a key in this map for the lifetime of the
++    // process, and every later commit walked it again. An update is for one
++    // commit; hand it over and forget it.
++    inline shadow::ShadowLeafUpdates takeUpdates() {
+         // call it only within withLock!
+-        return _unistylesUpdates;
++        auto updates = std::move(_unistylesUpdates);
++
++        _unistylesUpdates = {};
++
++        return updates;
+     }
+ 
+     inline void setUpdates(shadow::ShadowLeafUpdates& newUpdates) {
+diff --git a/cxx/shadowTree/ShadowTreeManager.cpp b/cxx/shadowTree/ShadowTreeManager.cpp
+index 01026dc5751b00473ae878804cdae1b283fdbc57..02addd76c18f69dedaa21ec34067d4534afa9a58 100644
+--- a/cxx/shadowTree/ShadowTreeManager.cpp
++++ b/cxx/shadowTree/ShadowTreeManager.cpp
+@@ -10,7 +10,28 @@ void shadow::ShadowTreeManager::updateShadowTree(jsi::Runtime& rt) {
+     auto& registry = core::UnistylesRegistry::get();
+ 
+     registry.trafficController.withLock([&](){
+-        auto updates = registry.trafficController.getUpdates();
++        auto updates = registry.trafficController.takeUpdates();
++
++        if (updates.empty()) {
++            return;
++        }
++
++        // Every branch below writes through `family` — `const_cast` to a
++        // `ShadowNodeFamily*` and assign its `nativeProps_DEPRECATED`, which
++        // frees whatever `unique_ptr` it finds there. The map keys are raw
++        // pointers, and a family that unmounted while its Suspense boundary
++        // was showing a fallback never reaches `unlink`: `ShadowRegistry.remove`
++        // routes it to `suspend` instead, so its key outlives the family
++        // Fabric has already destroyed. Writing through it frees a pointer read
++        // out of freed memory — SIGABRT, "pointer being freed was not
++        // allocated". Commit only for families this registry still tracks.
++        for (auto it = updates.begin(); it != updates.end();) {
++            if (!registry.isActiveUnistylesFamily(it->first)) {
++                it = updates.erase(it);
++            } else {
++                ++it;
++            }
++        }
+ 
+         if (updates.empty()) {
+             return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ patchedDependencies:
   minimatch@3.1.5: 476a0494e59e628ca5f44098245651424dd99db4757bc172a9e7bf6c4fe9daf1
   minimatch@9.0.9: 291dd2efac7e5cd6b31364c2548f9e97e74ae39487476509acbf3218cea1b813
   react-native-draggable-grid@2.2.1: b76c67d70eda667cbfa38d0a069bf76d77375bb01a3b87e60be4ff809a0877a2
-  react-native-unistyles@3.3.0: 97f911ceeb8b068619a8e50c12e193b52f9519b50ae93d9c4008093797620d8f
+  react-native-unistyles@3.3.0: cab49f4b32b6fef06b845fbc74a08cbac6a4d1f5e908a1f9ff0c97b8844f1f6a
   redux-saga@1.3.0: 8c7f7d64fa347d148c073162a8afd0e421c019bb94193fd3f29bccc3024e9a66
 
 importers:
@@ -325,7 +325,7 @@ importers:
         version: 1.5.0(react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native-community/cli@13.6.9(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native-community/cli@13.6.9(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
       react-native-unistyles:
         specifier: 3.3.0
-        version: 3.3.0(patch_hash=97f911ceeb8b068619a8e50c12e193b52f9519b50ae93d9c4008093797620d8f)(4d8a77ece7936d7e16be8a103421d3d4)
+        version: 3.3.0(patch_hash=cab49f4b32b6fef06b845fbc74a08cbac6a4d1f5e908a1f9ff0c97b8844f1f6a)(4d8a77ece7936d7e16be8a103421d3d4)
       react-native-web:
         specifier: ~0.21.2
         version: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -15145,7 +15145,7 @@ snapshots:
       react-native: 0.83.6(@babel/core@7.29.7(supports-color@8.1.1))(@react-native-community/cli@13.6.9(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.17)(react@19.2.0)(supports-color@8.1.1)
       warn-once: 0.1.1
 
-  react-native-unistyles@3.3.0(patch_hash=97f911ceeb8b068619a8e50c12e193b52f9519b50ae93d9c4008093797620d8f)(4d8a77ece7936d7e16be8a103421d3d4):
+  react-native-unistyles@3.3.0(patch_hash=cab49f4b32b6fef06b845fbc74a08cbac6a4d1f5e908a1f9ff0c97b8844f1f6a)(4d8a77ece7936d7e16be8a103421d3d4):
     dependencies:
       '@babel/types': 7.29.0
       '@react-native/normalize-colors': 0.83.6


### PR DESCRIPTION
## The crash

Selecting a theme in the Preferences bottom sheet — deep into a session — aborted the app natively:

```
EXC_CRASH (SIGABRT) — Abort trap: 6
thread com.facebook.react.runtime.JavaScript
  ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
  margelo::nitro::unistyles::shadow::ShadowTreeManager::updateShadowTree
  HybridStyleSheet::applyDependencyChanges
  HybridStyleSheet::onPlatformDependenciesChange
```

Captured on a Release build (iPhone 17 Pro Max, iOS 26.5). It fires on the *Automatic* branch — the path that goes through `UnistylesRuntime.setTheme` alone, entering via `onPlatformDependenciesChange`.

## Root cause (measured, not inferred)

unistyles' `ShadowTrafficController` keys pending updates on **raw `ShadowNodeFamily*`** and `updateShadowTree` writes through every one (`const_cast` + assign to `nativeProps_DEPRECATED`, freeing whatever `unique_ptr` sits at that address). Two defects let a key outlive its family:

1. **Nothing drains the map.** `getUpdates()` returns a reference; the only method that empties it (`restore()`) has zero callers in the package. An update queued once is re-walked by every later commit for the life of the process.
2. **Unmounts inside a suspended boundary never `unlink`.** `ShadowRegistry.remove` routes them to `suspend` — and this app puts every screen under `Suspense` (`NetworkBoundary` + `useSuspenseQuery`). Those families stay registered forever, and `buildDependencyMap` doesn't skip them.

A temporary counter in `buildDependencyMap` showed, per theme commit during a journey: `registry=180 suspended=4 skipped=4 queued=100` — 2–4 registered-but-dead families being written through per commit. Upstream: jpudysz/react-native-unistyles#1179 and #1217 (both open; npm `latest` is still 3.3.0).

## The fix

Extends `patches/react-native-unistyles@3.3.0.patch` (basis: upstream PR #1191, closed unmerged for want of a repro — we now have one). Four changes, each pinned to a frame of the stack:

- `takeUpdates()` drains the pending map on commit
- `updateShadowTree` skips families the registry no longer tracks before touching `nativeProps_DEPRECATED`
- `suspendShadowNode` drops a family's pending update as it suspends
- `buildDependencyMap` skips suspended families

**No UX tradeoff** — no deferral, no dismiss delay; the theme applies on the same commit it always did.

## Verification

The bug is a latent use-after-free, so `MallocScribble` + `MallocPreScribble` were used to make it deterministic. Controlled A/B, same tree, same flow, one variable:

| build | journeys | theme selections each | crashes |
|---|---|---|---|
| unpatched | 3 | 18 | **1** |
| patched | 4 | 18 | **0** |

On this branch's own Release builds: iOS deep session (12 laps of every tab, chat, dog profile) + 10 selections alternating Dark/Light — green, and each selection asserts the Profile row's own copy so the test fails if the theme doesn't actually land. Android same shape — green. Appearance path re-verified via theme-flip: four clean luma steps matching the reference run. Regression flows 30/34/37/40 pass on both platforms. `oxlint` (direct), `pnpm typecheck`, `oxfmt --check` clean.

## Follow-up

Once `test/grand-journey` (#154) lands its `accessible={false}` fix making the picker rows reachable on iOS, journey segment 10 becomes the standing regression guard for this crash.
