### PR TITLE
fix(mobile): mark photo grid clamp as worklet

### DIFF
--- a/apps/mobile/src/components/DraggableGrid/index.tsx
+++ b/apps/mobile/src/components/DraggableGrid/index.tsx
@@ -37,8 +37,10 @@ export type DraggableGridProps<T extends DraggableItem> = {
   renderItem: (item: T) => React.ReactNode;
 };
 
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(max, Math.max(min, value));
+const clamp = (value: number, min: number, max: number) => {
+  "worklet";
+  return Math.min(max, Math.max(min, value));
+};
 
 // Long enough that an ordinary tap or scroll never gets mistaken for the
 // start of a drag; short enough that intentionally holding a photo feels


### PR DESCRIPTION
### Summary
Moving a photo reaches `clamp` from the pan gesture UI worklet, but `clamp` was plain JS. Reanimated throws before the reorder can finish. Mark the shared helper as a worklet.

### Testing
- `pnpm -F @pegada/mobile test`
- `pnpm -F @pegada/mobile typecheck`
- Reproduced the Reanimated crash on the iOS Simulator
- Repeated the same real 200 ms hold and drag after the fix, with the photo settling from slot 4 into slot 1 and no crash
