### PR TITLE
fix(mobile): clear unlimited preference limits

### DIFF
--- a/apps/mobile/src/views/Preferences/index.tsx
+++ b/apps/mobile/src/views/Preferences/index.tsx
@@ -118,11 +118,11 @@ const Preferences: React.FC = () => {
 
     body.preferredMaxDistance = normalizePreferenceLimit(
       body.preferredMaxDistance,
-      MAX_FILTER_DISTANCE,
+      MAX_FILTER_DISTANCE + 1,
     );
     body.preferredMaxAge = normalizePreferenceLimit(
       body.preferredMaxAge,
-      MAX_FILTER_AGE,
+      MAX_FILTER_AGE + 1,
     );
 
     // if the values are the same as dog, don't update

--- a/apps/mobile/src/views/Preferences/index.tsx
+++ b/apps/mobile/src/views/Preferences/index.tsx
@@ -30,6 +30,7 @@ import { sendError } from "@/services/error-tracking";
 import { Actions } from "@/store/reducers";
 import { SceneName } from "@/types/scene-name";
 
+import { normalizePreferenceLimit } from "./preference-limit";
 import { styles } from "./styles";
 
 const { width } = Dimensions.get("window");
@@ -115,18 +116,14 @@ const Preferences: React.FC = () => {
       preferredMaxAge: data.preferredAgeRange[1],
     };
 
-    // Unlimited
-    if (
-      body.preferredMaxDistance &&
-      body.preferredMaxDistance >= MAX_FILTER_DISTANCE
-    ) {
-      body.preferredMaxDistance = undefined;
-    }
-
-    // Unlimited
-    if (body.preferredMaxAge && body.preferredMaxAge >= MAX_FILTER_AGE) {
-      body.preferredMaxAge = undefined;
-    }
+    body.preferredMaxDistance = normalizePreferenceLimit(
+      body.preferredMaxDistance,
+      MAX_FILTER_DISTANCE,
+    );
+    body.preferredMaxAge = normalizePreferenceLimit(
+      body.preferredMaxAge,
+      MAX_FILTER_AGE,
+    );
 
     // if the values are the same as dog, don't update
     if (

--- a/apps/mobile/src/views/Preferences/preference-limit.test.ts
+++ b/apps/mobile/src/views/Preferences/preference-limit.test.ts
@@ -1,7 +1,8 @@
 import { normalizePreferenceLimit } from "./preference-limit";
 
 test("sends unlimited limits as null so the API clears them", () => {
-  expect(normalizePreferenceLimit(301, 300)).toBeNull();
-  expect(normalizePreferenceLimit(10, 10)).toBeNull();
-  expect(normalizePreferenceLimit(295, 300)).toBe(295);
+  expect(normalizePreferenceLimit(301, 301)).toBeNull();
+  expect(normalizePreferenceLimit(11, 11)).toBeNull();
+  expect(normalizePreferenceLimit(300, 301)).toBe(300);
+  expect(normalizePreferenceLimit(10, 11)).toBe(10);
 });

--- a/apps/mobile/src/views/Preferences/preference-limit.test.ts
+++ b/apps/mobile/src/views/Preferences/preference-limit.test.ts
@@ -1,0 +1,7 @@
+import { normalizePreferenceLimit } from "./preference-limit";
+
+test("sends unlimited limits as null so the API clears them", () => {
+  expect(normalizePreferenceLimit(301, 300)).toBeNull();
+  expect(normalizePreferenceLimit(10, 10)).toBeNull();
+  expect(normalizePreferenceLimit(295, 300)).toBe(295);
+});

--- a/apps/mobile/src/views/Preferences/preference-limit.ts
+++ b/apps/mobile/src/views/Preferences/preference-limit.ts
@@ -1,0 +1,4 @@
+export const normalizePreferenceLimit = (
+  value: number | null | undefined,
+  max: number,
+) => (typeof value === "number" && value >= max ? null : value);


### PR DESCRIPTION
### Summary
Saving infinity sent `undefined`, so tRPC omitted the field and kept the old limit. Send `null` only for the extra infinity notch, while preserving finite `300 km` and `10 years` values.

### Testing
- `pnpm -F @pegada/mobile test`
- `pnpm -F @pegada/mobile typecheck`
- Focused test covers infinity and both finite maximums
- Reproduced the stale saved value on the iOS Simulator with the current `main` bundle
