### PR TITLE
fix(mobile): submit Android releases to production

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -33,8 +33,8 @@
         "ascAppId": "6450865592"
       },
       "android": {
-        "track": "internal",
-        "releaseStatus": "draft"
+        "track": "production",
+        "releaseStatus": "completed"
       }
     }
   }


### PR DESCRIPTION
## Summary

Android store submissions now create a production release ready for Google Play review.

## Details

- Sends the production build to Google Play's `production` track.
- Marks the release `completed`, allowing Google Play to start its review flow from the manually approved release run.

## Testing steps

1. After this is included in the next tagged mobile release, open GSTJ/pegada in GitHub, go to Actions, and select "Release Mobile (release + build + submit)".
2. Start the release from that tag, choose Android, and enable store submission.
3. Open the "Submit Android to Play Store" job. It should identify production as the release track and completed as the release status.
