### PR TITLE
fix(mobile): Automatic follows system dark on iOS

### DIFF
--- a/apps/mobile/src/contexts/theme-provider.test.ts
+++ b/apps/mobile/src/contexts/theme-provider.test.ts
@@ -1,0 +1,70 @@
+import type { ActiveTheme } from "./theme-provider";
+
+import { Appearance, Platform, Settings } from "react-native";
+
+import { applyStoredTheme, persistNativeThemeOverride } from "./theme-provider";
+
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  Appearance: { setColorScheme: jest.fn() },
+  Platform: { OS: "ios" },
+  Settings: { set: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("expo-system-ui", () => ({
+  setBackgroundColorAsync: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@react-navigation/native", () => ({
+  DarkTheme: {},
+  DefaultTheme: {},
+  ThemeProvider: ({ children }: { children: unknown }) => children,
+}));
+
+jest.mock<Record<string, unknown>>("react-native-unistyles", () => ({
+  UnistylesRuntime: { setTheme: jest.fn() },
+  useUnistyles: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/storage", () => ({
+  StorageKeys: { Theme: "theme" },
+  Theme: { Dark: "dark", Default: "light", Light: "light" },
+  deleteData: jest.fn(),
+  getData: jest.fn().mockResolvedValue(null),
+  storeData: jest.fn(),
+}));
+
+const appearance = jest.mocked(Appearance);
+const settings = jest.mocked(Settings);
+
+const DARK = "dark" as ActiveTheme;
+const LIGHT = "light" as ActiveTheme;
+
+test("releases a forced scheme and persists follow-system for Automatic", () => {
+  applyStoredTheme(null);
+
+  expect(appearance.setColorScheme).toHaveBeenCalledWith(null);
+  expect(settings.set).toHaveBeenCalledWith({
+    pegadaThemeOverride: "system",
+  });
+});
+
+test("still forces and persists an explicit dark/light choice", () => {
+  applyStoredTheme(DARK);
+
+  expect(appearance.setColorScheme).toHaveBeenCalledWith(DARK);
+  expect(settings.set).toHaveBeenCalledWith({ pegadaThemeOverride: "dark" });
+});
+
+test("skips UserDefaults on Android", () => {
+  settings.set.mockClear();
+  Platform.OS = "android";
+
+  persistNativeThemeOverride(LIGHT);
+
+  expect(settings.set).not.toHaveBeenCalled();
+  Platform.OS = "ios";
+});

--- a/apps/mobile/src/contexts/theme-provider.tsx
+++ b/apps/mobile/src/contexts/theme-provider.tsx
@@ -49,9 +49,19 @@ export const storedThemePromise: Promise<ActiveTheme> = getData(
 // start (see plugins/withInitialThemeOverride.js). Without this the native
 // splash always follows the system appearance, which is what made the boot
 // blink white for users who forced dark mode on a light-mode device.
-const persistNativeThemeOverride = (theme: ActiveTheme) => {
+export const persistNativeThemeOverride = (theme: ActiveTheme) => {
   if (Platform.OS !== "ios") return;
   Settings.set({ pegadaThemeOverride: theme ?? "system" });
+};
+
+// Forces Appearance to match the stored choice, including Automatic
+// (`theme === null`). Appearance.setColorScheme keeps forcing whatever was
+// last set until called with null, so skipping the call for Automatic left a
+// forced light/dark from a previous session stuck — including on the mount
+// path, which used to only call this for a non-null theme.
+export const applyStoredTheme = (theme: ActiveTheme) => {
+  Appearance.setColorScheme(theme as ColorSchemeName);
+  persistNativeThemeOverride(theme);
 };
 
 const ThemeContext = React.createContext<{
@@ -83,15 +93,13 @@ export const ThemeProvider: React.FC<{ children: React.ReactElement }> = ({
 
   // Apply the stored theme on component mount
   useEffect(() => {
-    const applyStoredTheme = async () => {
+    const initTheme = async () => {
       const storedTheme = await storedThemePromise;
-      if (storedTheme)
-        Appearance.setColorScheme(storedTheme as ColorSchemeName);
-      persistNativeThemeOverride(storedTheme);
+      applyStoredTheme(storedTheme);
       setActiveTheme(storedTheme);
     };
 
-    applyStoredTheme().catch(sendError);
+    initTheme().catch(sendError);
   }, []);
 
   // The user's explicit choice wins; the system scheme is only a fallback.
@@ -159,13 +167,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactElement }> = ({
   }, [colors, dark]);
 
   const handleActiveThemeChange = (theme: ActiveTheme) => {
-    // Picking "Automatic" (theme === null) must release the override, not
-    // just skip setting a new one — Appearance.setColorScheme keeps forcing
-    // whatever was last set until called with null, so useColorScheme() kept
-    // reporting the old forced value and the app only picked up the real
-    // system scheme after a full restart reset the native override.
-    Appearance.setColorScheme(theme as ColorSchemeName);
-    persistNativeThemeOverride(theme);
+    applyStoredTheme(theme);
     setActiveTheme(theme);
 
     if (!theme) return deleteData(StorageKeys.Theme);


### PR DESCRIPTION
- System dark + Automatic still showed light Preferencias
- Mount never released Appearance when storedTheme was null
- leftover pegadaThemeOverride "light" in UserDefaults
- force-release setColorScheme(null) on mount; persist "system"
- requested picks dark when colorScheme is dark; UnistylesRuntime.setTheme("dark") runs
- Forced Light/Dark still work
- No em dash