### PR TITLE
fix(mobile): stop DraggableGrid crash and stale reorders in photo grid

### DIFF
--- a/apps/mobile/src/components/DraggableGrid/index.tsx
+++ b/apps/mobile/src/components/DraggableGrid/index.tsx
@@ -73,11 +73,17 @@ const DraggableGridItem = <T extends DraggableItem>({
   const dragX = useSharedValue(0);
   const dragY = useSharedValue(0);
   const isActive = useSharedValue(false);
+  const liftScale = useSharedValue(1);
+  // Worklets close over `index` at gesture-creation time; mirroring it into a
+  // shared value keeps onEnd reading the current slot even if a native
+  // touch event is still in flight when a reorder shifts this item's index.
+  const currentIndex = useSharedValue(index);
 
   // Slots stay put while an item settles into a new position after a drop
   // elsewhere in the grid — only the coordinates change, not by a gesture on
   // this cell.
   useEffect(() => {
+    currentIndex.value = index;
     restX.value = withSpring((index % numColumns) * cellWidth, SLOT_SPRING);
     restY.value = withSpring(
       Math.floor(index / numColumns) * cellHeight,
@@ -95,11 +101,16 @@ const DraggableGridItem = <T extends DraggableItem>({
     .onStart(() => {
       "worklet";
       isActive.value = true;
+      liftScale.value = withSpring(LIFT_SCALE, LIFT_SPRING);
       runOnJS(onDragStart)();
     })
     .onFinalize(() => {
       "worklet";
+      // A tap that never reaches the long-press threshold still finalizes —
+      // only fire onDragEnd (and unwind the lift) if a drag actually started.
+      if (!isActive.value) return;
       isActive.value = false;
+      liftScale.value = withSpring(1, LIFT_SPRING);
       runOnJS(onDragEnd)();
     });
 
@@ -123,7 +134,7 @@ const DraggableGridItem = <T extends DraggableItem>({
       const col = clamp(Math.round(currentX / cellWidth), 0, numColumns - 1);
       const row = Math.max(0, Math.round(currentY / cellHeight));
       const hoverIndex = clamp(row * numColumns + col, 0, total - 1);
-      runOnJS(onReorder)(index, hoverIndex);
+      runOnJS(onReorder)(currentIndex.value, hoverIndex);
     })
     .onFinalize(() => {
       "worklet";
@@ -142,7 +153,7 @@ const DraggableGridItem = <T extends DraggableItem>({
     transform: [
       { translateX: dragX.value },
       { translateY: dragY.value },
-      { scale: withSpring(isActive.value ? LIFT_SCALE : 1, LIFT_SPRING) },
+      { scale: liftScale.value },
     ],
     zIndex: isActive.value ? 10 : 0,
     elevation: isActive.value ? 10 : 0,
@@ -188,15 +199,29 @@ export const DraggableGrid = <T extends DraggableItem>({
   };
 
   const handleReorder = (fromIndex: number, toIndex: number) => {
-    if (toIndex === fromIndex || items[toIndex]?.disabledReSorted) return;
+    let reordered: T[] | null = null;
 
-    const next = [...items];
-    const [moved] = next.splice(fromIndex, 1);
-    if (!moved) return;
-    next.splice(toIndex, 0, moved);
+    setItems((prev) => {
+      const inRange = (i: number) => i >= 0 && i < prev.length;
+      if (
+        toIndex === fromIndex ||
+        !inRange(fromIndex) ||
+        !inRange(toIndex) ||
+        prev[toIndex]?.disabledReSorted
+      ) {
+        return prev;
+      }
 
-    setItems(next);
-    onDragRelease?.(next);
+      const next = [...prev];
+      const [moved] = next.splice(fromIndex, 1);
+      if (!moved) return prev;
+      next.splice(toIndex, 0, moved);
+
+      reordered = next;
+      return next;
+    });
+
+    if (reordered) onDragRelease?.(reordered);
   };
 
   const handleLayout = (event: LayoutChangeEvent) => {


### PR DESCRIPTION
## Resumo

Corrige o crash no reorder de fotos do perfil (relatado no TestFlight 1.6.1, depois da reescrita do Slider/DraggableGrid com RNGH e Reanimated na #160).

## Detalhes

O `useAnimatedStyle` do `DraggableGrid` chamava `withSpring` direto dentro do worklet de estilo, recalculando a mola a cada frame. Isso reinicia a spring toda hora em vez de deixar ela convergir, e é um crash conhecido do Reanimated no thread de UI. Trocado por um shared value (`liftScale`) que só recebe `withSpring` no `onStart`/`onFinalize` do long press, e o worklet de estilo apenas lê o valor.

Junto disso, endureci três pontos que ficaram frágeis com a reescrita:

- `pan.onEnd` lia `index` direto do closure em JS. Se o grid reordena enquanto o worklet nativo ainda está processando o gesto, esse índice fica desatualizado. Agora tem um shared value (`currentIndex`) espelhando o índice atual, atualizado no mesmo `useEffect` que já sincroniza a posição do slot.
- `handleReorder` lia `items` do closure do render e podia estourar os índices se `fromIndex`/`toIndex` saíssem do range. Passou a usar a forma funcional do `setState` com guarda de range, e só chama `onDragRelease` depois do novo array estar de fato calculado.
- `longPress.onFinalize` disparava `onDragEnd` (e desfazia o "lift" visual) mesmo quando o long press nunca tinha ativado, por exemplo num toque rápido. Agora só dispara se o drag realmente começou.

O componente que usa o grid (`ProfileImageUploader`) já repassa o array novo pro `onChange` sem assumir formato específico, não precisou de mudança lá.

## Passos de teste

1. Abre o app, vai no perfil e entra na tela de editar fotos.
2. Segura uma foto, arrasta pra outra posição e solta. Confirma que ela troca de lugar sem travar o app.
3. Repete o arrasta-e-solta várias vezes seguidas, rápido, em fotos diferentes. O app não deve fechar sozinho.
4. Dá um toque rápido (sem segurar) numa foto, sem soltar pra arrastar. Confirma que nada se move e o app continua normal.
