### PR TITLE
fix(mobile): keep slider labels inside screen edges

### DIFF
--- a/apps/mobile/src/components/Slider/styles.ts
+++ b/apps/mobile/src/components/Slider/styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from "react-native-unistyles";
 
-export const WIDTH = 36;
+export const WIDTH = 32;
 const HEIGHT = 24;
 const TRIANGLE_SIZE = 4;
 export const MARKER_SIZE = 20;


### PR DESCRIPTION
### Summary
The 36pt value bubble overhung the 16pt screen inset at both slider ends. Match the bubble width to that inset so `0` and infinity stay fully visible.

### Testing
- `pnpm -F @pegada/mobile typecheck`
- iOS Simulator screenshots in light and dark mode at both endpoints
