### PR TITLE
fix(mobile): slider value bubbles below the track, thumbs reach the ends

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -24,7 +24,11 @@ const AppLayout = () => {
           backgroundColor: theme.colors.background,
         },
 
-        headerBlurEffect: "prominent",
+        // "prominent" follows the OS appearance rather than `theme.dark` —
+        // when the app is forced to (or stuck on) one theme while the
+        // system runs the other, the header glass renders in the wrong
+        // theme's color. "dark"/"light" are the legacy, non-adaptive styles.
+        headerBlurEffect: theme.dark ? "dark" : "light",
 
         headerStyle: {
           // BlurEffect doesn't work on Android, so opacity is not necessary

--- a/apps/mobile/src/components/Slider/index.tsx
+++ b/apps/mobile/src/components/Slider/index.tsx
@@ -101,6 +101,12 @@ const positionToValue = (
   step: number,
 ) => {
   "worklet";
+  // Visual ends must map to the real min / expanded max even when `step`
+  // does not divide (max - min) — e.g. distance min=1 max=301 step=5.
+  // Without this, the last notch (infinity) is unreachable and the thumb
+  // sits short of the right cap.
+  if (sliderLength <= 0 || position <= 0) return min;
+  if (position >= sliderLength) return max;
   const raw = min + (position / sliderLength) * (max - min);
   const snapped = Math.round(raw / step) * step;
   return clamp(snapped, min, max);

--- a/apps/mobile/src/components/Slider/index.tsx
+++ b/apps/mobile/src/components/Slider/index.tsx
@@ -11,7 +11,6 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from "react-native-reanimated";
-import { useUnistyles } from "react-native-unistyles";
 
 import { Text } from "@/components/text";
 import { useDisableSwipeBack } from "@/hooks/use-disable-swipe-back";
@@ -216,6 +215,22 @@ export type MultiSliderProps = {
   onValuesChangeFinish?: (values: number[]) => void;
 };
 
+type LastEmittedRef = React.RefObject<number[] | null>;
+
+/**
+ * True when `values` isn't this slider's own echo AND we've already emitted
+ * at least one local change — i.e. a parent re-render (a stale hydrate, a
+ * refetch) is trying to clobber an in-progress edit rather than reflect it.
+ */
+const isStaleExternalReset = (
+  lastEmittedRef: LastEmittedRef,
+  values: number[],
+) => {
+  const last = lastEmittedRef.current;
+  if (last === null) return false;
+  return last[0] !== values[0] || last[1] !== values[1];
+};
+
 const CustomSlider = ({
   values,
   min = 0,
@@ -225,7 +240,8 @@ const CustomSlider = ({
   onValuesChange,
   onValuesChangeStart,
   onValuesChangeFinish,
-}: MultiSliderProps) => {
+  lastEmittedRef,
+}: MultiSliderProps & { lastEmittedRef: LastEmittedRef }) => {
   const hasSecondMarker = values.length > 1;
 
   const positionA = useSharedValue(
@@ -241,6 +257,7 @@ const CustomSlider = ({
 
   useEffect(() => {
     if (isDraggingRef.current) return;
+    if (isStaleExternalReset(lastEmittedRef, values)) return;
     positionA.value = withSpring(
       valueToPosition(values[0] ?? min, min, max, sliderLength),
       SETTLE_SPRING,
@@ -328,22 +345,12 @@ const CustomSlider = ({
 };
 
 export const Root = (props: MultiSliderProps) => {
-  const { theme } = useUnistyles();
   const setSwipeBackEnabled = useDisableSwipeBack();
 
-  // When the slider reaches the edge of the screen, a horizontal drag there
-  // gets claimed by the OS navigation gesture (iOS interactive pop / Android
-  // system back) instead of the slider, sending the user back a screen. Inset
-  // the track on both platforms so no marker sits in that edge gesture zone.
-  // The marker's own gesture also disables that stack gesture for the
-  // duration of the drag (see Marker above) — this inset is a second,
-  // independent line of defense at the exact edge.
-  const sliderLength = (props?.sliderLength ?? 0) - theme.spacing[7] * 2;
-
-  // The edge inset above only softens the conflict — a drag that starts
-  // mid-track and moves the finger toward either edge still races the
-  // screen's swipe-back gesture. Turn the stack's gesture off for as long
-  // as a drag is in progress so the slider always wins.
+  // A drag that starts mid-track and moves the finger toward either edge
+  // still races the screen's own swipe-back gesture. Marker's own
+  // onTouchesDown (see above) already disables it the instant a finger lands
+  // on a marker; this keeps it off for the full duration of the drag too.
   const handleDragStart = () => {
     setSwipeBackEnabled(false);
     props.onValuesChangeStart?.();
@@ -360,50 +367,18 @@ export const Root = (props: MultiSliderProps) => {
   // to match so that notch is reachable.
   const expandedMax = props.max ? props.max + 1 : max;
 
-  const hasSecondMarker = (props.values?.length ?? 0) > 1;
-
-  const stroke = 3;
-
-  const safeBorderStyle = {
-    height: stroke,
-    width: theme.spacing[7],
-    backgroundColor: theme.colors.border,
-    zIndex: -1,
-    borderTopRightRadius: theme.radii.md,
-    borderBottomRightRadius: theme.radii.md,
-  };
-
-  const style = {
-    flexDirection: "row",
-    alignItems: "center",
-  } as const;
-
   return (
-    <View style={style}>
-      <View
-        style={[
-          safeBorderStyle,
-          {
-            backgroundColor: hasSecondMarker
-              ? theme.colors.border
-              : theme.colors.primary,
-          },
-        ]}
-      />
-      <SliderWithLabels
-        {...props}
-        onValuesChangeStart={handleDragStart}
-        onValuesChangeFinish={handleDragFinish}
-        max={expandedMax}
-        sliderLength={sliderLength}
-      />
-      <View style={safeBorderStyle} />
-    </View>
+    <SliderWithLabels
+      {...props}
+      onValuesChangeStart={handleDragStart}
+      onValuesChangeFinish={handleDragFinish}
+      max={expandedMax}
+    />
   );
 };
 
 /**
- * Wraps `CustomSlider` to render the value bubble(s) above each marker,
+ * Wraps `CustomSlider` to render the value bubble(s) below each marker,
  * outside the track's own clipping so the bubble's shadow isn't cut off.
  */
 const SliderWithLabels = (props: MultiSliderProps) => {
@@ -412,15 +387,24 @@ const SliderWithLabels = (props: MultiSliderProps) => {
 
   const [displayValues, setDisplayValues] = React.useState(values);
 
+  // Shared with CustomSlider below so both the bubble text and the marker
+  // position agree on whether an incoming `values` update is this slider's
+  // own echo or a stale reset trying to clobber an in-progress edit.
+  const lastEmittedRef = useRef<number[] | null>(null);
+
   useEffect(() => {
+    if (isStaleExternalReset(lastEmittedRef, values)) return;
     setDisplayValues(values);
-  }, [values]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values[0], values[1]]);
 
   return (
-    <View>
+    <View style={styles.sliderWrapper}>
       <CustomSlider
         {...props}
+        lastEmittedRef={lastEmittedRef}
         onValuesChange={(next) => {
+          lastEmittedRef.current = next;
           setDisplayValues(next);
           props.onValuesChange?.(next);
         }}

--- a/apps/mobile/src/components/Slider/styles.ts
+++ b/apps/mobile/src/components/Slider/styles.ts
@@ -5,6 +5,11 @@ const HEIGHT = 24;
 const TRIANGLE_SIZE = 4;
 export const MARKER_SIZE = 20;
 export const TRACK_STROKE = 3;
+// Gap between the marker and the value bubble sitting below it.
+const LABEL_GAP = 12;
+// Space the wrapper must reserve below the track so the bubble (plus its
+// shadow) never clips and never overlaps whatever comes after the slider.
+export const LABEL_SPACE = LABEL_GAP + HEIGHT;
 
 export const styles = StyleSheet.create((theme) => ({
   titleContainer: {
@@ -12,13 +17,18 @@ export const styles = StyleSheet.create((theme) => ({
     justifyContent: "space-between",
     marginTop: theme.spacing[6],
   },
+  sliderWrapper: {
+    // Reserves room below the track for the value bubble, which is
+    // absolutely positioned and would otherwise clip or overlap whatever
+    // follows the slider (the next slider, or the Save button).
+    paddingBottom: LABEL_SPACE,
+  },
   labelContainer: {
     position: "absolute",
-    // Anchored from the bottom of the slider's own container (which is
-    // exactly MARKER_SIZE tall — see sliderContainer below) rather than from
-    // the top, so the label sits just above the track regardless of
-    // whatever content happens to sit above this slider in the screen.
-    bottom: MARKER_SIZE + 20,
+    // Anchored from the top of the slider's own container, just below the
+    // marker, so the bubble never overlaps the title/range labels that sit
+    // above the track.
+    top: MARKER_SIZE + LABEL_GAP,
     width: WIDTH,
     height: HEIGHT,
     alignItems: "center",
@@ -35,6 +45,7 @@ export const styles = StyleSheet.create((theme) => ({
     shadowRadius: 2,
   },
   triangle: {
+    // Sits on the bubble's top edge, pointing up at the marker above it.
     position: "absolute",
     top: -(TRIANGLE_SIZE / 2),
     left: WIDTH / 2 - TRIANGLE_SIZE / 2,

--- a/apps/mobile/src/components/blur-view.tsx
+++ b/apps/mobile/src/components/blur-view.tsx
@@ -22,9 +22,18 @@ const ContainerComponent = (
 /** Only the styles are themed here; the blur props are constants. */
 const Container = withUnistyles(ContainerComponent);
 
-/** The former `.attrs(getProps)`: the tint/intensity pair the theme decides. */
+/**
+ * The former `.attrs(getProps)`: the tint/intensity pair the theme decides.
+ *
+ * `tint` is pinned to the legacy "light"/"dark" values rather than
+ * "prominent" or any "system*" tint on purpose — those follow the OS
+ * appearance (`UITraitCollection`), not `theme.dark`. When the app is forced
+ * to (or stuck on) one theme while the system runs the other — the whole
+ * point of `theme.dark` existing — a system-following tint renders glass in
+ * the wrong theme's color even though every other themed color is correct.
+ */
 const ThemedContainer = withUnistyles(ContainerComponent, (theme) => ({
-  tint: "prominent" as const,
+  tint: theme.dark ? ("dark" as const) : ("light" as const),
   intensity: theme.dark ? 70 : 40,
 }));
 

--- a/apps/mobile/src/views/Preferences/index.tsx
+++ b/apps/mobile/src/views/Preferences/index.tsx
@@ -78,7 +78,7 @@ const Preferences: React.FC = () => {
     defaultValues: {
       preferredColor: undefined,
       preferredSize: undefined,
-      preferredMaxDistance: [MAX_FILTER_DISTANCE],
+      preferredMaxDistance: [MAX_FILTER_DISTANCE + 1],
       preferredBreedId: undefined,
       preferredAgeRange: [0, MAX_FILTER_AGE],
     },
@@ -156,7 +156,7 @@ const Preferences: React.FC = () => {
     setValue("preferredColor", dog.preferredColor);
     setValue("preferredSize", dog.preferredSize);
     setValue("preferredMaxDistance", [
-      dog.preferredMaxDistance ?? MAX_FILTER_DISTANCE,
+      dog.preferredMaxDistance ?? MAX_FILTER_DISTANCE + 1,
     ]);
     setValue("preferredAgeRange", [
       dog.preferredMinAge ?? 0,

--- a/apps/mobile/src/views/Preferences/index.tsx
+++ b/apps/mobile/src/views/Preferences/index.tsx
@@ -69,7 +69,12 @@ const Preferences: React.FC = () => {
     throw new Error("Dog not found");
   }
 
-  const { control, handleSubmit, setValue } = useForm<Preference>({
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    formState: { isDirty },
+  } = useForm<Preference>({
     defaultValues: {
       preferredColor: undefined,
       preferredSize: undefined,
@@ -141,6 +146,12 @@ const Preferences: React.FC = () => {
   });
 
   useEffect(() => {
+    // `dog` refetches (app resume, focus, another screen touching the same
+    // query) and gets a new reference whether or not anything actually
+    // changed. Once the user has touched a field, that refetch must not
+    // clobber their in-progress edit with the still-saved server value —
+    // only hydrate the pristine form.
+    if (isDirty) return;
     setValue("preferredBreedId", dog.preferredBreedId);
     setValue("preferredColor", dog.preferredColor);
     setValue("preferredSize", dog.preferredSize);
@@ -151,6 +162,7 @@ const Preferences: React.FC = () => {
       dog.preferredMinAge ?? 0,
       dog.preferredMaxAge ?? MAX_FILTER_AGE + 1,
     ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dog, setValue]);
 
   const headerHeight = useHeaderHeight();
@@ -273,7 +285,7 @@ const Preferences: React.FC = () => {
               <Slider.Root
                 values={value}
                 sliderLength={width - theme.spacing[4] * 2}
-                min={0}
+                min={1}
                 max={MAX_FILTER_DISTANCE}
                 step={5}
                 onValuesChange={onChange}


### PR DESCRIPTION
## Bugs (from a TestFlight 1.6.1 screenshot pass on Preferencias)

- Value bubbles (age, distance) rendered ABOVE the track and overlapped the "Faixa etaria" / "Distancia maxima" titles and their range labels.
- The min (age) and max (infinity) thumbs sat visually inset from the actual ends of the track instead of reaching them.
- Backgrounding the app mid-edit (before tapping Salvar) reset the sliders back to the saved/server values.
- Save Preferencias / bottom bar rendered as dark glass even though the app itself is on its light theme, because the iOS system appearance was dark.

## What changed

- Bubbles below not above: `CustomLabel` now anchors from `top` (just below the marker) instead of `bottom`. The triangle already sat on the bubble's top edge, so it now correctly points up at the marker above it. The slider wrapper reserves padding below the track so the bubble (and its shadow) never clips and never collides with the next field or the Save button.
- 0/infinity at the visual ends: removed the `sliderLength` shrink and the two fake edge-cap views (`safeBorderStyle`) that Root used to paint. Those existed as an extra line of defense against iOS swipe-back stealing the drag, but they visually shortened the track so min/max never reached the real ends. Swipe-back is still fully disabled by `Marker`'s own `onTouchesDown` (fires the instant a finger lands on a marker, before any movement), which was already the real fix; `Root` also still disables it for the whole drag duration as a second layer. Also fixed the max-distance slider's `min` from 0 to 1 to match its own "1-300+ km" label — it only has one thumb (for max distance), so the left end of the track needs to represent the same minimum the label promises.
- Mid-edit survives app background: two layers, since either alone can regress independently.
  - `Slider`: tracks the last values it itself emitted. Once it has emitted a local edit, an incoming `values` prop that doesn't match that echo is treated as a stale external reset and ignored (both the marker position and the bubble text). A first hydrate (before any local edit) still applies normally.
  - `Preferences`: the `useEffect` that calls `setValue(...)` from the `dog` query now bails out while the form is dirty (`formState.isDirty`), so a refetch triggered by the app coming back to the foreground (react-query's default `refetchOnWindowFocus`, wired to `AppState` in `query-client.tsx`) can't stomp an in-progress edit. It still hydrates once on a pristine mount.
- Save / chrome follows the APP theme, not system: `blur-view.tsx`'s `tint` and the app Stack's `headerBlurEffect` (`apps/mobile/src/app/(app)/_layout.tsx`) were both pinned to `"prominent"`, which is a `UIBlurEffect` style that follows the OS appearance rather than the app's own forced theme. Switched both to the non-adaptive `"light"`/`"dark"` styles picked by `theme.dark` (Unistyles), which is the same source of truth the rest of the app (navigation theme, status bar) already uses. This does not touch the separate bug where "Automatic" doesn't correctly follow a system appearance change — that's out of scope here.
- Infinity notch reachable on distance: `positionToValue`'s step-snapping never lands exactly on `expandedMax` for min=1/max=301/step=5 (the grid based at 0 skips 301, so it snapped to 300 instead) — the drag's right end was one notch short of "unlimited" and a saved-unlimited distance rendered short of the cap. `positionToValue` now pins the track's two visual ends to the real min/max directly (position `<= 0` → min, `>= sliderLength` → max), independent of step. Also updated the distance default/hydrate fallback from `MAX_FILTER_DISTANCE` to `MAX_FILTER_DISTANCE + 1` so an unset max distance hydrates onto the infinity notch, matching how age already does it.

## Issues fixed (full list)

1. Value bubbles overlapping titles/range labels (rendered above, now below the track).
2. Min/max thumbs inset from the track's visual ends (removed fake edge-cap shrink).
3. Max-distance slider's `min` didn't match its own "1-300+ km" label (was 0, now 1).
4. Slider thumbs/labels reset to saved values when the app is backgrounded mid-edit.
5. Preferences form re-hydrates over dirty fields on any `dog` query refetch (react-query refetch-on-focus).
6. Save Preferencias button / bottom bar glass rendered dark on a light app theme when system is dark.
7. App header glass (`headerBlurEffect`) had the same system-following tint bug, affecting Preferencias' own header too.
8. Distance slider's infinity notch was unreachable by drag and a saved-unlimited value rendered short of the track's right end (step/min grid never landed on the expanded max).

Not touched (explicitly out of scope): the "Automatic" theme not following a system appearance change — that's a separate PR.

## Proof

Ran lint (`oxlint`, scoped to changed files), `tsc --noEmit` for the mobile package, and the full `pnpm test` suite (mobile: 100/100, api: 89/89, plus the repo's Python/security test scripts) — all green.

Simulator screenshot: attempted a local build (Docker Postgres + seed + iOS sim). Got the app running and logged in (reached the Swipe screen), but a rebuild afterward hit an unrelated native compile failure (a RevenueCat/Swift pod redeclaration error, nothing to do with this diff) before reaching Preferences. Not pursuing further to avoid rabbit-holing on an unrelated toolchain issue. TestFlight next.

