### PR TITLE
fix(mobile): apply Automatic theme live without app restart

### DIFF
--- a/apps/mobile/src/contexts/theme-provider.tsx
+++ b/apps/mobile/src/contexts/theme-provider.tsx
@@ -159,7 +159,12 @@ export const ThemeProvider: React.FC<{ children: React.ReactElement }> = ({
   }, [colors, dark]);
 
   const handleActiveThemeChange = (theme: ActiveTheme) => {
-    if (theme) Appearance.setColorScheme(theme as ColorSchemeName);
+    // Picking "Automatic" (theme === null) must release the override, not
+    // just skip setting a new one — Appearance.setColorScheme keeps forcing
+    // whatever was last set until called with null, so useColorScheme() kept
+    // reporting the old forced value and the app only picked up the real
+    // system scheme after a full restart reset the native override.
+    Appearance.setColorScheme(theme as ColorSchemeName);
     persistNativeThemeOverride(theme);
     setActiveTheme(theme);
 


### PR DESCRIPTION
## Summary

Picking "Automatic" in the theme picker didn't actually apply live — the app kept showing whatever theme was last forced (Light/Dark) until a full restart.

## Root cause

`handleActiveThemeChange` in `theme-provider.tsx` only called `Appearance.setColorScheme(theme)` when `theme` was truthy:

```ts
if (theme) Appearance.setColorScheme(theme as ColorSchemeName);
```

Picking "Automatic" sets `theme` to `null`, so this branch never ran. `Appearance.setColorScheme` keeps forcing whatever value was last set until it's explicitly called with `null` to release the override — so `useColorScheme()` kept reporting the stale forced value, and the app only picked up the real system appearance after a full process restart reset the native override (native module state, not app state).

React state (`activeTheme`) was already being updated correctly regardless — the derivation (`requested = activeTheme ?? colorScheme ?? Theme.Default`) and the layout effect that calls `UnistylesRuntime.setTheme()` were never the problem. The override itself just never actually got released.

## Fix

Call `Appearance.setColorScheme(theme)` unconditionally, including with `null`. That releases the override the moment "Automatic" is picked, `useColorScheme()` immediately starts reporting the real system scheme again, and the existing derivation + layout effect apply it in the same render pass — no restart.

## Testing

- `pnpm typecheck`, `oxlint`, `oxfmt` all pass.
- Verified interactively on a simulator: forced the theme to Dark, then picked Automatic while the simulator's system appearance was Light — the app flipped to light immediately, live, in the same session. See proof video below.

Note: I verified this specific fix using a build that also includes PR #156's picker-sheet rewrite, purely because that PR's Picker sheet is what's currently tappable end-to-end on a running build — the old `@gorhom/bottom-sheet` sheet on main clips its last row, so "Automatic" isn't reliably tappable to actually drive this test. The fix itself is a self-contained one-line behavior change in `theme-provider.tsx` and does not depend on #156.

## Proof
Forced Dark, then picked Automatic while the simulator's system appearance is Light — flips instantly, live, no restart:
https://github.com/GSTJ/pr-proof-assets/blob/main/proof/159/01-theme-automatic-live.mp4
