### PR TITLE
feat(web): dog share page with real CTA and per-dog OG image

### DIFF
--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -44,6 +44,23 @@ const nextConfig = {
     // use 75 for the lazy-loaded screenshot gallery.
     qualities: [75, 90],
   },
+
+  // `opengraph-image.tsx` reads Gilroy TTFs from `packages/shared` (outside
+  // this app's directory) and `public/logo.svg` off disk at module scope.
+  // Next's default output file tracing only follows files it can see through
+  // static imports/requires, and these are read with `node:fs` at a path
+  // built from `process.cwd()`, so the standalone/serverless bundle Vercel
+  // deploys would otherwise ship without them and 500 at runtime even though
+  // `next dev` (which runs from the full repo checkout) never surfaces it.
+  // Keys are globs matched against the route; values are globs relative to
+  // this file's directory (`apps/nextjs`, the project root `next build` and
+  // Vercel's build both use).
+  outputFileTracingIncludes: {
+    "/\\[locale\\]/dog/\\[id\\]/opengraph-image": [
+      "../../packages/shared/themes/fonts/Gilroy-*.ttf",
+      "./public/logo.svg",
+    ],
+  },
   // Queue consumers import native/dynamic-require packages that webpack
   // can't statically analyse — resolve them at runtime instead.
   serverExternalPackages: [

--- a/apps/nextjs/src/app/[locale]/dog/[id]/fonts.ts
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/fonts.ts
@@ -1,0 +1,40 @@
+import localFont from "next/font/local";
+
+/**
+ * The app is set in Gilroy (see `packages/shared/themes/themes.ts`); the
+ * rest of this site is Epilogue (`src/app/layout.tsx`). Loaded here, not in
+ * the root layout, so only the share page — which exists to look like the
+ * app it is advertising — pays for it. The weights below are the ones this
+ * page actually sets: body copy in medium, the CTA and tagline in semibold,
+ * the dog's name and headline in bold/extrabold.
+ *
+ * The TTFs live in `packages/shared/themes/fonts`, outside this app. That
+ * path survives `next build` (verified via `pnpm -F @pegada/nextjs build`),
+ * so there was no need to duplicate the files under `src/fonts`.
+ */
+export const gilroy = localFont({
+  variable: "--font-gilroy",
+  display: "swap",
+  src: [
+    {
+      path: "../../../../../../../packages/shared/themes/fonts/Gilroy-Medium.ttf",
+      weight: "500",
+      style: "normal",
+    },
+    {
+      path: "../../../../../../../packages/shared/themes/fonts/Gilroy-SemiBold.ttf",
+      weight: "600",
+      style: "normal",
+    },
+    {
+      path: "../../../../../../../packages/shared/themes/fonts/Gilroy-Bold.ttf",
+      weight: "700",
+      style: "normal",
+    },
+    {
+      path: "../../../../../../../packages/shared/themes/fonts/Gilroy-ExtraBold.ttf",
+      weight: "800",
+      style: "normal",
+    },
+  ],
+});

--- a/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
@@ -29,6 +29,7 @@ export const getDog = cache((id: string) => {
       name: true,
       bio: true,
       birthDate: true,
+      gender: true,
       breed: { select: { name: true, slug: true } },
       images: {
         where: { status: IMAGE_STATUS.APPROVED },
@@ -43,6 +44,22 @@ export const getDog = cache((id: string) => {
 export type Dog = NonNullable<Awaited<ReturnType<typeof getDog>>>;
 
 export const getDogImage = (dog: Dog) => dog.images[0]?.url;
+
+/**
+ * pt-BR needs a gendered article ("O Rex" / "A Bella") that English has no
+ * use for. `gender` is a required column, not inferred from the name, so
+ * this is safe to key off directly.
+ */
+export const getDogArticle = (dog: Dog) =>
+  dog.gender === "FEMALE" ? "A" : "O";
+
+/**
+ * pt-BR "quem cuida dela" / "quem cuida dele" needs a gendered object
+ * pronoun that English has no use for. Keyed off the required `gender`
+ * column, same as `getDogArticle`.
+ */
+export const getDogPronoun = (dog: Dog) =>
+  dog.gender === "FEMALE" ? "dela" : "dele";
 
 /** "Golden Retriever • 2 anos" — skips whichever half is missing. */
 export const getDogTagline = (dog: Dog, lng: string) => {

--- a/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
@@ -10,9 +10,10 @@ import { getFormattedYears } from "@pegada/shared/utils/get-formatted-years";
 import { t } from "@/lib/translate";
 
 /**
- * Shared by the page's `generateMetadata`, the page body, and
- * `opengraph-image.tsx` — all three render for the same request, and
- * `cache()` collapses them into a single Prisma query instead of three.
+ * Shared by the page's `generateMetadata` and the page body: both render
+ * within the same request, so `cache()` collapses them into a single Prisma
+ * query instead of two. `opengraph-image.tsx` is fetched by scrapers as its
+ * own separate HTTP request, so it makes its own query regardless.
  */
 export const getDog = cache((id: string) => {
   return prisma.dog.findFirst({
@@ -64,7 +65,7 @@ export const getDogPronoun = (dog: Dog) =>
 /** "Golden Retriever • 2 anos" — skips whichever half is missing. */
 export const getDogTagline = (dog: Dog, lng: string) => {
   const breedName = dog.breed
-    ? t(dog.breed.slug as BreedSlug, { ns: Namespace.Breed })
+    ? t(dog.breed.slug as BreedSlug, { ns: Namespace.Breed, lng })
     : undefined;
   const age = dog.birthDate
     ? getFormattedYears({ birthDate: dog.birthDate, lng })
@@ -75,7 +76,7 @@ export const getDogTagline = (dog: Dog, lng: string) => {
 
 /** Meta description: tagline + bio, then a fixed CTA-ish suffix. */
 export const getDogDescription = (dog: Dog, lng: string) => {
-  const suffix = t("dog.metadata.descriptionSuffix", { name: dog.name });
+  const suffix = t("dog.metadata.descriptionSuffix", { name: dog.name, lng });
   const lead = [getDogTagline(dog, lng), dog.bio]
     .filter(Boolean)
     .join(" — ")

--- a/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
@@ -1,0 +1,68 @@
+import type { BreedSlug } from "@pegada/shared/i18n/i18n";
+
+import { cache } from "react";
+
+import prisma from "@pegada/database";
+import { Namespace } from "@pegada/shared/i18n/types/types";
+import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
+import { getFormattedYears } from "@pegada/shared/utils/get-formatted-years";
+
+import { t } from "@/lib/translate";
+
+/**
+ * Shared by the page's `generateMetadata`, the page body, and
+ * `opengraph-image.tsx` — all three render for the same request, and
+ * `cache()` collapses them into a single Prisma query instead of three.
+ */
+export const getDog = cache((id: string) => {
+  return prisma.dog.findFirst({
+    where: {
+      id,
+      banned: false,
+      deletedAt: null,
+      images: {
+        some: { status: IMAGE_STATUS.APPROVED },
+        none: { status: IMAGE_STATUS.REJECTED },
+      },
+    },
+    select: {
+      name: true,
+      bio: true,
+      birthDate: true,
+      breed: { select: { name: true, slug: true } },
+      images: {
+        where: { status: IMAGE_STATUS.APPROVED },
+        orderBy: { position: "asc" },
+        take: 1,
+        select: { url: true },
+      },
+    },
+  });
+});
+
+export type Dog = NonNullable<Awaited<ReturnType<typeof getDog>>>;
+
+export const getDogImage = (dog: Dog) => dog.images[0]?.url;
+
+/** "Golden Retriever • 2 anos" — skips whichever half is missing. */
+export const getDogTagline = (dog: Dog, lng: string) => {
+  const breedName = dog.breed
+    ? t(dog.breed.slug as BreedSlug, { ns: Namespace.Breed })
+    : undefined;
+  const age = dog.birthDate
+    ? getFormattedYears({ birthDate: dog.birthDate, lng })
+    : undefined;
+
+  return [breedName, age].filter(Boolean).join(" • ");
+};
+
+/** Meta description: tagline + bio, then a fixed CTA-ish suffix. */
+export const getDogDescription = (dog: Dog, lng: string) => {
+  const suffix = t("dog.metadata.descriptionSuffix", { name: dog.name });
+  const lead = [getDogTagline(dog, lng), dog.bio]
+    .filter(Boolean)
+    .join(" — ")
+    .replace(/[.\s]+$/, "");
+
+  return lead ? `${lead}. ${suffix}` : suffix;
+};

--- a/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/get-dog.ts
@@ -55,12 +55,37 @@ export const getDogArticle = (dog: Dog) =>
   dog.gender === "FEMALE" ? "A" : "O";
 
 /**
- * pt-BR "quem cuida dela" / "quem cuida dele" needs a gendered object
- * pronoun that English has no use for. Keyed off the required `gender`
- * column, same as `getDogArticle`.
+ * Same article as `getDogArticle`, lowercased for mid-sentence use ("Curtir
+ * a Bella") where the sentence-initial capital would be wrong.
  */
-export const getDogPronoun = (dog: Dog) =>
-  dog.gender === "FEMALE" ? "dela" : "dele";
+export const getDogArticleLowercase = (dog: Dog) =>
+  getDogArticle(dog).toLowerCase();
+
+/**
+ * "quem cuida dela" / "quem cuida dele" (pt-BR) and "looks after her" /
+ * "looks after him" (English) both need a gendered object pronoun, keyed
+ * off the required `gender` column.
+ */
+export const getDogPronoun = (dog: Dog, lng: string) => {
+  const isPtBr = lng.toLowerCase().startsWith("pt");
+
+  if (isPtBr) return dog.gender === "FEMALE" ? "dela" : "dele";
+
+  return dog.gender === "FEMALE" ? "her" : "him";
+};
+
+/**
+ * "Ela quer fazer amigos" / "Ele quer fazer amigos" (pt-BR) and "She wants"
+ * / "He wants" (English): a sentence-initial subject pronoun, so it comes
+ * back capitalized. Keyed off the required `gender` column.
+ */
+export const getDogSubjectPronoun = (dog: Dog, lng: string) => {
+  const isPtBr = lng.toLowerCase().startsWith("pt");
+
+  if (isPtBr) return dog.gender === "FEMALE" ? "Ela" : "Ele";
+
+  return dog.gender === "FEMALE" ? "She" : "He";
+};
 
 /** "Golden Retriever • 2 anos" — skips whichever half is missing. */
 export const getDogTagline = (dog: Dog, lng: string) => {

--- a/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
@@ -1,0 +1,161 @@
+import { ImageResponse } from "next/og";
+
+import { getSafeLocale } from "@/lib/get-safe-locale";
+import { t } from "@/lib/translate";
+
+import { getDog, getDogImage, getDogTagline } from "./get-dog";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Same brand tokens as `@pegada/shared/themes/themes` (`LightTheme.colors`),
+// converted to hex: satori renders these outside Tailwind/PostCSS, so the CSS
+// vars/utility classes the rest of the app uses aren't available here.
+const COLORS = {
+  primary: "#EF62A1",
+  secondary: "#FDE8F1",
+  background: "#FFFFFF",
+  text: "#0F172A",
+  subtitle: "#5A5F6D",
+};
+
+// Hoisted to module scope, not inlined in JSX: every value below is static
+// (only the text nodes vary per dog), so building these once avoids a fresh
+// object per render for no reason — same object, every time.
+const containerStyle = {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  alignItems: "center",
+  gap: 56,
+  padding: 64,
+  background: `linear-gradient(135deg, ${COLORS.secondary} 0%, ${COLORS.background} 70%)`,
+} as const;
+
+const fallbackContainerStyle = {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 24,
+  background: `linear-gradient(135deg, ${COLORS.secondary} 0%, ${COLORS.background} 65%)`,
+} as const;
+
+const photoFrameStyle = {
+  width: 440,
+  height: 502,
+  borderRadius: 32,
+  overflow: "hidden",
+  display: "flex",
+  flexShrink: 0,
+  transform: "rotate(-3deg)",
+  boxShadow: "0 24px 48px rgba(15, 23, 42, 0.25)",
+  border: `10px solid ${COLORS.background}`,
+  background: COLORS.secondary,
+} as const;
+
+const photoImgStyle = { objectFit: "cover" } as const;
+
+const detailsStyle = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 20,
+  flex: 1,
+} as const;
+
+const wordmarkStyle = {
+  fontSize: 36,
+  fontWeight: 800,
+  color: COLORS.primary,
+  display: "flex",
+} as const;
+
+const fallbackWordmarkStyle = { ...wordmarkStyle, fontSize: 72 } as const;
+
+const nameStyle = {
+  fontSize: 76,
+  fontWeight: 800,
+  color: COLORS.text,
+  lineHeight: 1.05,
+  display: "flex",
+} as const;
+
+const taglineStyle = {
+  fontSize: 34,
+  color: COLORS.subtitle,
+  display: "flex",
+} as const;
+
+const fallbackTaglineStyle = { ...taglineStyle, fontSize: 32 } as const;
+
+const tagStyle = {
+  display: "flex",
+  marginTop: 12,
+  padding: "14px 28px",
+  borderRadius: 9999,
+  background: COLORS.primary,
+  color: COLORS.background,
+  fontSize: 26,
+  fontWeight: 600,
+  alignSelf: "flex-start",
+} as const;
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+/** Branded card with no dog-specific data, for a missing/removed profile. */
+const buildFallbackImage = () =>
+  new ImageResponse(
+    (
+      <div style={fallbackContainerStyle}>
+        <div style={fallbackWordmarkStyle}>Pegada</div>
+        <div style={fallbackTaglineStyle}>{t("home.title")}</div>
+      </div>
+    ),
+    size,
+  );
+
+const Image = async ({ params }: Props) => {
+  const { id } = await params;
+  const dog = await getDog(id);
+
+  if (!dog) {
+    return buildFallbackImage();
+  }
+
+  const lng = getSafeLocale();
+  const dogImage = getDogImage(dog);
+  const tagline = getDogTagline(dog, lng);
+
+  return new ImageResponse(
+    (
+      <div style={containerStyle}>
+        <div style={photoFrameStyle}>
+          {dogImage ? (
+            // oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image
+            <img
+              src={dogImage}
+              width={440}
+              height={502}
+              alt=""
+              style={photoImgStyle}
+            />
+          ) : null}
+        </div>
+
+        <div style={detailsStyle}>
+          <div style={wordmarkStyle}>Pegada</div>
+          <div style={nameStyle}>{dog.name}</div>
+          {tagline ? <div style={taglineStyle}>{tagline}</div> : null}
+          <div style={tagStyle}>{t("dog.og.tag")}</div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+};
+
+export default Image;

--- a/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
 import { ImageResponse } from "next/og";
 
 import { getSafeLocale } from "@/lib/get-safe-locale";
@@ -19,6 +22,47 @@ const COLORS = {
   subtitle: "#5A5F6D",
 };
 
+// Read once at module scope, same as the docs example for `ImageResponse`
+// fonts (`readFile` + `process.cwd()`), not per-request: font data never
+// changes between requests. `process.cwd()` is `apps/nextjs` in both `next
+// dev` and `next build`/the deployed function, so two `..` reaches the repo
+// root and into the same `packages/shared/themes/fonts` the app itself
+// loads its Gilroy weights from.
+const FONTS_DIR = join(
+  process.cwd(),
+  "..",
+  "..",
+  "packages",
+  "shared",
+  "themes",
+  "fonts",
+);
+
+const LOGO_PATH = join(process.cwd(), "public", "logo.svg");
+
+const [gilroyMedium, gilroySemiBold, gilroyExtraBold, logoSvg] =
+  await Promise.all([
+    readFile(join(FONTS_DIR, "Gilroy-Medium.ttf")),
+    readFile(join(FONTS_DIR, "Gilroy-SemiBold.ttf")),
+    readFile(join(FONTS_DIR, "Gilroy-ExtraBold.ttf")),
+    readFile(LOGO_PATH, "utf8"),
+  ]);
+
+// Satori (`next/og`'s renderer) only reliably draws an `<img>` from a data
+// URI, not an arbitrary `src` path — the actual brand mark
+// (`public/logo.svg`, the heart-shaped paw), inlined this way, is what makes
+// this a logo instead of the word "Pegada" set in a font.
+const logoBase64 = Buffer.from(logoSvg).toString("base64");
+const LOGO_DATA_URI = `data:image/svg+xml;base64,${logoBase64}`;
+
+const OG_FONTS = [
+  { name: "Gilroy", data: gilroyMedium, weight: 500, style: "normal" },
+  { name: "Gilroy", data: gilroySemiBold, weight: 600, style: "normal" },
+  { name: "Gilroy", data: gilroyExtraBold, weight: 800, style: "normal" },
+] satisfies NonNullable<
+  ConstructorParameters<typeof ImageResponse>[1]
+>["fonts"];
+
 // Hoisted to module scope, not inlined in JSX: every value below is static
 // (only the text nodes vary per dog), so building these once avoids a fresh
 // object per render for no reason — same object, every time.
@@ -39,7 +83,7 @@ const fallbackContainerStyle = {
   flexDirection: "column",
   alignItems: "center",
   justifyContent: "center",
-  gap: 24,
+  gap: 20,
   background: `linear-gradient(135deg, ${COLORS.secondary} 0%, ${COLORS.background} 65%)`,
 } as const;
 
@@ -65,18 +109,37 @@ const detailsStyle = {
   flex: 1,
 } as const;
 
+// The lockup: the real mark (an `<img>` of `public/logo.svg`, see
+// `LOGO_DATA_URI` above) next to the wordmark, in the same Gilroy ExtraBold
+// the app itself sets its brand name in. Neither one alone is the logo.
+const brandRowStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+} as const;
+
+const logoMarkStyle = { width: 40, height: 42, display: "flex" } as const;
+
+const fallbackLogoMarkStyle = {
+  width: 108,
+  height: 113,
+  display: "flex",
+} as const;
+
 const wordmarkStyle = {
-  fontSize: 36,
+  fontSize: 32,
   fontWeight: 800,
+  fontFamily: "Gilroy",
   color: COLORS.primary,
   display: "flex",
 } as const;
 
-const fallbackWordmarkStyle = { ...wordmarkStyle, fontSize: 72 } as const;
+const fallbackWordmarkStyle = { ...wordmarkStyle, fontSize: 56 } as const;
 
 const nameStyle = {
   fontSize: 76,
   fontWeight: 800,
+  fontFamily: "Gilroy",
   color: COLORS.text,
   lineHeight: 1.05,
   display: "flex",
@@ -84,21 +147,24 @@ const nameStyle = {
 
 const taglineStyle = {
   fontSize: 34,
+  fontWeight: 500,
+  fontFamily: "Gilroy",
   color: COLORS.subtitle,
   display: "flex",
 } as const;
 
-const fallbackTaglineStyle = { ...taglineStyle, fontSize: 32 } as const;
+const fallbackTaglineStyle = { ...taglineStyle, fontSize: 30 } as const;
 
 const tagStyle = {
   display: "flex",
   marginTop: 12,
-  padding: "14px 28px",
+  padding: "16px 30px",
   borderRadius: 9999,
-  background: COLORS.primary,
+  background: `linear-gradient(135deg, #FF81BD 0%, ${COLORS.primary} 100%)`,
   color: COLORS.background,
   fontSize: 26,
   fontWeight: 600,
+  fontFamily: "Gilroy",
   alignSelf: "flex-start",
 } as const;
 
@@ -106,14 +172,28 @@ type Props = {
   params: Promise<{ id: string }>;
 };
 
+type LogoStyle = { width: number; height: number; display: "flex" };
+
+const LogoMark = (props: { style: LogoStyle }) => (
+  // oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image
+  <img
+    src={LOGO_DATA_URI}
+    width={props.style.width}
+    height={props.style.height}
+    alt=""
+    style={props.style}
+  />
+);
+
 /** Branded card with no dog-specific data, for a missing/removed profile. */
 const buildFallbackImage = () =>
   new ImageResponse(
     <div style={fallbackContainerStyle}>
+      <LogoMark style={fallbackLogoMarkStyle} />
       <div style={fallbackWordmarkStyle}>Pegada</div>
       <div style={fallbackTaglineStyle}>{t("home.title")}</div>
     </div>,
-    size,
+    { ...size, fonts: OG_FONTS },
   );
 
 const Image = async ({ params }: Props) => {
@@ -144,13 +224,16 @@ const Image = async ({ params }: Props) => {
       </div>
 
       <div style={detailsStyle}>
-        <div style={wordmarkStyle}>Pegada</div>
+        <div style={brandRowStyle}>
+          <LogoMark style={logoMarkStyle} />
+          <div style={wordmarkStyle}>Pegada</div>
+        </div>
         <div style={nameStyle}>{dog.name}</div>
         {tagline ? <div style={taglineStyle}>{tagline}</div> : null}
         <div style={tagStyle}>{t("dog.og.tag")}</div>
       </div>
     </div>,
-    size,
+    { ...size, fonts: OG_FONTS },
   );
 };
 

--- a/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
@@ -8,6 +8,11 @@ import { t } from "@/lib/translate";
 
 import { getDog, getDogImage, getDogTagline } from "./get-dog";
 
+// Explicit, not the segment default: this route reads the Gilroy font files
+// off disk (`node:fs/promises`, `process.cwd()`) and queries the dog via
+// Prisma, both Node-only, so it needs the Node runtime rather than Edge.
+export const runtime = "nodejs";
+
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -204,23 +209,28 @@ const Image = async ({ params }: Props) => {
     return buildFallbackImage();
   }
 
-  const lng = getSafeLocale();
   const dogImage = getDogImage(dog);
+
+  // `getDog`'s `where` already requires an approved image, so this is
+  // belt and braces rather than a case that fires in practice.
+  if (!dogImage) {
+    return buildFallbackImage();
+  }
+
+  const lng = getSafeLocale();
   const tagline = getDogTagline(dog, lng);
 
   return new ImageResponse(
     <div style={containerStyle}>
       <div style={photoFrameStyle}>
-        {dogImage ? (
-          // oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image
-          <img
-            src={dogImage}
-            width={440}
-            height={502}
-            alt=""
-            style={photoImgStyle}
-          />
-        ) : null}
+        {/* oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image */}
+        <img
+          src={dogImage}
+          width={440}
+          height={502}
+          alt=""
+          style={photoImgStyle}
+        />
       </div>
 
       <div style={detailsStyle}>

--- a/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
@@ -109,12 +109,10 @@ type Props = {
 /** Branded card with no dog-specific data, for a missing/removed profile. */
 const buildFallbackImage = () =>
   new ImageResponse(
-    (
-      <div style={fallbackContainerStyle}>
-        <div style={fallbackWordmarkStyle}>Pegada</div>
-        <div style={fallbackTaglineStyle}>{t("home.title")}</div>
-      </div>
-    ),
+    <div style={fallbackContainerStyle}>
+      <div style={fallbackWordmarkStyle}>Pegada</div>
+      <div style={fallbackTaglineStyle}>{t("home.title")}</div>
+    </div>,
     size,
   );
 
@@ -131,29 +129,27 @@ const Image = async ({ params }: Props) => {
   const tagline = getDogTagline(dog, lng);
 
   return new ImageResponse(
-    (
-      <div style={containerStyle}>
-        <div style={photoFrameStyle}>
-          {dogImage ? (
-            // oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image
-            <img
-              src={dogImage}
-              width={440}
-              height={502}
-              alt=""
-              style={photoImgStyle}
-            />
-          ) : null}
-        </div>
-
-        <div style={detailsStyle}>
-          <div style={wordmarkStyle}>Pegada</div>
-          <div style={nameStyle}>{dog.name}</div>
-          {tagline ? <div style={taglineStyle}>{tagline}</div> : null}
-          <div style={tagStyle}>{t("dog.og.tag")}</div>
-        </div>
+    <div style={containerStyle}>
+      <div style={photoFrameStyle}>
+        {dogImage ? (
+          // oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image
+          <img
+            src={dogImage}
+            width={440}
+            height={502}
+            alt=""
+            style={photoImgStyle}
+          />
+        ) : null}
       </div>
-    ),
+
+      <div style={detailsStyle}>
+        <div style={wordmarkStyle}>Pegada</div>
+        <div style={nameStyle}>{dog.name}</div>
+        {tagline ? <div style={taglineStyle}>{tagline}</div> : null}
+        <div style={tagStyle}>{t("dog.og.tag")}</div>
+      </div>
+    </div>,
     size,
   );
 };

--- a/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
@@ -45,10 +45,11 @@ const FONTS_DIR = join(
 
 const LOGO_PATH = join(process.cwd(), "public", "logo.svg");
 
-const [gilroyMedium, gilroySemiBold, gilroyExtraBold, logoSvg] =
+const [gilroyMedium, gilroySemiBold, gilroyBold, gilroyExtraBold, logoSvg] =
   await Promise.all([
     readFile(join(FONTS_DIR, "Gilroy-Medium.ttf")),
     readFile(join(FONTS_DIR, "Gilroy-SemiBold.ttf")),
+    readFile(join(FONTS_DIR, "Gilroy-Bold.ttf")),
     readFile(join(FONTS_DIR, "Gilroy-ExtraBold.ttf")),
     readFile(LOGO_PATH, "utf8"),
   ]);
@@ -63,6 +64,7 @@ const LOGO_DATA_URI = `data:image/svg+xml;base64,${logoBase64}`;
 const OG_FONTS = [
   { name: "Gilroy", data: gilroyMedium, weight: 500, style: "normal" },
   { name: "Gilroy", data: gilroySemiBold, weight: 600, style: "normal" },
+  { name: "Gilroy", data: gilroyBold, weight: 700, style: "normal" },
   { name: "Gilroy", data: gilroyExtraBold, weight: 800, style: "normal" },
 ] satisfies NonNullable<
   ConstructorParameters<typeof ImageResponse>[1]
@@ -160,15 +162,20 @@ const taglineStyle = {
 
 const fallbackTaglineStyle = { ...taglineStyle, fontSize: 30 } as const;
 
+// Matches the app's primary button (`apps/mobile/src/components/button`:
+// flat `theme.colors.primary` fill, white text, Gilroy Bold) rather than a
+// bespoke badge, per Gabriel's review note. Padding/height are scaled up
+// from the button's own 68px-tall, 16px-padded footprint to read as a real
+// button at this canvas's size instead of a small pill.
 const tagStyle = {
   display: "flex",
   marginTop: 12,
-  padding: "16px 30px",
+  padding: "20px 40px",
   borderRadius: 9999,
-  background: `linear-gradient(135deg, #FF81BD 0%, ${COLORS.primary} 100%)`,
+  background: COLORS.primary,
   color: COLORS.background,
-  fontSize: 26,
-  fontWeight: 600,
+  fontSize: 28,
+  fontWeight: 700,
   fontFamily: "Gilroy",
   alignSelf: "flex-start",
 } as const;

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -14,9 +14,11 @@ import { gilroy } from "./fonts";
 import {
   getDog,
   getDogArticle,
+  getDogArticleLowercase,
   getDogDescription,
   getDogImage,
   getDogPronoun,
+  getDogSubjectPronoun,
   getDogTagline,
 } from "./get-dog";
 
@@ -66,7 +68,18 @@ const DogProfile = async ({ params }: DogProfileProps) => {
     name: dog.name,
     article: getDogArticle(dog),
   });
-  const nextStep = t("dog.hero.nextStep", { pronoun: getDogPronoun(dog) });
+  const nextStep = t("dog.hero.nextStep", {
+    name: dog.name,
+    article: getDogArticleLowercase(dog),
+    pronoun: getDogPronoun(dog, lng),
+  });
+  const ctaButton = t("dog.cta.button", {
+    name: dog.name,
+    article: getDogArticleLowercase(dog),
+  });
+  const mobileContext = t("dog.cta.mobileContext", {
+    pronoun: getDogSubjectPronoun(dog, lng),
+  });
 
   return (
     <div
@@ -174,7 +187,7 @@ const DogProfile = async ({ params }: DogProfileProps) => {
               href="/store"
               className="rounded-full bg-primary px-8 py-4 font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
             >
-              {t("dog.cta.button")}
+              {ctaButton}
             </a>
             <p className="text-sm font-light text-subtitle/80">
               {t("dog.cta.reassurance")}
@@ -186,14 +199,14 @@ const DogProfile = async ({ params }: DogProfileProps) => {
       {/* Mobile sticky CTA bar. `main`'s bottom padding above reserves room for it so it never covers the card. */}
       <div className="fixed inset-x-0 bottom-0 z-20 flex items-center justify-between gap-4 border-t border-border bg-white/95 px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3 shadow-[0_-8px_30px_-15px_rgba(15,23,42,0.2)] backdrop-blur md:hidden">
         <p className="flex-1 truncate text-sm font-medium text-text">
-          {t("dog.cta.mobileContext")}
+          {mobileContext}
         </p>
         {/* oxlint-disable-next-line next/no-html-link-for-pages -- /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to. */}
         <a
           href="/store"
           className="shrink-0 rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
         >
-          {t("dog.cta.button")}
+          {ctaButton}
         </a>
       </div>
     </div>

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -73,7 +73,7 @@ const DogProfile = async ({ params }: DogProfileProps) => {
   const dogImageStyle = { backgroundImage: `url(${dogImage})` };
 
   return (
-    <div className="pt-8 pb-12 space-y-8 flex flex-1 flex-col px-4 items-center min-h-screen">
+    <div className="pt-8 md:pt-6 pb-12 space-y-8 md:space-y-4 flex flex-1 flex-col px-4 items-center min-h-screen">
       {/* oxlint-disable-next-line nextjs/no-img-element -- A static SVG needs no next/image pipeline. */}
       <img
         src="/logo.svg"
@@ -82,7 +82,15 @@ const DogProfile = async ({ params }: DogProfileProps) => {
         className="h-12 select-none"
       />
 
-      <div className="relative rounded-lg border border-border flex flex-col overflow-hidden w-full max-w-xl aspect-[4/5]">
+      {/*
+       * `aspect-[4/5]` is what makes this a tall hero on mobile, where it's
+       * the only thing above the fold. On a laptop viewport that same ratio
+       * pushes the CTA below the fold, so `md:h-[46vh]` gives it a fixed,
+       * shorter height there instead (dropping the aspect ratio so it
+       * doesn't fight that height) — width still comes from `w-full
+       * max-w-xl`, so the card just reads a little wider/shorter.
+       */}
+      <div className="relative rounded-lg border border-border flex flex-col overflow-hidden w-full max-w-xl aspect-[4/5] md:aspect-auto md:h-[46vh]">
         <div style={dogImageStyle} className="flex flex-1 bg-cover bg-center">
           {Boolean(dog.breed?.name) && (
             <div className="border border-border/70 rounded-md p-2 py-1 m-4 bg-background/50 backdrop-blur ml-auto mb-auto font-semibold">
@@ -101,15 +109,15 @@ const DogProfile = async ({ params }: DogProfileProps) => {
         </div>
       </div>
 
-      <div className="w-full max-w-xl bg-secondary rounded-lg border border-border/70 flex flex-col items-center gap-4 p-8 text-center">
-        <h2 className="text-3xl font-extrabold text-text">
+      <div className="w-full max-w-xl bg-secondary rounded-lg border border-border/70 flex flex-col items-center gap-4 md:gap-3 p-8 md:p-6 text-center">
+        <h2 className="text-3xl md:text-2xl font-extrabold text-text">
           {t("dog.cta.title")}
         </h2>
         <p className="text-subtitle">{t("dog.cta.description")}</p>
         {/* oxlint-disable-next-line next/no-html-link-for-pages -- /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to. */}
         <a
           href="/store"
-          className="bg-primary text-white font-semibold rounded-full px-8 py-4 hover:scale-105 transition-transform duration-200 ease-in-out"
+          className="bg-primary text-white font-semibold rounded-full px-8 py-4 md:px-6 md:py-3 hover:scale-105 transition-transform duration-200 ease-in-out"
         >
           {t("dog.cta.button")}
         </a>

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -1,16 +1,17 @@
 import type { BreedSlug } from "@pegada/shared/i18n/i18n";
+import type { Metadata } from "next";
 
 import { preload } from "react-dom";
 
 import { notFound } from "next/navigation";
 
-import prisma from "@pegada/database";
 import { Namespace } from "@pegada/shared/i18n/types/types";
-import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
 import { getFormattedYears } from "@pegada/shared/utils/get-formatted-years";
 
 import { getSafeLocale } from "@/lib/get-safe-locale";
 import { t } from "@/lib/translate";
+
+import { getDog, getDogDescription, getDogImage } from "./get-dog";
 
 type DogProfileProps = {
   params: Promise<{
@@ -18,44 +19,41 @@ type DogProfileProps = {
   }>;
 };
 
-export const metadata = {
-  robots: { index: false, follow: false },
+export const generateMetadata = async ({
+  params,
+}: DogProfileProps): Promise<Metadata> => {
+  const { id } = await params;
+  const dog = await getDog(id);
+
+  // Never indexed either way — this is a share card, not a landing page —
+  // but a missing dog still needs a title/description that isn't "undefined".
+  if (!dog) {
+    return { robots: { index: false, follow: false } };
+  }
+
+  const lng = getSafeLocale();
+  const title = t("dog.metadata.title", { name: dog.name });
+  const description = getDogDescription(dog, lng);
+
+  return {
+    title,
+    description,
+    robots: { index: false, follow: false },
+    openGraph: { title, description, type: "profile" },
+    twitter: { card: "summary_large_image" },
+  };
 };
 
 const DogProfile = async ({ params }: DogProfileProps) => {
   const { id } = await params;
-  const dog = await prisma.dog.findFirst({
-    where: {
-      id,
-      banned: false,
-      deletedAt: null,
-      images: {
-        some: { status: IMAGE_STATUS.APPROVED },
-        none: { status: IMAGE_STATUS.REJECTED },
-      },
-    },
-    select: {
-      name: true,
-      bio: true,
-      birthDate: true,
-      breed: { select: { name: true, slug: true } },
-      images: {
-        where: { status: IMAGE_STATUS.APPROVED },
-        orderBy: { position: "asc" },
-        take: 1,
-        select: { url: true },
-      },
-    },
-  });
-
+  const dog = await getDog(id);
   const lng = getSafeLocale();
 
   if (!dog) {
     return notFound();
   }
 
-  const [firstImage] = dog.images;
-  const dogImage = firstImage?.url;
+  const dogImage = getDogImage(dog);
 
   // This photo is the page: it is the LCP element on every /dog/[id] view, and
   // it is a CSS `background-image`, which the browser's preload scanner cannot
@@ -75,7 +73,7 @@ const DogProfile = async ({ params }: DogProfileProps) => {
   const dogImageStyle = { backgroundImage: `url(${dogImage})` };
 
   return (
-    <div className="pt-8 space-y-8 flex flex-1 flex-col px-4 items-center pb-4 h-[100vh]">
+    <div className="pt-8 pb-12 space-y-8 flex flex-1 flex-col px-4 items-center min-h-screen">
       {/* oxlint-disable-next-line nextjs/no-img-element -- A static SVG needs no next/image pipeline. */}
       <img
         src="/logo.svg"
@@ -84,7 +82,7 @@ const DogProfile = async ({ params }: DogProfileProps) => {
         className="h-12 select-none"
       />
 
-      <div className="relative rounded-lg border border-border flex flex-col overflow-hidden flex-1 w-full max-w-xl">
+      <div className="relative rounded-lg border border-border flex flex-col overflow-hidden w-full max-w-xl aspect-[4/5]">
         <div style={dogImageStyle} className="flex flex-1 bg-cover bg-center">
           {Boolean(dog.breed?.name) && (
             <div className="border border-border/70 rounded-md p-2 py-1 m-4 bg-background/50 backdrop-blur ml-auto mb-auto font-semibold">
@@ -101,6 +99,20 @@ const DogProfile = async ({ params }: DogProfileProps) => {
           </p>
           <p>{dog.bio}</p>
         </div>
+      </div>
+
+      <div className="w-full max-w-xl bg-secondary rounded-lg border border-border/70 flex flex-col items-center gap-4 p-8 text-center">
+        <h2 className="text-3xl font-extrabold text-text">
+          {t("dog.cta.title")}
+        </h2>
+        <p className="text-subtitle">{t("dog.cta.description")}</p>
+        {/* oxlint-disable-next-line next/no-html-link-for-pages -- /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to. */}
+        <a
+          href="/store"
+          className="bg-primary text-white font-semibold rounded-full px-8 py-4 hover:scale-105 transition-transform duration-200 ease-in-out"
+        >
+          {t("dog.cta.button")}
+        </a>
       </div>
     </div>
   );

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -1,17 +1,22 @@
 import type { BreedSlug } from "@pegada/shared/i18n/i18n";
-import type { Metadata } from "next";
 
-import { preload } from "react-dom";
+import type { Metadata } from "next";
 
 import { notFound } from "next/navigation";
 
 import { Namespace } from "@pegada/shared/i18n/types/types";
-import { getFormattedYears } from "@pegada/shared/utils/get-formatted-years";
 
 import { getSafeLocale } from "@/lib/get-safe-locale";
 import { t } from "@/lib/translate";
 
-import { getDog, getDogDescription, getDogImage } from "./get-dog";
+import {
+  getDog,
+  getDogArticle,
+  getDogDescription,
+  getDogImage,
+  getDogPronoun,
+  getDogTagline,
+} from "./get-dog";
 
 type DogProfileProps = {
   params: Promise<{
@@ -54,70 +59,124 @@ const DogProfile = async ({ params }: DogProfileProps) => {
   }
 
   const dogImage = getDogImage(dog);
-
-  // This photo is the page: it is the LCP element on every /dog/[id] view, and
-  // it is a CSS `background-image`, which the browser's preload scanner cannot
-  // see. It is only discovered after the stylesheet has been fetched and the
-  // rule has matched, so the request starts late no matter how fast the HTML
-  // is. `preload` emits a hoisted `<link rel="preload" as="image">` in <head>,
-  // which puts the fetch in the very first round of requests.
-  //
-  // Deliberately not `next/image`: this URL is on the media CDN and
-  // `images.remotePatterns` is not configured, so switching would mean routing
-  // user photos through the optimiser — a bigger change than an LCP fix needs.
-  if (dogImage) {
-    preload(dogImage, { as: "image", fetchPriority: "high" });
-  }
-
-  // oxlint-disable-next-line react-perf/jsx-no-new-object-as-prop -- server component: this renders once per request, there is no re-render to memoise against
-  const dogImageStyle = { backgroundImage: `url(${dogImage})` };
+  const tagline = getDogTagline(dog, lng);
+  const invite = t("dog.hero.invite", {
+    name: dog.name,
+    article: getDogArticle(dog),
+  });
+  const nextStep = t("dog.hero.nextStep", { pronoun: getDogPronoun(dog) });
 
   return (
-    <div className="pt-8 md:pt-6 pb-12 space-y-8 md:space-y-4 flex flex-1 flex-col px-4 items-center min-h-screen">
-      {/* oxlint-disable-next-line nextjs/no-img-element -- A static SVG needs no next/image pipeline. */}
-      <img
-        src="/logo.svg"
-        draggable="false"
-        alt=""
-        className="h-12 select-none"
+    <div className="relative flex min-h-screen flex-col overflow-hidden bg-[#FFF9FB]">
+      {/*
+       * The only decoration on the page: a soft echo of the brand gradient
+       * (see public/logo.svg) blooming behind the card. Everything else here
+       * stays plain so the photo keeps the attention.
+       */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute left-1/2 top-[10%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(255,129,189,0.14)_0%,rgba(251,110,144,0.05)_45%,rgba(255,129,189,0)_72%)] blur-2xl md:left-[30%] md:top-1/2 md:h-[720px] md:w-[720px] md:-translate-y-1/2"
       />
 
       {/*
-       * `aspect-[4/5]` is what makes this a tall hero on mobile, where it's
-       * the only thing above the fold. On a laptop viewport that same ratio
-       * pushes the CTA below the fold, so `md:h-[46vh]` gives it a fixed,
-       * shorter height there instead (dropping the aspect ratio so it
-       * doesn't fight that height) — width still comes from `w-full
-       * max-w-xl`, so the card just reads a little wider/shorter.
+       * Centred on a phone, where the card sits directly underneath it, and
+       * pinned to the left of the same container as `main` on a desktop, so
+       * it reads as the page's header instead of floating over the gap
+       * between the two columns.
        */}
-      <div className="relative rounded-lg border border-border flex flex-col overflow-hidden w-full max-w-xl aspect-[4/5] md:aspect-auto md:h-[46vh]">
-        <div style={dogImageStyle} className="flex flex-1 bg-cover bg-center">
-          {Boolean(dog.breed?.name) && (
-            <div className="border border-border/70 rounded-md p-2 py-1 m-4 bg-background/50 backdrop-blur ml-auto mb-auto font-semibold">
-              {t(`${dog.breed?.slug as BreedSlug}`, { ns: Namespace.Breed })}
-            </div>
-          )}
-        </div>
-        <div className="absolute bottom-0 right-0 left-0 bg-background/50 backdrop-blur flex flex-col items-center justify-center p-8 border-t border-t-border/70 text-center">
-          <p className="text-xl text-text">
-            <b>{dog.name}</b>
-            {dog?.birthDate
-              ? `, ${getFormattedYears({ birthDate: dog?.birthDate, lng })}`
-              : null}
-          </p>
-          <p>{dog.bio}</p>
-        </div>
-      </div>
+      <header className="relative z-10 mx-auto w-full max-w-5xl px-4 md:px-8">
+        {/* oxlint-disable-next-line nextjs/no-img-element -- A static SVG needs no next/image pipeline. */}
+        <img
+          src="/logo.svg"
+          draggable="false"
+          alt=""
+          className="mx-auto mt-4 h-8 select-none md:mx-0 md:mt-8 md:h-9"
+        />
+      </header>
 
-      <div className="w-full max-w-xl bg-secondary rounded-lg border border-border/70 flex flex-col items-center gap-4 md:gap-3 p-8 md:p-6 text-center">
-        <h2 className="text-3xl md:text-2xl font-extrabold text-text">
-          {t("dog.cta.title")}
-        </h2>
-        <p className="text-subtitle">{t("dog.cta.description")}</p>
+      <main className="relative z-10 mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-start gap-6 px-4 pb-24 pt-4 md:grid md:grid-cols-[minmax(0,400px)_1fr] md:items-center md:justify-normal md:gap-16 md:px-8 md:pb-16 md:pt-0">
+        {/* The card: this page's entire pitch is "here is the product, with your friend's dog already in it." */}
+        <div className="flex w-full max-w-[380px] flex-1 flex-col fill-mode-both animate-in fade-in slide-in-from-bottom-4 duration-700 motion-reduce:animate-none md:max-w-none md:flex-none">
+          <div className="relative w-full flex-1 overflow-hidden rounded-[28px] bg-gradient-to-b from-primary via-[#FB6E90] to-[#DC5791] shadow-[0_20px_60px_-15px_rgba(220,87,145,0.45)] md:aspect-[4/5] md:flex-none">
+            {dogImage ? (
+              // This photo is the page: it is the LCP element on every
+              // /dog/[id] view. A plain <img> in the initial HTML is
+              // visible to the browser's preload scanner, so it starts
+              // fetching in the first round of requests without any
+              // manual `preload()` call.
+              //
+              // Deliberately not `next/image`: this URL is on the media
+              // CDN and `images.remotePatterns` is not configured, so
+              // switching would mean routing user photos through the
+              // optimiser — a bigger change than this page needs. The
+              // gradient behind it is the loading placeholder, so there
+              // is no flash of white either way.
+              // oxlint-disable-next-line nextjs/no-img-element -- see comment above; deliberately not next/image
+              <img
+                src={dogImage}
+                alt=""
+                fetchPriority="high"
+                decoding="async"
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            ) : (
+              <div className="absolute inset-0 flex items-center justify-center">
+                {/* oxlint-disable-next-line nextjs/no-img-element -- A static SVG needs no next/image pipeline. */}
+                <img src="/logo.svg" alt="" className="h-16 w-16 opacity-90" />
+              </div>
+            )}
+
+            {Boolean(dog.breed?.name) && (
+              <div className="absolute right-4 top-4 rounded-full bg-black/30 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-white backdrop-blur">
+                {t(`${dog.breed?.slug as BreedSlug}`, { ns: Namespace.Breed })}
+              </div>
+            )}
+
+            <div className="absolute inset-x-0 bottom-0 flex flex-col gap-1 bg-gradient-to-t from-black/85 via-black/35 to-transparent px-5 pb-5 pt-16">
+              <h1 className="text-2xl font-extrabold leading-tight text-white md:text-3xl">
+                {dog.name}
+              </h1>
+              {tagline ? (
+                <p className="text-sm font-medium text-white/70">{tagline}</p>
+              ) : null}
+              {dog.bio ? (
+                <p className="line-clamp-2 text-sm font-light text-white/85">
+                  {dog.bio}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {/* Desktop copy column. Hidden below `md`, where the sticky bar carries the ask instead. */}
+        <div className="hidden fill-mode-both animate-in fade-in slide-in-from-bottom-2 delay-150 duration-700 motion-reduce:animate-none md:flex md:max-w-md md:flex-col md:gap-5">
+          <h2 className="text-4xl font-extrabold leading-tight text-text lg:text-5xl">
+            {invite}
+          </h2>
+          <p className="text-lg font-light text-subtitle">{nextStep}</p>
+          <div className="mt-2 flex flex-col items-start gap-3">
+            {/* oxlint-disable-next-line next/no-html-link-for-pages -- /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to. */}
+            <a
+              href="/store"
+              className="rounded-full bg-primary px-8 py-4 font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
+            >
+              {t("dog.cta.button")}
+            </a>
+            <p className="text-sm font-light text-subtitle/80">
+              {t("dog.cta.reassurance")}
+            </p>
+          </div>
+        </div>
+      </main>
+
+      {/* Mobile sticky CTA bar. `main`'s bottom padding above reserves room for it so it never covers the card. */}
+      <div className="fixed inset-x-0 bottom-0 z-20 flex items-center justify-between gap-4 border-t border-border bg-white/95 px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3 shadow-[0_-8px_30px_-15px_rgba(15,23,42,0.2)] backdrop-blur md:hidden">
+        <p className="flex-1 truncate text-sm font-medium text-text">
+          {t("dog.cta.mobileContext")}
+        </p>
         {/* oxlint-disable-next-line next/no-html-link-for-pages -- /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to. */}
         <a
           href="/store"
-          className="bg-primary text-white font-semibold rounded-full px-8 py-4 md:px-6 md:py-3 hover:scale-105 transition-transform duration-200 ease-in-out"
+          className="shrink-0 rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
         >
           {t("dog.cta.button")}
         </a>

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -8,7 +8,9 @@ import { Namespace } from "@pegada/shared/i18n/types/types";
 
 import { getSafeLocale } from "@/lib/get-safe-locale";
 import { t } from "@/lib/translate";
+import { cn } from "@/lib/utils";
 
+import { gilroy } from "./fonts";
 import {
   getDog,
   getDogArticle,
@@ -67,7 +69,12 @@ const DogProfile = async ({ params }: DogProfileProps) => {
   const nextStep = t("dog.hero.nextStep", { pronoun: getDogPronoun(dog) });
 
   return (
-    <div className="relative flex min-h-screen flex-col overflow-hidden bg-[#FFF9FB]">
+    <div
+      className={cn(
+        gilroy.variable,
+        "relative flex min-h-screen flex-col overflow-hidden bg-[#FFF9FB] font-gilroy",
+      )}
+    >
       {/*
        * The only decoration on the page: a soft echo of the brand gradient
        * (see public/logo.svg) blooming behind the card. Everything else here
@@ -127,8 +134,16 @@ const DogProfile = async ({ params }: DogProfileProps) => {
             )}
 
             {Boolean(dog.breed?.name) && (
-              <div className="absolute right-4 top-4 rounded-full bg-black/30 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-white backdrop-blur">
-                {t(`${dog.breed?.slug as BreedSlug}`, { ns: Namespace.Breed })}
+              // Mirrors the app's own breed tag (`breed-tag.tsx` +
+              // `Glassmorphism`): a frosted, bordered pill, not an uppercase
+              // dark badge — same casing, same md radius, same light glass
+              // tint the app uses over photos.
+              <div className="absolute right-4 top-4 flex h-8 items-center rounded-xl border border-white/30 bg-white/20 px-3 leading-none text-white backdrop-blur-md">
+                <span className="text-sm font-medium">
+                  {t(`${dog.breed?.slug as BreedSlug}`, {
+                    ns: Namespace.Breed,
+                  })}
+                </span>
               </div>
             )}
 

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -121,7 +121,7 @@ const DogProfile = async ({ params }: DogProfileProps) => {
               // oxlint-disable-next-line nextjs/no-img-element -- see comment above; deliberately not next/image
               <img
                 src={dogImage}
-                alt=""
+                alt={dog.name}
                 fetchPriority="high"
                 decoding="async"
                 className="absolute inset-0 h-full w-full object-cover"

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -41,7 +41,7 @@ export const generateMetadata = async ({
   }
 
   const lng = getSafeLocale();
-  const title = t("dog.metadata.title", { name: dog.name });
+  const title = t("dog.metadata.title", { name: dog.name, lng });
   const description = getDogDescription(dog, lng);
 
   return {

--- a/apps/nextjs/tailwind.config.ts
+++ b/apps/nextjs/tailwind.config.ts
@@ -11,6 +11,7 @@ module.exports = {
     fontFamily: {
       epilogue: "var(--font-epilogue)",
       atkinson: "var(--font-atkinson)",
+      gilroy: "var(--font-gilroy)",
     },
     colors: {
       ...DefaultTheme.colors,

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -74,6 +74,20 @@
       }
     }
   },
+  "dog": {
+    "metadata": {
+      "title": "{{name}} | Pegada",
+      "descriptionSuffix": "Meet {{name}} and other dogs near you on Pegada."
+    },
+    "cta": {
+      "title": "Get Pegada",
+      "description": "Find friends for your dog nearby.",
+      "button": "Download the app"
+    },
+    "og": {
+      "tag": "meet them on Pegada"
+    }
+  },
   "privacyPolicy": {
     "metadata": {
       "title": "Pegada | Privacy Policy"

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -89,7 +89,7 @@
       "mobileContext": "A new friend is waiting."
     },
     "og": {
-      "tag": "meet them on Pegada"
+      "tag": "Meet them on Pegada"
     }
   },
   "privacyPolicy": {

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -79,10 +79,14 @@
       "title": "{{name}} | Pegada",
       "descriptionSuffix": "Meet {{name}} and other dogs near you on Pegada."
     },
+    "hero": {
+      "invite": "{{name}} wants to make friends",
+      "nextStep": "Download the app to chat with the person who looks after them."
+    },
     "cta": {
-      "title": "Get Pegada",
-      "description": "Find friends for your dog nearby.",
-      "button": "Download the app"
+      "button": "Get Pegada",
+      "reassurance": "It's free and takes less than a minute.",
+      "mobileContext": "A new friend is waiting."
     },
     "og": {
       "tag": "meet them on Pegada"

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -81,12 +81,12 @@
     },
     "hero": {
       "invite": "{{name}} wants to make friends",
-      "nextStep": "Download the app to chat with the person who looks after them."
+      "nextStep": "Like {{name}} and chat with the person who looks after {{pronoun}}."
     },
     "cta": {
-      "button": "Get Pegada",
-      "reassurance": "It's free and takes less than a minute.",
-      "mobileContext": "A new friend is waiting."
+      "button": "Like {{name}}",
+      "reassurance": "You'll need the app. It's free and takes a minute.",
+      "mobileContext": "{{pronoun}} wants to make friends."
     },
     "og": {
       "tag": "Meet them on Pegada"

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -81,12 +81,12 @@
     },
     "hero": {
       "invite": "{{article}} {{name}} quer fazer amigos",
-      "nextStep": "Baixa o app e fala com quem cuida {{pronoun}}."
+      "nextStep": "Curte {{article}} {{name}} e fala com quem cuida {{pronoun}}."
     },
     "cta": {
-      "button": "Baixar o Pegada",
-      "reassurance": "É de graça e leva menos de um minuto.",
-      "mobileContext": "Um novo amigo te espera."
+      "button": "Curtir {{article}} {{name}}",
+      "reassurance": "Você vai precisar do app. É de graça e leva um minuto.",
+      "mobileContext": "{{pronoun}} quer fazer amigos."
     },
     "og": {
       "tag": "Conheça no Pegada"

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -89,7 +89,7 @@
       "mobileContext": "Um novo amigo te espera."
     },
     "og": {
-      "tag": "conheça no Pegada"
+      "tag": "Conheça no Pegada"
     }
   },
   "privacyPolicy": {

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -75,6 +75,20 @@
       }
     }
   },
+  "dog": {
+    "metadata": {
+      "title": "{{name}} | Pegada",
+      "descriptionSuffix": "Conheça {{name}} e outros cachorros perto de você no Pegada."
+    },
+    "cta": {
+      "title": "Baixe o Pegada",
+      "description": "Faça amigos pro seu cachorro perto de casa.",
+      "button": "Baixar o app"
+    },
+    "og": {
+      "tag": "conheça no Pegada"
+    }
+  },
   "privacyPolicy": {
     "metadata": {
       "title": "Pegada | Política de Privacidade"

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -4,7 +4,6 @@
     "description": "Pegada é um aplicativo de relacionamento para cachorros. Com ele, você pode encontrar outros cachorros para passear, brincar e até mesmo namorar. O aplicativo é gratuito e está disponível para Android e iOS.",
     "ogImageAlt": "Um iPhone com o Pegada aberto, mostrando o perfil de uma golden retriever chamada Maui, ao lado dos dizeres “Friends For Your Doggie” e “Pawfect Matches”."
   },
-
   "home": {
     "title": "Amigos Pro Seu Dog",
     "description": "Aqui do lado tem cachorro da mesma raça e com o mesmo jeito do seu.",
@@ -80,10 +79,14 @@
       "title": "{{name}} | Pegada",
       "descriptionSuffix": "Conheça {{name}} e outros cachorros perto de você no Pegada."
     },
+    "hero": {
+      "invite": "{{article}} {{name}} quer fazer amigos",
+      "nextStep": "Baixa o app e fala com quem cuida {{pronoun}}."
+    },
     "cta": {
-      "title": "Baixe o Pegada",
-      "description": "Faça amigos pro seu cachorro perto de casa.",
-      "button": "Baixar o app"
+      "button": "Baixar o Pegada",
+      "reassurance": "É de graça e leva menos de um minuto.",
+      "mobileContext": "Um novo amigo te espera."
     },
     "og": {
       "tag": "conheça no Pegada"

--- a/packages/shared/utils/get-formatted-years.ts
+++ b/packages/shared/utils/get-formatted-years.ts
@@ -32,12 +32,12 @@ export const getFormattedYears = ({
   if (ageInYears !== 0 && months !== 0) {
     return `${
       ageInYears === 1
-        ? t("dateFormatting.year", { replace: { unit: ageInYears } })
-        : t("dateFormatting.years", { replace: { unit: ageInYears } })
-    } ${t("dateFormatting.and")} ${
+        ? t("dateFormatting.year", { replace: { unit: ageInYears }, lng })
+        : t("dateFormatting.years", { replace: { unit: ageInYears }, lng })
+    } ${t("dateFormatting.and", { lng })} ${
       months === 1
-        ? t("dateFormatting.month", { replace: { unit: months } })
-        : t("dateFormatting.months", { replace: { unit: months } })
+        ? t("dateFormatting.month", { replace: { unit: months }, lng })
+        : t("dateFormatting.months", { replace: { unit: months }, lng })
     }`;
   }
 };


### PR DESCRIPTION
## Summary
Someone who taps a shared link lands on a page built around the dog's photo, with the CTA on screen without scrolling on both a phone and a laptop. The link preview in chat apps carries that dog's own photo and name.

## Details
- The page is set in Gilroy, the same face the app uses, loaded only on this route through `next/font/local` from the shared fonts folder. The rest of the site stays on Epilogue.
- The dog is presented as one tall profile card on a warm off white ground, with the name, breed, age and bio set over the bottom of the photo. A soft pink bloom sits behind the card and is the only decoration on the page.
- On a phone the CTA lives in a sticky bar pinned to the bottom of the screen, so it stays put while the photo fills the rest. On a laptop that bar is dropped and the page becomes two columns, photo on the left, invite and button on the right. Only one of the two ever shows at a given width.
- `generateMetadata` builds a per dog title and description and points `openGraph`/`twitter` at the dynamic OG image. Robots stays noindex, same as before.
- `opengraph-image.tsx` renders a 1200x630 card with `next/og`'s `ImageResponse` (built into Next 15, no new deps). It is typeset in Gilroy fed in as font data, carries the real paw mark from `logo.svg` next to the wordmark, and falls back to a generic Pegada card with the same mark when the dog is missing or has no photo.
- The breed chip on the photo mirrors the app's own breed tag: sentence case, a visible frosted blur, a hairline border, and the text centred inside the pill.
- The photo is now a plain `<img>` in the initial HTML, which the browser's preload scanner finds on its own, so the manual `preload()` call is gone. The brand gradient behind it doubles as the loading placeholder, so there is no flash of white.
- The button asks for the action, not the install: "Curtir a Bella" / "Like Bella". The download only comes up once, in the reassurance line under the button ("Você vai precisar do app. É de graça e leva um minuto." / "You'll need the app. It's free and takes a minute."). The button, the sticky bar and the desktop line under the headline are all gendered off the dog's `gender` column, so a male dog reads "Curtir o Rex" and "Ele quer fazer amigos" where a female dog reads "Curtir a Bella" and "Ela quer fazer amigos" (same split in English: "Like Rex" / "He wants to make friends" versus "Like Bella" / "She wants to make friends").
- `getFormattedYears` was dropping the language on the branch that formats an age with both years and months, which printed "2 years and 1 month" on a Portuguese page. It passes the language through now, which also fixes the age line inside the OG image.
- Both dog data fetches (metadata and page) share one Prisma query via React's `cache()`.
- Copy is localized in pt-BR and en (`packages/shared/i18n/locales/*/web.json`), pt-BR first since that is where the app lives.

## Testing steps
1. Share a dog's profile from the app and open the link on your phone.
2. The dog's photo should fill the screen with its name, breed and age across the bottom, and a pink button with the dog's name, like "Curtir a Bella", should already be sitting at the bottom of the screen before you scroll anything.
3. Tap that button and check it takes you to the right app store for your phone.
4. Open the same link on a laptop. The photo should sit on the left with the invite line and that same pink button on the right, all of it visible without scrolling.
5. Paste the link into WhatsApp or any other chat app. The preview card should show that dog's photo, name, breed and age.

## Screenshots

Share page, iPhone width:

![mobile](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-dog-share-page/shots/mobile-390x844.png)

Share page, desktop:

![desktop](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-dog-share-page/shots/desktop-1280x800.png)

The generated OG image (what shows up as the link preview):

![og image](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-dog-share-page/shots/og-image.png)

