### PR TITLE
fix(mobile): keep Android submissions on the internal track as drafts

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -33,8 +33,8 @@
         "ascAppId": "6450865592"
       },
       "android": {
-        "track": "production",
-        "releaseStatus": "completed"
+        "track": "internal",
+        "releaseStatus": "draft"
       }
     }
   }


### PR DESCRIPTION
## Summary
A manual Android submission now lands on the internal track as a draft again, so nothing goes live to everyone without a staged rollout in between.

## Details
- `apps/mobile/eas.json` had the Android submit profile pointed at the `production` track with `releaseStatus` set to `completed`, which means the moment someone runs the submit job the build is live for every user.
- Back to `internal` and `draft`, which is what the release workflow's own header comment describes as the intent: a new native binary gets internal-track testing first, and promotion to production is a deliberate step in the Play Console.
- The release workflow itself was never auto-submitting. Submission only runs on a manual dispatch with the submit input set to true. This change is about where that manual submit ends up, not about whether it runs.

## Testing steps
1. Open the mobile release workflow on GitHub and run it by hand with the submit option turned on for Android.
2. When it finishes, open the Play Console and look at the Internal testing track. The new build should be there as a draft release.
3. Check the Production track. Nothing new should have appeared there.

## Screenshots

The submit profile after this change:

![eas submit config](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-eas-android-draft/shots/eas-submit-config.png)
