### PR TITLE
feat(mobile): add bidirectional dog profile hero transition

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -56,7 +56,21 @@ const AppLayout = () => {
           animation: "default",
         }}
       />
-      <Stack.Screen name="profile/[id]" />
+      <Stack.Screen
+        name="profile/[id]"
+        options={({ route }) => ({
+          // The photo overlay drives the forward transition from Swipe/Chat.
+          // Running the stack fade at the same time doubles up the whole
+          // screen behind it. The same route-level opt-out lets the shared
+          // elements reverse cleanly on Back without a competing stack
+          // animation.
+          animation:
+            (route.params as { heroTransition?: string } | undefined)
+              ?.heroTransition === "1"
+              ? "none"
+              : "fade",
+        })}
+      />
       <Stack.Screen
         name="preferences"
         options={{

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-native-unistyles";
 import { Provider } from "react-redux";
 
+import { HeroTransitionOverlay } from "@/components/HeroTransition";
 import { NetworkBoundary } from "@/components/NetworkBoundary";
 import { storedThemePromise, ThemeProvider } from "@/contexts/theme-provider";
 import { TRPCProvider } from "@/contexts/trpc-provider";
@@ -119,6 +120,8 @@ const App = () => {
             </Provider>
             <MagicModalPortal />
           </NetworkBoundary>
+          {/* Above the navigator so shared profile elements paint over both screens. */}
+          <HeroTransitionOverlay />
         </>
       </ThemeProvider>
     </TRPCProvider>

--- a/apps/mobile/src/components/HeroTransition/index.tsx
+++ b/apps/mobile/src/components/HeroTransition/index.tsx
@@ -29,9 +29,9 @@ import {
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 
-// Short enough to preserve the direct-manipulation feel while giving the
-// photo and shared controls time to read as one continuous object.
-const MORPH_DURATION = 320;
+// Emil bar: UI motion stays under 300ms. 280ms is the ceiling that still
+// reads as one continuous object instead of feeling clipped.
+const MORPH_DURATION = 280;
 
 const frameStyle = (frame: HeroFrame) => ({
   x: frame.x,
@@ -91,6 +91,15 @@ export const HeroTransitionOverlay = () => {
   }, [heroId, from, actionFrom]);
 
   // Morph to the destination frame once it's measured, then clear.
+  //
+  // width/height/borderRadius are genuine layout props, not transform/opacity
+  // -- normally a GPU-only violation. This is the one case that justifies it:
+  // the card photo and profile photo have different aspect ratios and corner
+  // radii, so a true shared-element morph has to interpolate size, not just
+  // position. Every value below animates via withTiming from whatever the
+  // shared value currently holds (never a fresh mount value), so a new hero
+  // starting mid-flight (see the snap effect above, which cancels these same
+  // animations) always retargets from the current frame instead of jumping.
   useEffect(() => {
     if (!from || !to || !sharedElementsReady) return;
     const t = frameStyle(to);

--- a/apps/mobile/src/components/HeroTransition/index.tsx
+++ b/apps/mobile/src/components/HeroTransition/index.tsx
@@ -1,0 +1,211 @@
+import type { HeroFrame } from "./store";
+
+import { useEffect } from "react";
+import { View } from "react-native";
+
+import Animated, {
+  cancelAnimation,
+  runOnJS,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { StyleSheet } from "react-native-unistyles";
+
+import { Image } from "@/components/image";
+import Distance from "@/components/MainCard/components/Distance";
+import Pagination from "@/components/MainCard/components/Pagination";
+import { styles as mainCardStyles } from "@/components/MainCard/styles";
+import { MatchActionBar } from "@/components/MatchActionBar";
+
+import {
+  abandonHero,
+  areHeroSharedElementsReady,
+  endHero,
+  markHeroOverlayReady,
+  useHeroState,
+} from "./store";
+
+const AnimatedImage = Animated.createAnimatedComponent(Image);
+
+// Short enough to preserve the direct-manipulation feel while giving the
+// photo and shared controls time to read as one continuous object.
+const MORPH_DURATION = 320;
+
+const frameStyle = (frame: HeroFrame) => ({
+  x: frame.x,
+  y: frame.y,
+  width: frame.width,
+  height: frame.height,
+  borderRadius: frame.borderRadius,
+});
+
+const noop = () => {};
+
+/**
+ * Renders the flying photo during a manual hero transition. Mounted once, high
+ * in the tree (above the navigator), so it stays visible while the source and
+ * destination routes swap underneath it. Does nothing until a hero is
+ * active. See {@link file://./store.ts} for the why.
+ */
+export const HeroTransitionOverlay = () => {
+  const hero = useHeroState();
+  const reduceMotion = useReducedMotion();
+
+  const x = useSharedValue(0);
+  const y = useSharedValue(0);
+  const width = useSharedValue(0);
+  const height = useSharedValue(0);
+  const borderRadius = useSharedValue(0);
+  const actionX = useSharedValue(0);
+  const actionY = useSharedValue(0);
+  const actionWidth = useSharedValue(0);
+  const actionHeight = useSharedValue(0);
+
+  const { from, to, id: heroId, actionFrom, actionTo } = hero;
+  const sharedElementsReady = areHeroSharedElementsReady(hero);
+
+  // Snap to the source frame the instant a hero starts.
+  useEffect(() => {
+    if (!from) return;
+    cancelAnimation(x);
+    cancelAnimation(y);
+    cancelAnimation(width);
+    cancelAnimation(height);
+    cancelAnimation(borderRadius);
+    const f = frameStyle(from);
+    x.value = f.x;
+    y.value = f.y;
+    width.value = f.width;
+    height.value = f.height;
+    borderRadius.value = f.borderRadius ?? 0;
+    if (actionFrom) {
+      actionX.value = actionFrom.x;
+      actionY.value = actionFrom.y;
+      actionWidth.value = actionFrom.width;
+      actionHeight.value = actionFrom.height;
+    }
+    // Only re-run when a brand new hero begins.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heroId, from, actionFrom]);
+
+  // Morph to the destination frame once it's measured, then clear.
+  useEffect(() => {
+    if (!from || !to || !sharedElementsReady) return;
+    const t = frameStyle(to);
+    // Reduced motion still needs the same handoff sequencing (route removal
+    // waits on the withTiming callback below) -- a duration of 0 keeps that
+    // sequencing intact while skipping the perceived motion.
+    const config = { duration: reduceMotion ? 0 : MORPH_DURATION };
+    x.value = withTiming(t.x, config);
+    y.value = withTiming(t.y, config);
+    width.value = withTiming(t.width, config);
+    borderRadius.value = withTiming(t.borderRadius ?? 0, config);
+    if (actionFrom && actionTo) {
+      actionX.value = withTiming(actionTo.x, config);
+      actionY.value = withTiming(actionTo.y, config);
+      actionWidth.value = withTiming(actionTo.width, config);
+      actionHeight.value = withTiming(actionTo.height, config);
+    }
+    height.value = withTiming(t.height, config, (finished) => {
+      "worklet";
+      if (finished) {
+        runOnJS(endHero)();
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [heroId, to, actionFrom, actionTo, sharedElementsReady, reduceMotion]);
+
+  // Safety net: if the destination never reports a frame (e.g. profile failed
+  // to mount), don't leave a frozen photo on screen forever.
+  useEffect(() => {
+    if (!heroId || !from || sharedElementsReady) return;
+    const timeout = setTimeout(() => abandonHero(heroId), 700);
+    return () => clearTimeout(timeout);
+  }, [heroId, from, sharedElementsReady]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: x.value }, { translateY: y.value }],
+    width: width.value,
+    height: height.value,
+    borderRadius: borderRadius.value,
+  }));
+  const actionStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: actionX.value }, { translateY: actionY.value }],
+    width: actionWidth.value,
+    height: actionHeight.value,
+  }));
+
+  if (!heroId || !from || !hero.source?.uri) return null;
+
+  return (
+    <View pointerEvents="none" style={styles.overlay}>
+      <AnimatedImage
+        source={{
+          uri: hero.source.uri,
+          blurhash: hero.source.blurhash ?? undefined,
+        }}
+        contentFit="cover"
+        // The real photos underneath stay visible until the overlay has
+        // painted (see store.ts), otherwise the card blanks for the frames
+        // the image spends decoding. A transparent background keeps this
+        // view invisible during that same gap instead of it (and Android in
+        // particular) defaulting to an opaque white paint over them.
+        onDisplay={markHeroOverlayReady}
+        style={[styles.image, animatedStyle]}
+      />
+      {hero.chrome ? (
+        <Animated.View style={[styles.chrome, animatedStyle]}>
+          <View style={mainCardStyles.upperPart}>
+            <Distance dog={hero.chrome.dog} />
+            <Pagination
+              pages={hero.chrome.pages}
+              currentPage={hero.chrome.currentPage}
+            />
+          </View>
+        </Animated.View>
+      ) : null}
+      {hero.chrome && actionFrom && actionTo ? (
+        <Animated.View style={[styles.actionBar, actionStyle]}>
+          <MatchActionBar
+            visualOnly
+            onNope={noop}
+            onMaybe={noop}
+            onYep={noop}
+          />
+        </Animated.View>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create((theme) => ({
+  overlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  image: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    backgroundColor: theme.colors.transparent,
+  },
+  chrome: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    overflow: "hidden",
+    paddingTop: 24,
+    backgroundColor: theme.colors.transparent,
+  },
+  actionBar: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    backgroundColor: theme.colors.transparent,
+  },
+}));

--- a/apps/mobile/src/components/HeroTransition/store.ts
+++ b/apps/mobile/src/components/HeroTransition/store.ts
@@ -1,0 +1,349 @@
+import type { SwipeDog } from "@/store/reducers/dogs/swipe";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * Manual shared-element ("hero") transition for the swipe-card -> DogProfile
+ * photo morph.
+ *
+ * Why not Reanimated's `sharedTransitionTag`? Reanimated 4's shared-element
+ * transitions are driven entirely by react-native-screens' native
+ * `onTransitionProgress` event, which is only emitted when screens render
+ * through `ReanimatedScreenProvider`. expo-router never wraps its navigator in
+ * that provider, so the event never reaches Reanimated and the tag does
+ * nothing (you just get the plain stack "fade"). Rather than fork the
+ * router's screen tree, we drive the morph ourselves: measure the card photo
+ * on tap, measure the profile photo when it mounts, and animate an overlay
+ * image between the two frames while navigation swaps the routes underneath.
+ *
+ * This is a tiny external store (no Redux/context needed) so both ends can
+ * publish frames imperatively without re-rendering the whole tree.
+ */
+
+export type HeroFrame = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  borderRadius?: number;
+};
+
+export type HeroSource = {
+  uri?: string;
+  blurhash?: string | null;
+};
+
+export type HeroChrome = {
+  dog: SwipeDog;
+  pages: number;
+  currentPage: number;
+};
+
+export type HeroRole = "source" | "destination";
+
+export type HeroState = {
+  /** dog id the transition belongs to; ties source and destination together. */
+  id: string | null;
+  source: HeroSource | null;
+  /** Card chrome that is genuinely shared by both ends of the transition. */
+  chrome: HeroChrome | null;
+  phase: "forward" | "reverse" | null;
+  /** measured swipe-card photo frame (start of the forward morph). */
+  from: HeroFrame | null;
+  /** measured DogProfile photo frame (end of the forward morph), set once it mounts. */
+  to: HeroFrame | null;
+  actionFrom: HeroFrame | null;
+  actionTo: HeroFrame | null;
+  /**
+   * True once the flying overlay image has actually painted (expo-image
+   * `onDisplay`). Gates when the "from" side of the morph is allowed to hide
+   * its real elements -- hiding them on `startHero` left a blank flash while
+   * the overlay image decoded. The "to" side has no such flash risk (the
+   * overlay's blurhash placeholder already covers it) and hides immediately;
+   * see `useHeroVisibility`.
+   */
+  overlayReady: boolean;
+  /** bumped every mutation so subscribers re-read. */
+  version: number;
+};
+
+const initialState: HeroState = {
+  id: null,
+  source: null,
+  chrome: null,
+  phase: null,
+  from: null,
+  to: null,
+  actionFrom: null,
+  actionTo: null,
+  overlayReady: false,
+  version: 0,
+};
+
+let state: HeroState = initialState;
+let settledHero: HeroState | null = null;
+let reverseCompletions: (() => void)[] = [];
+let reverseHandoffPending = false;
+const sourceActionFrames = new Map<string, HeroFrame>();
+
+const listeners = new Set<() => void>();
+
+const emit = () => {
+  for (const listener of listeners) listener();
+};
+
+const setState = (next: Partial<HeroState>) => {
+  state = { ...state, ...next, version: state.version + 1 };
+  emit();
+};
+
+/**
+ * Begin a hero transition. Called from the swipe card or chat header the
+ * moment the user taps to open a profile, with the tapped photo's measured
+ * frame and source. The destination frame arrives later via
+ * {@link setHeroTarget}.
+ */
+export const startHero = (args: {
+  id: string;
+  source: HeroSource;
+  from: HeroFrame;
+  chrome?: HeroChrome;
+}) => {
+  // A new navigation attempt supersedes every previously completed hero,
+  // including one for the same dog. Until this forward transition itself
+  // lands, there must be nothing reversible: an immediate Back or a timeout
+  // cannot resurrect geometry from an older Swipe/Profile visit.
+  settledHero = null;
+  setState({
+    id: args.id,
+    source: args.source,
+    chrome: args.chrome ?? null,
+    phase: "forward",
+    from: args.from,
+    to: null,
+    // Only Swipe heroes carry card chrome/action controls. A Chat avatar can
+    // share a dog id with an earlier Swipe card, but must never inherit that
+    // process-lifetime action frame and wait for a target it does not render.
+    actionFrom: args.chrome ? (sourceActionFrames.get(args.id) ?? null) : null,
+    actionTo: null,
+    overlayReady: false,
+  });
+};
+
+const MEASURE_WATCHDOG_MS = 250;
+
+/**
+ * Navigation must not depend indefinitely on a native measurement callback:
+ * refs can be null during teardown and native callbacks are not guaranteed to
+ * arrive. The returned function wins exactly once; a valid measurement can
+ * prepare a hero before navigating, otherwise the watchdog takes the normal
+ * non-hero route.
+ */
+export const createHeroNavigationWatchdog = (
+  navigate: (heroTransition?: string) => void,
+): ((prepareHero?: () => void) => void) => {
+  let completed = false;
+
+  const complete = (prepareHero?: () => void) => {
+    if (completed) return;
+    completed = true;
+    clearTimeout(timer);
+    prepareHero?.();
+    navigate(prepareHero ? "1" : undefined);
+  };
+
+  const timer = setTimeout(complete, MEASURE_WATCHDOG_MS);
+  return complete;
+};
+
+/** Called by the overlay image's `onDisplay` -- it has pixels on screen. */
+export const markHeroOverlayReady = () => {
+  if (state.id === null || state.overlayReady) return;
+  setState({ overlayReady: true });
+};
+
+/**
+ * Provide the destination frame (the DogProfile photo, once measured).
+ * Ignored if it doesn't match the in-flight hero's dog id, so a stale mount
+ * can't hijack the animation.
+ */
+export const setHeroTarget = (args: { id: string; to: HeroFrame }) => {
+  if (state.id !== args.id || state.phase !== "forward") return;
+  setState({ to: args.to });
+};
+
+export const registerHeroActionFrame = (args: {
+  id: string;
+  role: HeroRole;
+  frame: HeroFrame;
+}) => {
+  if (args.role === "source") {
+    sourceActionFrames.set(args.id, args.frame);
+    if (state.id === args.id && state.phase === "forward" && state.chrome) {
+      setState({ actionFrom: args.frame });
+    }
+    return;
+  }
+
+  if (state.id === args.id && state.phase === "forward" && state.chrome) {
+    setState({ actionTo: args.frame });
+  }
+  if (settledHero?.id === args.id && settledHero.chrome) {
+    settledHero = { ...settledHero, actionTo: args.frame };
+  }
+};
+
+export const unregisterHeroSourceActionFrame = (id: string) => {
+  sourceActionFrames.delete(id);
+};
+
+/** Shared-element readiness is deliberately photo-only outside Swipe. */
+export const areHeroSharedElementsReady = (hero: HeroState): boolean =>
+  Boolean(hero.to) &&
+  (!hero.chrome || !hero.actionFrom || Boolean(hero.actionTo));
+
+/**
+ * Generation token for native measurements whose callbacks may arrive after
+ * React cleanup. Both the queued RAF and the native callback must hold the
+ * currently active token before they can publish geometry.
+ */
+export const createHeroMeasurementLifecycle = () => {
+  let nextGeneration = 0;
+  let activeGeneration: number | null = null;
+
+  return {
+    activate: () => {
+      activeGeneration = ++nextGeneration;
+      return activeGeneration;
+    },
+    invalidate: () => {
+      activeGeneration = null;
+      nextGeneration++;
+    },
+    current: () => activeGeneration,
+    isCurrent: (generation: number) => activeGeneration === generation,
+  };
+};
+
+/** Clear an incomplete forward hero without publishing a reverse snapshot. */
+export const abandonHero = (id: string) => {
+  if (state.id !== id || state.phase !== "forward") return;
+  settledHero = null;
+  state = { ...initialState, version: state.version + 1 };
+  emit();
+};
+
+export const startReverseHero = (
+  id: string,
+  onComplete?: () => void,
+): boolean => {
+  if (state.id === id && state.phase === "reverse") {
+    if (onComplete) reverseCompletions.push(onComplete);
+    return true;
+  }
+
+  // Back can arrive before the forward morph has landed and published its
+  // reversible snapshot. Let navigation pop normally, but remove the
+  // unfinished overlay first so it cannot keep flying over the source screen
+  // or later publish stale geometry for a route that is already gone.
+  if (state.id === id && state.phase === "forward") {
+    abandonHero(id);
+    return false;
+  }
+
+  if (
+    !settledHero ||
+    settledHero.id !== id ||
+    !settledHero.from ||
+    !settledHero.to
+  )
+    return false;
+
+  reverseCompletions = onComplete ? [onComplete] : [];
+  const previous = settledHero;
+  setState({
+    id,
+    source: previous.source,
+    chrome: previous.chrome,
+    phase: "reverse",
+    from: previous.to,
+    to: previous.from,
+    actionFrom: previous.actionTo,
+    actionTo: previous.actionFrom,
+    overlayReady: false,
+  });
+  return true;
+};
+
+/** Clear the hero once the morph finishes (or is abandoned). */
+export const endHero = () => {
+  if (state.id === null) return;
+  const finished = state;
+
+  if (finished.phase === "reverse") {
+    if (reverseHandoffPending) return;
+    reverseHandoffPending = true;
+
+    const completions = reverseCompletions;
+    reverseCompletions = [];
+    for (const completion of completions) completion();
+
+    // The reverse overlay has landed on the source frame, but the held route
+    // removal has not committed visually yet. Keep that landed overlay alive
+    // while navigation exposes the source and its real shared elements mount;
+    // only then hand visibility back. Clearing before dispatch produced one
+    // blank frame followed by a duplicate profile/source frame.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (state.id === finished.id && state.phase === "reverse") {
+          state = { ...initialState, version: state.version + 1 };
+          emit();
+        }
+        reverseHandoffPending = false;
+      });
+    });
+    return;
+  }
+
+  if (finished.phase === "forward" && finished.to) {
+    settledHero = { ...finished, overlayReady: false };
+  }
+  state = { ...initialState, version: state.version + 1 };
+  emit();
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const getSnapshot = () => state;
+
+export const useHeroState = (): HeroState =>
+  useSyncExternalStore(subscribe, getSnapshot);
+
+/**
+ * Whether a real (non-overlay) element for `dogId` playing `role` in the
+ * active hero should hide itself.
+ *
+ * The morph has a "to" side (the side the overlay is flying towards) and a
+ * "from" side. Which physical role -- swipe card vs. profile card -- plays
+ * "to" flips with direction: the profile is "to" going forward, the card is
+ * "to" coming back. The "to" side hides the instant the hero claims it,
+ * because the overlay's blurhash placeholder already covers that spot from
+ * frame one. The "from" side hides only once the overlay has actually
+ * painted (`overlayReady`) -- hiding it earlier leaves a blank gap while the
+ * overlay image decodes.
+ */
+export const useHeroVisibility = (
+  dogId: string | undefined,
+  role: HeroRole,
+): boolean => {
+  const hero = useHeroState();
+  if (!dogId || hero.id !== dogId || !hero.phase) return false;
+
+  const isToRole = (hero.phase === "forward") === (role === "destination");
+  return isToRole || hero.overlayReady;
+};

--- a/apps/mobile/src/components/MainCard/index.tsx
+++ b/apps/mobile/src/components/MainCard/index.tsx
@@ -1,6 +1,6 @@
 import type { SwipeDog } from "@/store/reducers/dogs/swipe";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import * as React from "react";
 import { Pressable, View } from "react-native";
 
@@ -8,18 +8,28 @@ import { useRouter } from "expo-router";
 
 import {
   useAnimatedStyle,
+  useReducedMotion,
   useSharedValue,
   withSequence,
   withSpring,
 } from "react-native-reanimated";
+import { useUnistyles } from "react-native-unistyles";
 
+import {
+  createHeroNavigationWatchdog,
+  setHeroTarget,
+  startHero,
+  useHeroState,
+  useHeroVisibility,
+} from "@/components/HeroTransition/store";
 import { PressableArea } from "@/components/pressable-area";
+import { getTrcpContext } from "@/contexts/trcp-context";
 import { SceneName } from "@/types/scene-name";
 
 import Distance from "./components/Distance";
 import Pagination from "./components/Pagination";
 import PersonalInfo from "./components/PersonalInfo";
-import { Container, Picture, Scrim, styles } from "./styles";
+import { Container, Picture, PhotoAnchor, Scrim, styles } from "./styles";
 
 const springConfig = { mass: 0.2 };
 
@@ -65,18 +75,80 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
   const { images = [] } = dog;
   const [currentImage, setCurrentImage] = useState(startImageIndex);
   const router = useRouter();
+  const { theme } = useUnistyles();
+  const reduceMotion = useReducedMotion();
 
   const nudge = useSharedValue(0);
 
+  // When rendered inside DogProfile (no personal info), this card is the hero
+  // *destination*; on the swipe deck it's the *source*.
+  const isHeroDestination = !shouldShowPersonalInfo;
+  const heroRole = isHeroDestination ? "destination" : "source";
+  const photoAnchorRef = useRef<View>(null);
+  const hero = useHeroState();
+  const hidePhoto = useHeroVisibility(dog.id, heroRole);
+  const hideChrome = hidePhoto && Boolean(hero.chrome);
+
+  const currentPhoto = images[currentImage];
+
   const openUserProfile = () => {
-    router.push({
-      pathname: `${SceneName.Profile}/[id]`,
-      params: {
-        id: dog.id,
-        currentImageIndex: currentImage,
-      },
+    const navigate = (heroTransition?: string) => {
+      router.push({
+        pathname: `${SceneName.Profile}/[id]`,
+        params: {
+          id: dog.id,
+          currentImageIndex: currentImage,
+          heroTransition,
+        },
+      });
+    };
+
+    // Reduced motion skips the manual morph entirely and falls back to the
+    // stack's own (non-hero) screen transition.
+    if (reduceMotion) return navigate();
+
+    // The swipe response already contains the complete DogProfile payload.
+    // Refresh the exact query key at the interaction boundary so an entry
+    // that has aged out of React Query never suspends between the card and
+    // the hero destination.
+    getTrcpContext().dog.get.setData({ id: dog.id }, dog);
+
+    const finishNavigation = createHeroNavigationWatchdog(navigate);
+
+    // Kick off the manual hero morph: freeze the tapped photo into a flying
+    // overlay measured at its on-screen frame, then navigate. The destination
+    // card reports its frame on mount (see onDestinationLayout) and the
+    // overlay animates between the two. See @/components/HeroTransition/store.
+    photoAnchorRef.current?.measureInWindow((x, y, width, height) => {
+      if (width > 0 && height > 0 && currentPhoto?.url) {
+        finishNavigation(() => {
+          startHero({
+            id: dog.id,
+            source: { uri: currentPhoto.url, blurhash: currentPhoto.blurhash },
+            from: { x, y, width, height, borderRadius: theme.radii.lg },
+            chrome: { dog, pages: images.length, currentPage: currentImage },
+          });
+        });
+        return;
+      }
+      finishNavigation();
     });
   };
+
+  const onDestinationLayout = useCallback(() => {
+    if (!isHeroDestination) return;
+    // Defer to the next frame so native layout has settled before we measure.
+    requestAnimationFrame(() => {
+      photoAnchorRef.current?.measureInWindow((x, y, width, height) => {
+        if (width > 0 && height > 0) {
+          setHeroTarget({
+            id: dog.id,
+            to: { x, y, width, height, borderRadius: 0 },
+          });
+        }
+      });
+    });
+  }, [dog.id, isHeroDestination]);
 
   const gotoPreviousImage = () => {
     // If there is only one image, open the user profile for now.
@@ -115,13 +187,22 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
 
   return (
     <Container testID="swipe-card" {...props} style={[props.style, transform]}>
-      <Picture
-        source={{
-          uri: images[currentImage]?.url,
-          blurhash: images[currentImage]?.blurhash ?? undefined,
-        }}
-        key={images[currentImage]?.id}
-      />
+      <PhotoAnchor
+        ref={photoAnchorRef}
+        onLayout={onDestinationLayout}
+        // While the hero overlay covers this element, hide the real photo so
+        // only the overlay copy is visible (no double image). It reappears
+        // once the morph clears (see useHeroVisibility).
+        style={hidePhoto ? styles.hidden : undefined}
+      >
+        <Picture
+          source={{
+            uri: currentPhoto?.url,
+            blurhash: currentPhoto?.blurhash ?? undefined,
+          }}
+          key={currentPhoto?.id}
+        />
+      </PhotoAnchor>
       <Scrim
         style={styles.scrim}
         colors={[
@@ -131,7 +212,7 @@ const VisitingCard: React.FC<VisitingCardProps> = ({
           "rgba(0, 0, 0, 0)",
         ]}
       />
-      <View style={styles.upperPart}>
+      <View style={[styles.upperPart, hideChrome ? styles.hidden : undefined]}>
         <Distance dog={dog} />
         <Pagination pages={images.length} currentPage={currentImage} />
         <View style={styles.carouselContainer}>

--- a/apps/mobile/src/components/MainCard/styles.tsx
+++ b/apps/mobile/src/components/MainCard/styles.tsx
@@ -1,7 +1,10 @@
 import type { LocalImageProps } from "@/components/image";
 import type { AnimatedProps } from "react-native-reanimated";
 
-import type { ViewProps } from "react-native";
+import type { Ref } from "react";
+import type { View, ViewProps } from "react-native";
+
+import { forwardRef } from "react";
 
 import { LinearGradient } from "expo-linear-gradient";
 
@@ -42,6 +45,19 @@ export const Picture = ({ style, ...props }: LocalImageProps) => (
   <ThemedImage {...props} style={[styles.picture, style]} />
 );
 
+/**
+ * Stable (never remounted) wrapper around the photo. `Picture` itself remounts
+ * (via its `key`) whenever the visible photo index changes, so keeping the
+ * measure anchor on this always-mounted outer view gives the manual hero
+ * transition (@/components/HeroTransition) a stable frame to measure.
+ */
+export const PhotoAnchor = forwardRef(
+  ({ style, ...props }: AnimatedProps<ViewProps>, ref: Ref<View>) => (
+    <Animated.View ref={ref} {...props} style={[styles.photoAnchor, style]} />
+  ),
+);
+PhotoAnchor.displayName = "PhotoAnchor";
+
 /** Full-bleed gradient that darkens the top of the card. */
 export const Scrim = withUnistyles(LinearGradient);
 
@@ -56,6 +72,13 @@ export const styles = StyleSheet.create((theme) => ({
     flexShrink: 1,
     flexBasis: 0,
     ...absoluteFill,
+  },
+  photoAnchor: {
+    flex: 1,
+    ...absoluteFill,
+  },
+  hidden: {
+    opacity: 0,
   },
   upperPart: {
     flexGrow: 1,

--- a/apps/mobile/src/components/MatchActionBar/index.tsx
+++ b/apps/mobile/src/components/MatchActionBar/index.tsx
@@ -1,6 +1,18 @@
+import type { HeroRole } from "@/components/HeroTransition/store";
+
+import type { View } from "react-native";
+
+import { useCallback, useEffect, useRef } from "react";
 import * as React from "react";
 
 import Animated, { FadeInDown, ZoomOutDown } from "react-native-reanimated";
+
+import {
+  createHeroMeasurementLifecycle,
+  registerHeroActionFrame,
+  unregisterHeroSourceActionFrame,
+  useHeroVisibility,
+} from "@/components/HeroTransition/store";
 
 import {
   ActionItem,
@@ -15,6 +27,11 @@ type MatchActionBarProps = React.ComponentProps<typeof Container> & {
   onYep: () => void;
   onMaybe: () => void;
   animated?: boolean;
+  /** dog id this bar shares an action-frame with the hero overlay for. */
+  sharedDogId?: string;
+  sharedRole?: HeroRole;
+  /** the overlay's own non-interactive copy, rendered mid-morph. */
+  visualOnly?: boolean;
 };
 
 export const MatchActionBar: React.FC<MatchActionBarProps> = ({
@@ -22,14 +39,82 @@ export const MatchActionBar: React.FC<MatchActionBarProps> = ({
   onYep,
   onMaybe,
   animated,
+  sharedDogId,
+  sharedRole,
+  visualOnly,
   ...props
 }) => {
+  const containerRef = useRef<View>(null);
+  const measurementLifecycle = useRef(createHeroMeasurementLifecycle()).current;
+  const pendingAnimationFrames = useRef(new Set<number>()).current;
+  const hidden = useHeroVisibility(sharedDogId, sharedRole ?? "source");
+
+  const measureSharedFrame = useCallback(() => {
+    if (!sharedDogId || !sharedRole) return;
+    const generation = measurementLifecycle.current();
+    if (generation === null) return;
+
+    const animationFrame = requestAnimationFrame(() => {
+      pendingAnimationFrames.delete(animationFrame);
+      if (!measurementLifecycle.isCurrent(generation)) return;
+
+      containerRef.current?.measureInWindow((x, y, width, height) => {
+        if (!measurementLifecycle.isCurrent(generation)) return;
+        if (width > 0 && height > 0) {
+          registerHeroActionFrame({
+            id: sharedDogId,
+            role: sharedRole,
+            frame: { x, y, width, height },
+          });
+        }
+      });
+    });
+    pendingAnimationFrames.add(animationFrame);
+  }, [measurementLifecycle, pendingAnimationFrames, sharedDogId, sharedRole]);
+
+  useEffect(() => {
+    measurementLifecycle.activate();
+    measureSharedFrame();
+    return () => {
+      // Invalidate first: even a native callback already beyond the RAF
+      // cannot publish after this component/id stops owning the frame.
+      measurementLifecycle.invalidate();
+      for (const animationFrame of pendingAnimationFrames) {
+        cancelAnimationFrame(animationFrame);
+      }
+      pendingAnimationFrames.clear();
+      if (sharedDogId && sharedRole === "source") {
+        unregisterHeroSourceActionFrame(sharedDogId);
+      }
+    };
+  }, [
+    measureSharedFrame,
+    measurementLifecycle,
+    pendingAnimationFrames,
+    sharedDogId,
+    sharedRole,
+  ]);
+
   const dislikeAnimation = animated ? FadeInDown.delay(300) : undefined;
   const maybeAnimation = animated ? FadeInDown.delay(350) : undefined;
   const likeAnimation = animated ? FadeInDown.delay(400) : undefined;
+  // Transition copies are visual-only and excluded from screen readers; the
+  // real controls take over the instant the morph clears.
+  const hiddenFromAccessibility = Boolean(visualOnly || hidden);
 
   return (
-    <Container exiting={ZoomOutDown} {...props}>
+    <Container
+      ref={containerRef}
+      exiting={visualOnly ? undefined : ZoomOutDown}
+      $hidden={!visualOnly && hidden}
+      $inline={visualOnly}
+      {...props}
+      accessibilityElementsHidden={hiddenFromAccessibility}
+      importantForAccessibility={
+        hiddenFromAccessibility ? "no-hide-descendants" : "auto"
+      }
+      onLayout={measureSharedFrame}
+    >
       <Animated.View entering={dislikeAnimation}>
         <ActionItem testID="swipe-dislike" onPress={onNope}>
           <ConfusedEmoji />

--- a/apps/mobile/src/components/MatchActionBar/styles.tsx
+++ b/apps/mobile/src/components/MatchActionBar/styles.tsx
@@ -1,12 +1,16 @@
 import type { LocalImageProps } from "@/components/image";
 import type { AnimatedProps } from "react-native-reanimated";
 
+import type { Ref } from "react";
 import type {
   PressableProps,
   StyleProp,
+  View,
   ViewProps,
   ViewStyle,
 } from "react-native";
+
+import { forwardRef } from "react";
 
 import Color from "color";
 import Animated from "react-native-reanimated";
@@ -41,17 +45,32 @@ const ThemedImage = withUnistyles(Image);
  * The `.attrs` defaults were static objects, so they still beat the caller:
  * they sit after the spread, exactly where `.attrs` used to put them.
  */
-export const Container = ({ style, ...props }: AnimatedProps<ViewProps>) => (
-  <Animated.View
-    {...props}
-    // box-none keeps the bar itself non-blocking so the card below stays
-    // pannable in the gaps, but lifts the bar above the card visually so
-    // each ActionItem reliably wins taps over the card's PersonalInfo
-    // pressable that sits underneath.
-    pointerEvents="box-none"
-    style={[styles.container, style]}
-  />
+type ContainerProps = AnimatedProps<ViewProps> & {
+  /** hides the bar (used while the hero overlay flies its own copy over it). */
+  $hidden?: boolean;
+  /** the hero overlay's own copy: laid out in place rather than pinned to the deck's bottom edge. */
+  $inline?: boolean;
+};
+
+export const Container = forwardRef(
+  ({ style, $hidden, $inline, ...props }: ContainerProps, ref: Ref<View>) => {
+    styles.useVariants({ hidden: Boolean($hidden), inline: Boolean($inline) });
+
+    return (
+      <Animated.View
+        ref={ref}
+        {...props}
+        // box-none keeps the bar itself non-blocking so the card below stays
+        // pannable in the gaps, but lifts the bar above the card visually so
+        // each ActionItem reliably wins taps over the card's PersonalInfo
+        // pressable that sits underneath.
+        pointerEvents={$hidden ? "none" : "box-none"}
+        style={[styles.container, style]}
+      />
+    );
+  },
 );
+Container.displayName = "Container";
 
 /** `Pressable` also accepts a style callback; composing needs a plain style. */
 type ActionItemProps = { style?: StyleProp<ViewStyle> } & Omit<
@@ -107,6 +126,10 @@ const styles = StyleSheet.create((theme) => ({
     paddingLeft: theme.spacing[2],
     zIndex: 10,
     elevation: 10,
+    variants: {
+      hidden: { true: { opacity: 0 } },
+      inline: { true: { position: "relative", bottom: 0 } },
+    },
   },
   actionItem: {
     paddingTop: theme.spacing[2.5],

--- a/apps/mobile/src/views/(tabs)/Swipe/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/index.tsx
@@ -35,6 +35,8 @@ const MatchActionBarWrapper = () => {
 
   return (
     <MatchActionBar
+      sharedDogId={currentCard}
+      sharedRole="source"
       onNope={() => swipeHandlerRef.current?.gotoDirection(Swipe.Dislike)}
       onYep={() => swipeHandlerRef.current?.gotoDirection(Swipe.Like)}
       onMaybe={() => swipeHandlerRef.current?.gotoDirection(Swipe.Maybe)}

--- a/apps/mobile/src/views/Chat/components/Header/index.tsx
+++ b/apps/mobile/src/views/Chat/components/Header/index.tsx
@@ -1,14 +1,21 @@
+import { useRef } from "react";
 import { ActivityIndicator, View } from "react-native";
 
 import { useLocalSearchParams, useRouter } from "expo-router";
 
 import { useTranslation } from "react-i18next";
+import { useReducedMotion } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useUnistyles } from "react-native-unistyles";
 
 import BackArrow from "@/assets/images/BackArrow.svg";
+import {
+  createHeroNavigationWatchdog,
+  startHero,
+} from "@/components/HeroTransition/store";
 import { NetworkBoundary } from "@/components/NetworkBoundary";
 import { Text } from "@/components/text";
+import { getTrcpContext } from "@/contexts/trcp-context";
 import { api } from "@/contexts/trpc-provider";
 import { SceneName } from "@/types/scene-name";
 
@@ -17,43 +24,133 @@ import { styles } from "./styles";
 
 export const HEADER_HEIGHT = 65;
 
-const DogProfileInfo = ({ dogId }: { dogId: string }) => {
+const DogProfileInfo = ({
+  dogId,
+  matchId,
+}: {
+  dogId: string;
+  matchId: string;
+}) => {
   const [dog] = api.dog.get.useSuspenseQuery(
     { id: dogId },
     { refetchOnMount: false },
   );
+  const router = useRouter();
+  const reduceMotion = useReducedMotion();
+  // A plain View anchor, not a ref straight to `S.Picture`: expo-image's ref
+  // doesn't expose `measureInWindow`, but a wrapping host View always does.
+  const pictureAnchorRef = useRef<View>(null);
+
+  const openDogProfile = () => {
+    const navigate = (heroTransition?: string) => {
+      router.push({
+        pathname: `${SceneName.Profile}/[id]`,
+        params: { matchId, id: dogId, heroTransition },
+      });
+    };
+
+    if (reduceMotion) return navigate();
+
+    // Keep the destination's exact query hot even if this already-rendered
+    // header outlives React Query's cache window.
+    getTrcpContext().dog.get.setData({ id: dogId }, dog);
+
+    const finishNavigation = createHeroNavigationWatchdog(navigate);
+
+    if (!pictureAnchorRef.current || !dog.images[0]?.url) {
+      finishNavigation();
+      return;
+    }
+
+    pictureAnchorRef.current.measureInWindow((x, y, width, height) => {
+      if (width <= 0 || height <= 0) {
+        finishNavigation();
+        return;
+      }
+
+      finishNavigation(() => {
+        startHero({
+          id: dogId,
+          source: {
+            uri: dog.images[0]?.url,
+            blurhash: dog.images[0]?.blurhash,
+          },
+          from: {
+            x,
+            y,
+            width,
+            height,
+            borderRadius: Math.min(width, height) / 2,
+          },
+        });
+      });
+    });
+  };
 
   return (
-    <View style={styles.profileInfoContainer}>
-      <S.Picture
-        source={{
-          uri: dog.images[0]?.url,
-          blurhash: dog.images[0]?.blurhash ?? undefined,
-        }}
-        style={styles.picture}
-      />
-      <Text numberOfLines={1} fontWeight="bold">
-        {dog.name}
-      </Text>
-    </View>
+    <S.PressableAreaFlex
+      onPress={openDogProfile}
+      style={styles.pressableAreaFlex}
+    >
+      <View style={styles.profileInfoContainer}>
+        <View ref={pictureAnchorRef}>
+          <S.Picture
+            source={{
+              uri: dog.images[0]?.url,
+              blurhash: dog.images[0]?.blurhash ?? undefined,
+            }}
+            style={styles.picture}
+          />
+        </View>
+        <Text numberOfLines={1} fontWeight="bold">
+          {dog.name}
+        </Text>
+      </View>
+    </S.PressableAreaFlex>
   );
+};
+
+/** No photo to morph yet, so these fall back to a plain (non-hero) navigate. */
+const useNavigateToDogProfile = () => {
+  const router = useRouter();
+  const { dogId, matchId } = useLocalSearchParams();
+
+  return () =>
+    router.push({
+      pathname: `${SceneName.Profile}/[id]`,
+      params: { matchId: matchId ?? "", id: dogId as string },
+    });
 };
 
 const DogProfileError = () => {
   const { t } = useTranslation();
+  const navigateToDogProfile = useNavigateToDogProfile();
+
   return (
-    <View style={styles.profileInfoContainer}>
-      <S.Picture style={styles.picture} />
-      <Text numberOfLines={1}>{t("dogProfile.profileInfoError")}</Text>
-    </View>
+    <S.PressableAreaFlex
+      onPress={navigateToDogProfile}
+      style={styles.pressableAreaFlex}
+    >
+      <View style={styles.profileInfoContainer}>
+        <S.Picture style={styles.picture} />
+        <Text numberOfLines={1}>{t("dogProfile.profileInfoError")}</Text>
+      </View>
+    </S.PressableAreaFlex>
   );
 };
 
 const DogProfileInfoLoading = () => {
+  const navigateToDogProfile = useNavigateToDogProfile();
+
   return (
-    <View style={styles.profileInfoLoadingContainer}>
-      <ActivityIndicator />
-    </View>
+    <S.PressableAreaFlex
+      onPress={navigateToDogProfile}
+      style={styles.pressableAreaFlex}
+    >
+      <View style={styles.profileInfoLoadingContainer}>
+        <ActivityIndicator />
+      </View>
+    </S.PressableAreaFlex>
   );
 };
 
@@ -83,22 +180,15 @@ const Header = () => {
       >
         <BackArrow height={15} width={15} fill={theme.colors.text} />
       </S.BackTouchArea>
-      <S.PressableAreaFlex
-        onPress={() =>
-          router.push({
-            pathname: `${SceneName.Profile}/[id]`,
-            params: { matchId: matchId ?? "", id: dogId as string },
-          })
-        }
-        style={styles.pressableAreaFlex}
+      <NetworkBoundary
+        errorFallback={DogProfileError}
+        suspenseFallback={<DogProfileInfoLoading />}
       >
-        <NetworkBoundary
-          errorFallback={DogProfileError}
-          suspenseFallback={<DogProfileInfoLoading />}
-        >
-          <DogProfileInfo dogId={dogId as string} />
-        </NetworkBoundary>
-      </S.PressableAreaFlex>
+        <DogProfileInfo
+          dogId={dogId as string}
+          matchId={(matchId as string) ?? ""}
+        />
+      </NetworkBoundary>
     </S.Header>
   );
 };

--- a/apps/mobile/src/views/DogProfile/index.tsx
+++ b/apps/mobile/src/views/DogProfile/index.tsx
@@ -1,6 +1,6 @@
 import type { SwipeDog } from "@/store/reducers/dogs/swipe";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as React from "react";
 import {
   ActivityIndicator,
@@ -11,7 +11,12 @@ import {
   ScrollView,
 } from "react-native";
 
-import { router, useLocalSearchParams, useRouter } from "expo-router";
+import {
+  router,
+  useLocalSearchParams,
+  useNavigation,
+  useRouter,
+} from "expo-router";
 import { StatusBar } from "expo-status-bar";
 
 import { Header, HeaderBackButton } from "@react-navigation/elements";
@@ -21,6 +26,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useUnistyles } from "react-native-unistyles";
 import { useDispatch, useSelector } from "react-redux";
 
+import { startReverseHero } from "@/components/HeroTransition/store";
 import MainCard from "@/components/MainCard";
 import { MatchActionBar } from "@/components/MatchActionBar";
 import {
@@ -129,13 +135,20 @@ const useSwipeHandler = (id: string) => {
   const dispatch = useDispatch();
 
   return (swipeType: Swipe) => {
+    const commitSwipe = () => {
+      if (id === currentCardId && swipeHandlerRef.current) {
+        return swipeHandlerRef.current.gotoDirection(swipeType);
+      }
+
+      dispatch(Actions.dogs.swipe.request({ id, swipeType }));
+    };
+
+    // Reverses this dog's hero photo back onto its swipe card first, if one
+    // is in flight to reverse (no-op otherwise -- e.g. reduced motion, or a
+    // profile opened without a hero at all).
+    const reversing = startReverseHero(id, commitSwipe);
     router.back();
-
-    if (id === currentCardId && swipeHandlerRef.current) {
-      return swipeHandlerRef.current.gotoDirection(swipeType);
-    }
-
-    dispatch(Actions.dogs.swipe.request({ id, swipeType }));
+    if (!reversing) commitSwipe();
   };
 };
 
@@ -143,10 +156,12 @@ const DogProfile = () => {
   const {
     id,
     currentImageIndex = 0,
+    heroTransition,
     matchId,
   } = useLocalSearchParams<{
     id: string;
     currentImageIndex?: string;
+    heroTransition?: string;
     matchId?: string;
   }>();
 
@@ -156,6 +171,21 @@ const DogProfile = () => {
   const insets = useSafeAreaInsets();
   const topInset = useCustomTopInset();
   const router = useRouter();
+  const navigation = useNavigation();
+  const completingHeroRemoval = useRef(false);
+
+  useEffect(() => {
+    if (heroTransition !== "1") return;
+    return navigation.addListener("beforeRemove", (event) => {
+      if (completingHeroRemoval.current) return;
+
+      const reversing = startReverseHero(id as string, () => {
+        completingHeroRemoval.current = true;
+        navigation.dispatch(event.data.action);
+      });
+      if (reversing) event.preventDefault();
+    });
+  }, [heroTransition, id, navigation]);
 
   const { theme } = useUnistyles();
 
@@ -316,6 +346,8 @@ const DogProfile = () => {
             ]}
           />
           <MatchActionBar
+            sharedDogId={id as string}
+            sharedRole="destination"
             style={{ bottom: topInset }}
             onNope={() => swipeHandler(Swipe.Dislike)}
             onYep={() => swipeHandler(Swipe.Like)}


### PR DESCRIPTION
## Summary

Opening a dog profile from Swipe or Chat now morphs the tapped photo into the profile instead of a plain screen fade, and Back reverses it back onto the card.

## Details

- Reanimated's shared-element tag never fires here (expo-router doesn't wrap screens in the provider that emits its transition-progress event), so the morph is a manual overlay: measure the source photo on tap, measure the destination on mount, animate a flying copy between the two frames while the real screens swap underneath.
- Fixes the white flash: every overlay layer now pins its background to the theme's transparent token instead of leaving it unset, so there's no stray opaque paint while the image decodes. It only showed in dark mode, which is why it slipped through before.
- Fixes the jump: which side of the morph hides is now asymmetric by role instead of both sides waiting on the same signal. The side the overlay is flying *toward* hides the instant the transition claims it (the overlay's blurhash placeholder already covers that spot), and the side it's flying *from* still waits for the overlay to actually paint before hiding, so neither a blank gap nor the full-size destination snapping into view early sneaks through.
- Chat's dog avatar triggers the same morph, photo-only (no card chrome/action bar, since chat has none to share).
- Falls back to a plain navigate if the source photo never measures, or if Reduce Motion is on.
- A 250ms watchdog covers the case where a native measurement callback just never arrives, so navigation is never blocked on it.

## Testing steps

1. From Swipe, page to a photo that isn't the first one, then tap it to open the profile. The photo should grow smoothly into place with no white flash and no jump.
2. Go back. It should shrink smoothly back onto the card.
3. Switch to dark mode in Preferences and repeat steps 1-2. Same result, no flash.
4. Open a profile from a chat conversation's header. Only the avatar photo should morph, not a full card.
5. Turn on Reduce Motion in the device's accessibility settings, then tap a card. The profile should open instantly with no animated photo.


## Proof

Light, dark, and reduced-motion recordings on the iOS Simulator: https://github.com/GSTJ/pegada/tree/GSTJ/pr-proof-assets/evidence
