### PR TITLE
fix(api): stop exposing private account data

### DIFF
--- a/apps/mobile/src/views/(auth)/CompleteProfile/index.tsx
+++ b/apps/mobile/src/views/(auth)/CompleteProfile/index.tsx
@@ -55,7 +55,12 @@ const CompleteProfile = () => {
     onSuccess: (data) => {
       analytics.track({
         event_type: "Complete Dog Profile",
-        event_properties: data ?? {},
+        event_properties: {
+          has_birth_date: Boolean(data?.birthDate),
+          has_breed: Boolean(data?.breed),
+          has_color: Boolean(data?.color),
+          has_size: Boolean(data?.size),
+        },
       });
       getTrcpContext().myDog.get.setData(undefined, data);
       router.replace(SceneName.AskForLocation);

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 
 import prisma from "@pegada/database";
 import { Namespace } from "@pegada/shared/i18n/types/types";
+import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
 import { getFormattedYears } from "@pegada/shared/utils/get-formatted-years";
 
 import { getSafeLocale } from "@/lib/get-safe-locale";
@@ -17,11 +18,34 @@ type DogProfileProps = {
   }>;
 };
 
+export const metadata = {
+  robots: { index: false, follow: false },
+};
+
 const DogProfile = async ({ params }: DogProfileProps) => {
   const { id } = await params;
   const dog = await prisma.dog.findFirst({
-    where: { id, deletedAt: null },
-    include: { images: true, breed: true },
+    where: {
+      id,
+      banned: false,
+      deletedAt: null,
+      images: {
+        some: { status: IMAGE_STATUS.APPROVED },
+        none: { status: IMAGE_STATUS.REJECTED },
+      },
+    },
+    select: {
+      name: true,
+      bio: true,
+      birthDate: true,
+      breed: { select: { name: true, slug: true } },
+      images: {
+        where: { status: IMAGE_STATUS.APPROVED },
+        orderBy: { position: "asc" },
+        take: 1,
+        select: { url: true },
+      },
+    },
   });
 
   const lng = getSafeLocale();

--- a/packages/api/src/queue/handlers/push.ts
+++ b/packages/api/src/queue/handlers/push.ts
@@ -23,7 +23,7 @@ const expo = new Expo({
 
 const handlePushError = async (errorMessage: string, pushToken: string) => {
   const newError = new Error(
-    `There was an error sending a notification: ${errorMessage}. Push Token: ${pushToken}.`,
+    `There was an error sending a notification: ${errorMessage}.`,
   );
 
   if (errorMessage === "DeviceNotRegistered") {
@@ -111,7 +111,9 @@ export const handleCheckPushReceipts = async ({
   if (nonProcessedReceipts.length === 0) return;
 
   sendError(
-    `Some push notifications weren't processed. Receipts: ${JSON.stringify(nonProcessedReceipts)}`,
+    `Some push notifications weren't processed. Receipt IDs: ${JSON.stringify(
+      nonProcessedReceipts.map(({ id }) => id),
+    )}`,
   );
 
   await enqueue(

--- a/packages/api/src/routes/private-output.test.ts
+++ b/packages/api/src/routes/private-output.test.ts
@@ -1,0 +1,146 @@
+import prisma from "@pegada/database";
+import { breedData } from "@pegada/database/fixtures/breed-data";
+import { generateFakeUserWithDog } from "@pegada/database/fixtures/generate-fake-user-with-dog";
+
+import { appRouter } from "../root";
+import { PushNotificationService } from "../services/push-notification-service";
+import { createInnerTRPCContext } from "../trpc";
+
+jest.mock("../services/push-notification-service", () => ({
+  PushNotificationService: {
+    enqueuePushNotification: jest.fn(async () => undefined),
+  },
+}));
+
+jest.mock("../shared/observability", () => ({
+  observability: {
+    enabled: false,
+    disabledReason: "explicitly-disabled",
+    capture: jest.fn(),
+    captureError: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    register: jest.fn(),
+    flush: jest.fn(),
+    shutdown: jest.fn(),
+  },
+  getPostHogNode: jest.fn(() => null),
+}));
+
+jest.mock("superjson", () => ({
+  __esModule: true,
+  default: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value,
+  },
+}));
+
+const enqueuePushNotification = jest.mocked(
+  PushNotificationService.enqueuePushNotification,
+);
+
+const callerFor = (userId: string) =>
+  appRouter.createCaller(
+    createInnerTRPCContext({ session: { user: { id: userId } } }),
+  );
+
+beforeAll(async () => {
+  await prisma.breed.createMany({ data: breedData, skipDuplicates: true });
+});
+
+beforeEach(async () => {
+  enqueuePushNotification.mockClear();
+  await prisma.message.deleteMany();
+  await prisma.match.deleteMany();
+  await prisma.interest.deleteMany();
+  await prisma.image.deleteMany();
+  await prisma.dog.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+it("returns only the match id after a mutual swipe", async () => {
+  const codeExpiresAt = new Date(Date.now() + 60_000);
+  const [
+    { user: attacker, dog: attackerDog },
+    { user: victim, dog: victimDog },
+  ] = await Promise.all([
+    generateFakeUserWithDog(),
+    generateFakeUserWithDog(undefined, {
+      email: "private-victim@pegada.app",
+      code: "654321",
+      codeExpiresAt,
+      latitude: -15.793889,
+      longitude: -47.882778,
+      pushToken: "ExponentPushToken[private-victim]",
+    }),
+  ]);
+
+  await prisma.interest.create({
+    data: {
+      requesterId: victimDog.id,
+      responderId: attackerDog.id,
+      swipeType: "INTERESTED",
+    },
+  });
+
+  const response = await callerFor(attacker.id).swipe.swipe({
+    id: victimDog.id,
+    swipeType: "INTERESTED",
+  });
+
+  expect(response.match).toEqual({ id: expect.any(String) });
+  expect(response.match).not.toHaveProperty("responder");
+
+  const serialized = JSON.stringify(response);
+  expect(serialized).not.toContain(victim.email);
+  expect(serialized).not.toContain("654321");
+  expect(serialized).not.toContain("ExponentPushToken[private-victim]");
+  expect(serialized).not.toContain("-15.793889");
+  expect(serialized).not.toContain("-47.882778");
+
+  expect(enqueuePushNotification).toHaveBeenCalledWith(
+    expect.objectContaining({ to: "ExponentPushToken[private-victim]" }),
+  );
+});
+
+it("does not return notification-only relations after sending a message", async () => {
+  const [{ user: sender, dog: senderDog }, { dog: receiverDog }] =
+    await Promise.all([
+      generateFakeUserWithDog(),
+      generateFakeUserWithDog(undefined, {
+        pushToken: "ExponentPushToken[private-receiver]",
+      }),
+    ]);
+
+  const match = await prisma.match.create({
+    data: { requesterId: senderDog.id, responderId: receiverDog.id },
+  });
+
+  const response = await callerFor(sender.id).message.send({
+    matchId: match.id,
+    content: "hello",
+  });
+
+  expect(response).toEqual({
+    id: expect.any(String),
+    content: "hello",
+    createdAt: expect.any(Date),
+    deletedAt: null,
+    senderId: senderDog.id,
+    receiverId: receiverDog.id,
+    matchId: match.id,
+  });
+  expect(response).not.toHaveProperty("sender");
+  expect(response).not.toHaveProperty("receiver");
+  expect(JSON.stringify(response)).not.toContain(
+    "ExponentPushToken[private-receiver]",
+  );
+
+  expect(enqueuePushNotification).toHaveBeenCalledWith(
+    expect.objectContaining({ to: "ExponentPushToken[private-receiver]" }),
+  );
+});

--- a/packages/api/src/services/match-service.ts
+++ b/packages/api/src/services/match-service.ts
@@ -25,6 +25,7 @@ class MatchService {
           { requesterId: responderId, responderId: requesterId },
         ],
       },
+      select: { id: true },
     });
 
     if (existingMatch) {
@@ -37,10 +38,15 @@ class MatchService {
         requesterId,
         responderId,
       },
-      include: {
+      select: {
+        id: true,
+        requesterId: true,
         responder: {
-          include: {
-            user: true,
+          select: {
+            name: true,
+            user: {
+              select: { pushToken: true },
+            },
           },
         },
       },
@@ -62,7 +68,10 @@ class MatchService {
       });
     }
 
-    return match;
+    // `responder.user` exists only to address the notification. Returning the
+    // Prisma result here used to serialize the complete User row through
+    // `swipe.swipe`, including email, location, push token and active OTP.
+    return { id: match.id };
   }
 
   static async getMatchesForDog(dogId: string) {

--- a/packages/api/src/services/message-service.ts
+++ b/packages/api/src/services/message-service.ts
@@ -65,11 +65,17 @@ class MessageService {
         receiverId: otherDogId,
         matchId,
       },
-      include: {
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        deletedAt: true,
+        senderId: true,
+        receiverId: true,
+        matchId: true,
         sender: {
           select: {
             name: true,
-            images: true,
           },
         },
         receiver: {
@@ -105,7 +111,10 @@ class MessageService {
       });
     }
 
-    return newMessage;
+    // Relations are selected only for the notification above. Returning them
+    // exposed the recipient's Expo token and every sender image to the client.
+    const { receiver: _receiver, sender: _sender, ...message } = newMessage;
+    return message;
   }
 
   /**

--- a/packages/api/src/services/push-notification-service.ts
+++ b/packages/api/src/services/push-notification-service.ts
@@ -19,9 +19,7 @@ export class PushNotificationService {
       }
 
       if (!Expo.isExpoPushToken(pushToken)) {
-        const error = new Error(
-          `Push token ${pushToken} is not a valid Expo push token`,
-        );
+        const error = new Error("Stored push token is not a valid Expo token");
 
         await UserService.blacklistPushToken(pushToken);
 


### PR DESCRIPTION
## Summary

Match and message mutations now keep private account data inside the server. Shared dog pages also hide moderated profiles from visitors and search engines.

## Details

- Returns only the new match ID from swipe mutations while keeping the recipient push token inside notification delivery.
- Returns the message fields used by the app without recipient notification data or sender image records.
- Serves only active dog profiles with approved images and marks shared pages `noindex`.
- Limits the profile completion event to four presence flags.
- Removes push tokens from error reporting.

## Testing steps

1. Run:
   ```sh
   pnpm install --frozen-lockfile
   pnpm exec dotenv -e .env.test -- pnpm -F @pegada/api test -- private-output.test.ts
   pnpm test
   pnpm typecheck
   pnpm lint
   pnpm format
   pnpm exec dotenv -e .env.test -- pnpm -F @pegada/nextjs build
   ```
   Every command should finish without errors. The private-response check should report a pass.
2. Sign in to two test accounts and have both dogs like each other. Both accounts should see the new match, and the recipient should receive a push notification.
3. Send a message in the new match. It should appear in the chat, and the recipient should receive a push notification.
4. Open an approved dog's shared link. The profile and its approved photo should load.
5. Open a banned dog's shared link. The page should return 404.
6. Open the shared link for a dog with a rejected photo. The page should return 404.
7. There is no user-visible change to search indexing, profile completion analytics, or push error reporting. These changes only remove private fields from background data.
