### PR TITLE
fix(mobile): restore gestures after every photo drag

### DIFF
--- a/apps/mobile/src/components/DraggableGrid/index.tsx
+++ b/apps/mobile/src/components/DraggableGrid/index.tsx
@@ -33,6 +33,7 @@ export type DraggableGridProps<T extends DraggableItem> = {
   itemHeight: number;
   style?: StyleProp<ViewStyle>;
   onDragStart?: () => void;
+  onDragEnd?: () => void;
   onDragRelease?: (newData: T[]) => void;
   renderItem: (item: T) => React.ReactNode;
 };
@@ -172,6 +173,7 @@ export const DraggableGrid = <T extends DraggableItem>({
   itemHeight,
   style,
   onDragStart,
+  onDragEnd,
   onDragRelease,
   renderItem,
 }: DraggableGridProps<T>) => {
@@ -196,6 +198,7 @@ export const DraggableGrid = <T extends DraggableItem>({
   const handleDragEnd = () => {
     isDraggingRef.current = false;
     setSwipeBackEnabled(true);
+    onDragEnd?.();
   };
 
   const handleReorder = (fromIndex: number, toIndex: number) => {

--- a/apps/mobile/src/components/ProfileImageUploader/index.test.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/index.test.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+
+type GridProps = {
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
+};
+
+let gridProps: GridProps = {};
+
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  View: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/DraggableGrid", () => ({
+  DraggableGrid: (props: GridProps) => {
+    gridProps = props;
+    return null;
+  },
+}));
+
+jest.mock<Record<string, unknown>>(
+  "@/components/ProfileImageUploader/utils",
+  () => ({
+    deleteItem: () => () => null,
+    sortByUrl: () => 0,
+  }),
+);
+
+jest.mock<Record<string, unknown>>("@/components/text", () => ({
+  Text: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+jest.mock<Record<string, unknown>>("./components/AddUserPhoto", () => ({
+  AddUserPhoto: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("./components/AddUserPhoto/styles", () => ({
+  dogPictureHeight: 100,
+  numOfColumns: 3,
+}));
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ProfileImagesUploader } from ".";
+
+test("re-enables parent gestures when a photo drag ends without a reorder", () => {
+  const setGesturesEnabled = jest.fn();
+
+  renderToStaticMarkup(
+    <ProfileImagesUploader
+      value={[]}
+      onChange={jest.fn()}
+      setGesturesEnabled={setGesturesEnabled}
+    />,
+  );
+
+  gridProps.onDragStart?.();
+  gridProps.onDragEnd?.();
+
+  expect(setGesturesEnabled).toHaveBeenNthCalledWith(1, false);
+  expect(setGesturesEnabled).toHaveBeenNthCalledWith(2, true);
+});

--- a/apps/mobile/src/components/ProfileImageUploader/index.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/index.tsx
@@ -9,7 +9,6 @@ import { View } from "react-native";
 import { DraggableGrid } from "@/components/DraggableGrid";
 import { deleteItem, sortByUrl } from "@/components/ProfileImageUploader/utils";
 import { Text } from "@/components/text";
-import { useDisableSwipeBack } from "@/hooks/use-disable-swipe-back";
 
 import { AddUserPhoto } from "./components/AddUserPhoto";
 import {
@@ -82,20 +81,15 @@ export const ProfileImagesUploader: React.FC<ProfileImagesUploaderProps> = ({
 
   const draggableGridStyle = { zIndex: 20 };
 
-  const setSwipeBackEnabled = useDisableSwipeBack();
-
-  // Reordering is a drag, same as the grid's own internal pan responder —
-  // and, same as a Slider drag, an independent recognizer from the stack's
-  // native swipe-back gesture. Without this, dragging a photo toward the
-  // screen's left edge pops the screen instead of reordering.
   const onDragStart = () => {
-    setSwipeBackEnabled(false);
     setGesturesEnabled(false);
   };
 
-  const onDragRelease = (newImages: GenericPictures) => {
-    setSwipeBackEnabled(true);
+  const onDragEnd = () => {
     setGesturesEnabled(true);
+  };
+
+  const onDragRelease = (newImages: GenericPictures) => {
     onChange(() => newImages);
   };
 
@@ -120,6 +114,7 @@ export const ProfileImagesUploader: React.FC<ProfileImagesUploaderProps> = ({
         itemHeight={dogPictureHeight}
         style={draggableGridStyle}
         onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
         onDragRelease={onDragRelease}
         renderItem={renderItem}
       />


### PR DESCRIPTION
### Summary
A long press released in the same photo slot never fired the reorder callback, leaving the edit screen scroll and swipe-back gestures disabled. Give the grid a drag-end callback and restore parent gestures on every completed drag.

### Testing
- `pnpm -F @pegada/mobile test`
- `pnpm -F @pegada/mobile typecheck`
- Focused no-reorder drag-end regression test
- Real 200 ms hold and same-slot release on the iOS Simulator, followed by a successful edit-screen scroll
