### PR TITLE
fix(deps): update codemod postcss

### DIFF
--- a/.unistyles-codemod/package-lock.json
+++ b/.unistyles-codemod/package-lock.json
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -689,9 +689,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/.unistyles-codemod/package.json
+++ b/.unistyles-codemod/package.json
@@ -17,5 +17,8 @@
     "styled-components": "6.1.11",
     "ts-morph": "28.0.0",
     "tsx": "4.20.6"
+  },
+  "overrides": {
+    "postcss": "8.5.23"
   }
 }


### PR DESCRIPTION
## Summary

The Unistyles codemod now uses a patched PostCSS release instead of the vulnerable version pinned through styled-components.

## Details

- Overrides the transitive PostCSS dependency with 8.5.23, covering all four open advisories.
- Keeps styled-components at 6.1.11 so the codemod's migration behavior stays unchanged.

## Testing steps

1. Run:
   ```sh
   cd .unistyles-codemod
   npm ci
   npm run snapshots
   npm audit --audit-level=moderate
   npm ls postcss
   ```
   The commands should finish without errors, the audit should find no vulnerabilities, and the dependency tree should show PostCSS 8.5.23.
2. From the repository root, run:
   ```sh
   pnpm test
   pnpm typecheck
   pnpm lint
   pnpm format
   ```
   Each command should finish without errors.
