### PR TITLE
feat: open pegada.app/dog links in the app, with a sign in hand off

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -1694,19 +1694,30 @@ jobs:
         if: matrix.shard.name == 'core'
         run: |
           set -euo pipefail
-          MAGIC_EMAIL="${APPLE_MAGIC_EMAIL%%,*}"
+          # Default before trimming the comma separated list: `set -u` makes
+          # a suffix expansion on an unset name an error, and the job-level
+          # fallback for this env can be dropped or emptied independently.
+          MAGIC_EMAIL="${APPLE_MAGIC_EMAIL:-test@pegada.app}"
+          MAGIC_EMAIL="${MAGIC_EMAIL%%,*}"
           TOKEN=$(curl -sf -X POST "$EXPO_PUBLIC_API_URL/trpc/authentication.login?batch=1" \
             -H "Content-Type: application/json" \
             -d "{\"0\":{\"json\":{\"email\":\"$MAGIC_EMAIL\",\"code\":\"$APPLE_MAGIC_CODE\"}}}" \
             | jq -r '.[0].result.data.json.token // empty')
+          # Flows 46/47 are in this shard, so a missing id is not recoverable
+          # later: the flows would open `pegada://dog/` and fail on a screen
+          # assertion instead. Fail here, where the cause is in the message.
           if [ -z "$TOKEN" ]; then
-            echo "::warning::could not log in as $MAGIC_EMAIL to resolve a dog id; 46/47 will fail if they run"
-            exit 0
+            echo "::error::could not log in as $MAGIC_EMAIL at $EXPO_PUBLIC_API_URL to resolve a dog id for flows 46/47"
+            exit 1
           fi
           MATCH_INPUT='%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D%7D'
           DOG_ID=$(curl -sf "$EXPO_PUBLIC_API_URL/trpc/match.getAll?batch=1&input=$MATCH_INPUT" \
             -H "Authorization: Bearer $TOKEN" \
             | jq -r '[.[0].result.data.json[] | select(.dog.name == "Bella")][0].dog.id // empty')
+          if [ -z "$DOG_ID" ]; then
+            echo "::error::logged in as $MAGIC_EMAIL but match.getAll returned no dog named Bella; the staging seed needs a maestro-seed.ts run"
+            exit 1
+          fi
           echo "DOG_ID=$DOG_ID" >> "$GITHUB_ENV"
 
       - name: Run extended Maestro flows (${{ matrix.shard.name }})

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -1579,7 +1579,7 @@ jobs:
           # stay sequential and co-located, see the shard design note
           # at the top of this file for the full dependency analysis.
           - name: core
-            flows: "02-sign-in,03-create-profile,04-complete-profile,05-ask-location,06-force-update,07-tabs-navigation,08-swipe-like,09-swipe-dislike,10-dog-profile,11-messages-list,12-chat-conversation,19-chat-message-order,25-upgrade-journey,21-swipe-journey,22-new-match-journey,23-preferences-journey,23b-lang-theme-persistence,24-profile-journey,26-logout-journey"
+            flows: "02-sign-in,03-create-profile,04-complete-profile,05-ask-location,06-force-update,07-tabs-navigation,08-swipe-like,09-swipe-dislike,10-dog-profile,11-messages-list,12-chat-conversation,19-chat-message-order,25-upgrade-journey,21-swipe-journey,22-new-match-journey,23-preferences-journey,23b-lang-theme-persistence,24-profile-journey,46-deep-link-sign-in-handoff,47-deep-link-logged-in,26-logout-journey"
           # "fresh": self-purging APPLE_MAGIC_EMAIL_REGEX user, disjoint
           # from test@pegada.app's rows.
           - name: fresh
@@ -1681,6 +1681,34 @@ jobs:
       # need their own DATABASE_URL wired the same way once staging is
       # connected, tracked together with the EXPO_PUBLIC_API_URL secret
       # setup, out of scope for this change.
+      #
+      # 46/47 (deep-link hand-off) are the one pair in "core" that needs a
+      # real dog id rather than just a logged-in session — resolved here
+      # the same way scripts/pre/46-resolve-dog-id.sh does locally: log in
+      # as the magic user against the staging API and read Bella's id off
+      # match.getAll. Runs over HTTP (curl+jq), not psql, so it needs
+      # nothing beyond what this job already has (EXPO_PUBLIC_API_URL,
+      # APPLE_MAGIC_EMAIL/CODE) and works whether or not DATABASE_URL is
+      # ever wired for the other shards' scripts above.
+      - name: Resolve dog id for deep-link flows (core)
+        if: matrix.shard.name == 'core'
+        run: |
+          set -euo pipefail
+          MAGIC_EMAIL="${APPLE_MAGIC_EMAIL%%,*}"
+          TOKEN=$(curl -sf -X POST "$EXPO_PUBLIC_API_URL/trpc/authentication.login?batch=1" \
+            -H "Content-Type: application/json" \
+            -d "{\"0\":{\"json\":{\"email\":\"$MAGIC_EMAIL\",\"code\":\"$APPLE_MAGIC_CODE\"}}}" \
+            | jq -r '.[0].result.data.json.token // empty')
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::could not log in as $MAGIC_EMAIL to resolve a dog id; 46/47 will fail if they run"
+            exit 0
+          fi
+          MATCH_INPUT='%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D%7D'
+          DOG_ID=$(curl -sf "$EXPO_PUBLIC_API_URL/trpc/match.getAll?batch=1&input=$MATCH_INPUT" \
+            -H "Authorization: Bearer $TOKEN" \
+            | jq -r '[.[0].result.data.json[] | select(.dog.name == "Bella")][0].dog.id // empty')
+          echo "DOG_ID=$DOG_ID" >> "$GITHUB_ENV"
+
       - name: Run extended Maestro flows (${{ matrix.shard.name }})
         id: maestro-extended
         run: |
@@ -1709,7 +1737,10 @@ jobs:
           # Single maestro invocation per shard so THIS SHARD's internal
           # ordering is respected (config.yaml's flowsOrder governs
           # relative order when multiple files are passed together).
+          # DOG_ID is only ever set on the "core" shard (see the resolve
+          # step above); every other flow ignores an unused `-e` var.
           maestro test "${FLOWS[@]}" \
+            -e DOG_ID="${DOG_ID:-}" \
             --format junit \
             --output "maestro-results-extended-${{ matrix.shard.name }}.xml" \
             --exclude-tags no-api,util || true

--- a/apps/mobile/.maestro/46-deep-link-sign-in-handoff.yaml
+++ b/apps/mobile/.maestro/46-deep-link-sign-in-handoff.yaml
@@ -1,0 +1,58 @@
+appId: ${APP_ID}
+name: Deep link while logged out — banner, then hand off to the dog profile after sign in
+tags:
+  - smoke
+  - regression
+---
+# Product ask (Gabriel): opening a shared `pegada://dog/<id>` link while
+# logged out must not look like the app "did nothing" — a banner has to
+# say the profile is waiting, then sign-in has to actually land there.
+#
+# 1. Cold-launch logged out, open the deep link (app/dog/[id].tsx stashes
+#    the id in the pending-dog-profile store without navigating anywhere).
+# 2. The auth redirect in _layout.tsx then replaces to SignIn — assert the
+#    banner (PendingDogProfileBanner, testID signin-pending-dog-profile).
+# 3. Sign in as the returning magic user. usePendingDogProfile only fires
+#    once the auth router's initialRouteName reaches Swipe (see
+#    _layout.tsx), so login-returning.yaml is used rather than login.yaml —
+#    it is the util documented to land on swipe, not CreateProfile.
+# 4. Assert the dog profile screen — DOG_ID is resolved by
+#    scripts/pre/46-resolve-dog-id.sh to Bella's id (test+bella@pegada.app,
+#    matched with Rex, so test@pegada.app's session can always read her via
+#    dog.get) and forwarded here as `-e DOG_ID=...` by run-flow.sh.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+# `dog/[id].tsx` renders nothing and never navigates itself — the id is only
+# picked up by the pending-dog-profile store, and root `_layout.tsx`'s own
+# auth-redirect effect is what puts SignIn on screen. That effect only
+# REPLACES the current route with SignIn on its very first run, right after
+# `_layout` mounts; once it has already run once (e.g. because the app was
+# left sitting on SignIn from the `launchApp` above), a later deep link
+# instead gets PUSHED on top as a new, still-invisible screen, and nothing
+# ever pops it — a real, acknowledged limit documented in dog/[id].tsx's own
+# comment. `stopApp` here forces the NEXT step to be a genuine cold launch
+# straight into the link, so dog/[id] is the app's first and only route and
+# the redirect's REPLACE actually swaps it for SignIn.
+- stopApp
+- waitForAnimationToEnd
+- openLink: "pegada://dog/${DOG_ID}"
+- waitForAnimationToEnd
+# iOS asks to confirm opening a custom-scheme link from outside the app
+# (e.g. Safari, or Maestro's own openLink) — not something a real shared
+# link from Messages/WhatsApp prompts for, but simctl-driven opens always
+# do. `optional` because a warm relaunch of the same scheme sometimes skips
+# the system dialog entirely.
+- tapOn:
+    text: "Open"
+    optional: true
+- waitForAnimationToEnd
+- assertVisible:
+    id: "signin-pending-dog-profile"
+- takeScreenshot: 46-banner-on-signin
+- runFlow: utils/login-returning.yaml
+- waitForAnimationToEnd:
+    timeout: 15000
+- assertVisible:
+    id: "dog-profile-name"
+- takeScreenshot: 46-after-login-profile

--- a/apps/mobile/.maestro/46-deep-link-sign-in-handoff.yaml
+++ b/apps/mobile/.maestro/46-deep-link-sign-in-handoff.yaml
@@ -1,45 +1,51 @@
 appId: ${APP_ID}
-name: Deep link while logged out — banner, then hand off to the dog profile after sign in
+name: Deep link while logged out, warm and cold, banner then hand off after sign in
 tags:
   - smoke
   - regression
 ---
 # Product ask (Gabriel): opening a shared `pegada://dog/<id>` link while
-# logged out must not look like the app "did nothing" — a banner has to
-# say the profile is waiting, then sign-in has to actually land there.
+# logged out must not look like the app "did nothing". A banner has to say
+# the profile is waiting, then sign-in has to actually land there.
 #
-# 1. Cold-launch logged out, open the deep link (app/dog/[id].tsx stashes
-#    the id in the pending-dog-profile store without navigating anywhere).
-# 2. The auth redirect in _layout.tsx then replaces to SignIn — assert the
-#    banner (PendingDogProfileBanner, testID signin-pending-dog-profile).
-# 3. Sign in as the returning magic user. usePendingDogProfile only fires
-#    once the auth router's initialRouteName reaches Swipe (see
-#    _layout.tsx), so login-returning.yaml is used rather than login.yaml —
-#    it is the util documented to land on swipe, not CreateProfile.
-# 4. Assert the dog profile screen — DOG_ID is resolved by
-#    scripts/pre/46-resolve-dog-id.sh to Bella's id (test+bella@pegada.app,
-#    matched with Rex, so test@pegada.app's session can always read her via
-#    dog.get) and forwarded here as `-e DOG_ID=...` by run-flow.sh.
+# Both entries into that journey are covered here, because they used to
+# behave differently and only one of them worked:
+#
+# 1. WARM: the app is already running on SignIn when the link arrives.
+#    expo-router PUSHES `dog/[id]` on top, and that screen renders nothing.
+#    `_layout.tsx`'s auth-redirect effect keys on `initialRouteName`, which
+#    is `/sign-in` before and after, so it never re-ran and never replaced
+#    anything: the invisible frame stayed on top forever and `back` could
+#    not recover it. `dog/[id].tsx` now pops itself when there is a screen
+#    underneath, which lands the user back on SignIn with the banner.
+#    This flow previously ran `stopApp` right here to sidestep exactly that
+#    bug, which meant the warm path shipped untested.
+# 2. COLD: the link launches the app, `dog/[id]` is the only route, and
+#    `_layout.tsx`'s redirect replaces it with SignIn on mount.
+#
+# Then: sign in as the returning magic user. usePendingDogProfile only
+# fires once the auth router's initialRouteName reaches Swipe (see
+# _layout.tsx), so login-returning.yaml is used rather than login.yaml. It
+# is the util documented to land on swipe, not CreateProfile.
+#
+# DOG_ID is resolved by scripts/pre/46-resolve-dog-id.sh to Bella's id
+# (test+bella@pegada.app, matched with Rex, so test@pegada.app's session can
+# always read her via dog.get) and forwarded here as `-e DOG_ID=...` by
+# run-flow.sh.
 - launchApp:
     clearState: true
     clearKeychain: true
-# `dog/[id].tsx` renders nothing and never navigates itself — the id is only
-# picked up by the pending-dog-profile store, and root `_layout.tsx`'s own
-# auth-redirect effect is what puts SignIn on screen. That effect only
-# REPLACES the current route with SignIn on its very first run, right after
-# `_layout` mounts; once it has already run once (e.g. because the app was
-# left sitting on SignIn from the `launchApp` above), a later deep link
-# instead gets PUSHED on top as a new, still-invisible screen, and nothing
-# ever pops it — a real, acknowledged limit documented in dog/[id].tsx's own
-# comment. `stopApp` here forces the NEXT step to be a genuine cold launch
-# straight into the link, so dog/[id] is the app's first and only route and
-# the redirect's REPLACE actually swaps it for SignIn.
-- stopApp
 - waitForAnimationToEnd
+# The app has to actually be sitting on SignIn for the next open to be the
+# warm case rather than a slow cold start.
+- extendedWaitUntil:
+    visible:
+      id: "signin-email"
+    timeout: 20000
 - openLink: "pegada://dog/${DOG_ID}"
 - waitForAnimationToEnd
 # iOS asks to confirm opening a custom-scheme link from outside the app
-# (e.g. Safari, or Maestro's own openLink) — not something a real shared
+# (e.g. Safari, or Maestro's own openLink). Not something a real shared
 # link from Messages/WhatsApp prompts for, but simctl-driven opens always
 # do. `optional` because a warm relaunch of the same scheme sometimes skips
 # the system dialog entirely.
@@ -47,9 +53,28 @@ tags:
     text: "Open"
     optional: true
 - waitForAnimationToEnd
+# The regression guard: before the fix this was a blank screen, so both the
+# banner and the sign-in form itself were gone.
 - assertVisible:
     id: "signin-pending-dog-profile"
-- takeScreenshot: 46-banner-on-signin
+- assertVisible:
+    id: "signin-email"
+- takeScreenshot: 46-warm-banner-on-signin
+# Now the cold entry: kill the app so the link is what launches it and
+# `dog/[id]` is the first and only route in the stack.
+- stopApp
+- waitForAnimationToEnd
+- openLink: "pegada://dog/${DOG_ID}"
+- waitForAnimationToEnd
+- tapOn:
+    text: "Open"
+    optional: true
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "signin-pending-dog-profile"
+    timeout: 20000
+- takeScreenshot: 46-cold-banner-on-signin
 - runFlow: utils/login-returning.yaml
 - waitForAnimationToEnd:
     timeout: 15000

--- a/apps/mobile/.maestro/46-deep-link-sign-in-handoff.yaml
+++ b/apps/mobile/.maestro/46-deep-link-sign-in-handoff.yaml
@@ -38,10 +38,17 @@ tags:
 - waitForAnimationToEnd
 # The app has to actually be sitting on SignIn for the next open to be the
 # warm case rather than a slow cold start.
+#
+# 45s, not 20s, on every cold-launch wait in this flow. Timed on an iPhone 17
+# Pro simulator, three back to back runs of stopApp + openLink: 2s, 10s, 22s
+# to the banner. The spread is the point — a cold launch has to clear the
+# splash, resolve `getInitialRouteName` off storage and mount the auth stack
+# before anything asserts, and the 22s run would have failed a 20s budget on
+# a machine that is doing nothing else. CI runners are busier than that.
 - extendedWaitUntil:
     visible:
       id: "signin-email"
-    timeout: 20000
+    timeout: 45000
 - openLink: "pegada://dog/${DOG_ID}"
 - waitForAnimationToEnd
 # iOS asks to confirm opening a custom-scheme link from outside the app
@@ -73,11 +80,17 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "signin-pending-dog-profile"
-    timeout: 20000
+    timeout: 45000
 - takeScreenshot: 46-cold-banner-on-signin
 - runFlow: utils/login-returning.yaml
-- waitForAnimationToEnd:
-    timeout: 15000
-- assertVisible:
-    id: "dog-profile-name"
+# `waitForAnimationToEnd` then a bare `assertVisible` was a race: it only
+# waits for the screen to stop moving, and the screen is already still while
+# the hand off is still in flight. usePendingDogProfile does not push until
+# initialRouteName reaches Swipe, and the pushed profile then has to wait on
+# `dog.get` before it renders a name. `extendedWaitUntil` polls for the thing
+# that actually matters instead of for the absence of motion.
+- extendedWaitUntil:
+    visible:
+      id: "dog-profile-name"
+    timeout: 45000
 - takeScreenshot: 46-after-login-profile

--- a/apps/mobile/.maestro/47-deep-link-logged-in.yaml
+++ b/apps/mobile/.maestro/47-deep-link-logged-in.yaml
@@ -1,0 +1,28 @@
+appId: ${APP_ID}
+name: Deep link while already logged in — opens straight to the dog profile
+tags:
+  - smoke
+  - regression
+---
+# Companion to 46-deep-link-sign-in-handoff.yaml: the "warm" half of the
+# same feature. A returning, already-authenticated user is already sitting
+# on Swipe (initialRouteName is already Swipe, so usePendingDogProfile's
+# gate is already open — see services/linking/index.ts) when the link
+# arrives, so it should push the profile immediately, no banner involved.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- waitForAnimationToEnd
+- runFlow: utils/login-returning.yaml
+- waitForAnimationToEnd:
+    timeout: 8000
+- openLink: "pegada://dog/${DOG_ID}"
+- waitForAnimationToEnd
+# See 46-deep-link-sign-in-handoff.yaml for why this confirmation is here.
+- tapOn:
+    text: "Open"
+    optional: true
+- waitForAnimationToEnd
+- assertVisible:
+    id: "dog-profile-name"
+- takeScreenshot: 47-warm-link-profile

--- a/apps/mobile/.maestro/47-deep-link-logged-in.yaml
+++ b/apps/mobile/.maestro/47-deep-link-logged-in.yaml
@@ -23,6 +23,11 @@ tags:
     text: "Open"
     optional: true
 - waitForAnimationToEnd
-- assertVisible:
-    id: "dog-profile-name"
+# Same race as flow 46's post-login assert: the pop, the push and `dog.get`
+# all have to land before a name renders, and none of that moves the screen
+# in a way `waitForAnimationToEnd` can see. Poll for the name itself.
+- extendedWaitUntil:
+    visible:
+      id: "dog-profile-name"
+    timeout: 30000
 - takeScreenshot: 47-warm-link-profile

--- a/apps/mobile/.maestro/README.md
+++ b/apps/mobile/.maestro/README.md
@@ -80,15 +80,17 @@ maestro test apps/mobile/.maestro/
 
 ## Flows
 
-| File                               | What it does                                                                                                                                                                                                     |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `launch.yaml`                      | Cold-launches the app, asserts the sign-in screen is visible.                                                                                                                                                    |
-| `sign-in.yaml`                     | Enters magic email + 6-digit code, asserts OTP screen exits.                                                                                                                                                     |
-| `create-profile.yaml`              | Runs sign-in, fills dog name, asserts location screen appears.                                                                                                                                                   |
-| `swipe.yaml`                       | Runs sign-in (assumes full profile), taps like button, asserts no crash.                                                                                                                                         |
-| `20-account-creation-journey.yaml` | Full end-to-end user journey: sign-in → photo upload → name → birthdate → location → swipe. Requires `APPLE_MAGIC_EMAIL_REGEX`.                                                                                  |
-| `26-logout-journey.yaml`           | Login → Profile → Logout → confirm → assert sign-in screen + cold relaunch stays logged out (Keychain wiped).                                                                                                    |
-| `27-delete-account-journey.yaml`   | Login as disposable `delete-me@pegada.app` → Profile → Delete Account → confirm → assert sign-in. Wrap with `maestro:seed` (before) and `maestro:check-deleted` (after) to seed the user and verify DB deletion. |
+| File                                | What it does                                                                                                                                                                                                     |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `launch.yaml`                       | Cold-launches the app, asserts the sign-in screen is visible.                                                                                                                                                    |
+| `sign-in.yaml`                      | Enters magic email + 6-digit code, asserts OTP screen exits.                                                                                                                                                     |
+| `create-profile.yaml`               | Runs sign-in, fills dog name, asserts location screen appears.                                                                                                                                                   |
+| `swipe.yaml`                        | Runs sign-in (assumes full profile), taps like button, asserts no crash.                                                                                                                                         |
+| `20-account-creation-journey.yaml`  | Full end-to-end user journey: sign-in → photo upload → name → birthdate → location → swipe. Requires `APPLE_MAGIC_EMAIL_REGEX`.                                                                                  |
+| `26-logout-journey.yaml`            | Login → Profile → Logout → confirm → assert sign-in screen + cold relaunch stays logged out (Keychain wiped).                                                                                                    |
+| `27-delete-account-journey.yaml`    | Login as disposable `delete-me@pegada.app` → Profile → Delete Account → confirm → assert sign-in. Wrap with `maestro:seed` (before) and `maestro:check-deleted` (after) to seed the user and verify DB deletion. |
+| `46-deep-link-sign-in-handoff.yaml` | Cold, logged out → open `pegada://dog/<id>` → assert the pending-profile banner on sign-in → log in → assert the app landed on that dog's profile. Needs `DOG_ID` (see `scripts/pre/46-resolve-dog-id.sh`).      |
+| `47-deep-link-logged-in.yaml`       | Already logged in → open `pegada://dog/<id>` → assert it opens straight to that dog's profile, no banner involved.                                                                                               |
 
 ## Required GitHub Secrets
 

--- a/apps/mobile/.maestro/config.yaml
+++ b/apps/mobile/.maestro/config.yaml
@@ -63,6 +63,17 @@ executionOrder:
     # every screen that renders her, so it sits down here with the other two
     # fixture-heavy flows. `seed-before-test.sh` drops the extra photos again.
     - 45-dog-profile-photo-edges
+    # 46/47 cover the `pegada://dog/<id>` deep-link hand-off (universal
+    # links branch): 46 is the cold, logged-out case (banner on sign-in,
+    # then the profile after login); 47 is the warm, already-logged-in
+    # case. Both resolve a real dog id at run time via
+    # scripts/pre/46-resolve-dog-id.sh (shared by 47's pre-hook), so they
+    # sit after the other fixture-dependent flows for the same reason 43-45
+    # do — nothing here mutates shared state, so their exact position only
+    # needs to be after login-returning.yaml's target account (test@pegada.app)
+    # is in its usual seeded shape.
+    - 46-deep-link-sign-in-handoff
+    - 47-deep-link-logged-in
     # 50 is the two-account journey. It runs late because it is the longest
     # flow in the suite by a wide margin and because it is the only one that
     # creates its own accounts — journey-a / journey-b, reset by

--- a/apps/mobile/.maestro/scripts/pre/46-resolve-dog-id.sh
+++ b/apps/mobile/.maestro/scripts/pre/46-resolve-dog-id.sh
@@ -25,8 +25,12 @@
 set -euo pipefail
 
 API_URL="${EXPO_PUBLIC_API_URL:-http://localhost:3010/api}"
-MAGIC_EMAIL="${APPLE_MAGIC_EMAIL%%,*}"
-MAGIC_EMAIL="${MAGIC_EMAIL:-test@pegada.app}"
+# APPLE_MAGIC_EMAIL is a comma separated list and is often unset on a dev
+# machine. Default it before trimming: under `set -u` a suffix expansion on
+# an unset name is an error, so `${APPLE_MAGIC_EMAIL%%,*}` would abort the
+# hook instead of falling through to test@pegada.app.
+MAGIC_EMAIL="${APPLE_MAGIC_EMAIL:-test@pegada.app}"
+MAGIC_EMAIL="${MAGIC_EMAIL%%,*}"
 MAGIC_CODE="${APPLE_MAGIC_CODE:-424242}"
 CACHE_FILE="${TMPDIR:-/tmp}/pegada-maestro-dog-id"
 

--- a/apps/mobile/.maestro/scripts/pre/46-resolve-dog-id.sh
+++ b/apps/mobile/.maestro/scripts/pre/46-resolve-dog-id.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Pre-test setup shared by flow 46 (deep-link sign-in hand-off) and flow 47
+# (deep link while already logged in). Both open `pegada://dog/<id>` and
+# need an id that resolves through `dog.get` for ANY logged-in user.
+#
+# Bella (test+bella@pegada.app) is exactly that: seeded and upserted on
+# every maestro-seed.ts run (ensureBellaWithMatch in
+# packages/database/maestro-seed.ts) and matched with Rex, so
+# test@pegada.app can always read her profile. Her id is a cuid2 assigned
+# at insert time, not a constant, so it has to be resolved at run time
+# rather than hardcoded here.
+#
+# Maestro's `runScript:` step cannot make this call itself (sandboxed
+# GraalJS, no network access — see the README's "Why a wrapper script"
+# section for the same limitation applied to DB access), so this resolves
+# the id out of band, the same way seed-before-test.sh and the other
+# pre/*.sh hooks do, and drops it in a file run-flow.sh reads and forwards
+# to `maestro test -e DOG_ID=...`.
+#
+# Goes through the API rather than psql: psql isn't guaranteed to be on a
+# dev machine and no other script here depends on it. Logging in as the
+# magic user and reading match.getAll is the same path the app itself uses
+# to learn about Bella, so this doubles as a liveness check of the API +
+# magic-login bypass before the flow even starts.
+set -euo pipefail
+
+API_URL="${EXPO_PUBLIC_API_URL:-http://localhost:3010/api}"
+MAGIC_EMAIL="${APPLE_MAGIC_EMAIL%%,*}"
+MAGIC_EMAIL="${MAGIC_EMAIL:-test@pegada.app}"
+MAGIC_CODE="${APPLE_MAGIC_CODE:-424242}"
+CACHE_FILE="${TMPDIR:-/tmp}/pegada-maestro-dog-id"
+
+TOKEN=$(curl -sf -X POST "$API_URL/trpc/authentication.login?batch=1" \
+  -H "Content-Type: application/json" \
+  -d "{\"0\":{\"json\":{\"email\":\"$MAGIC_EMAIL\",\"code\":\"$MAGIC_CODE\"}}}" \
+  | jq -r '.[0].result.data.json.token // empty')
+
+if [[ -z "$TOKEN" ]]; then
+  echo "[pre-46] FATAL: could not log in as $MAGIC_EMAIL at $API_URL to resolve Bella's dog id" >&2
+  exit 1
+fi
+
+MATCH_INPUT='%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D%7D'
+DOG_ID=$(curl -sf "$API_URL/trpc/match.getAll?batch=1&input=$MATCH_INPUT" \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq -r '[.[0].result.data.json[] | select(.dog.name == "Bella")][0].dog.id // empty')
+
+if [[ -z "$DOG_ID" ]]; then
+  echo "[pre-46] FATAL: could not resolve Bella's dog id — run maestro:seed first" >&2
+  exit 1
+fi
+
+echo "$DOG_ID" > "$CACHE_FILE"
+echo "[pre-46] resolved dog id: $DOG_ID (cached at $CACHE_FILE)"

--- a/apps/mobile/.maestro/scripts/pre/47-resolve-dog-id.sh
+++ b/apps/mobile/.maestro/scripts/pre/47-resolve-dog-id.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Flow 47's pre-hook. The work is shared with flow 46 — see
+# 46-resolve-dog-id.sh for what it does and why.
+set -euo pipefail
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/46-resolve-dog-id.sh"

--- a/apps/mobile/.maestro/scripts/run-flow.sh
+++ b/apps/mobile/.maestro/scripts/run-flow.sh
@@ -99,6 +99,18 @@ fi
 export APP_ID="${APP_ID:-app.pegada}"
 export APP_SCHEME="${APP_SCHEME:-pegada}"
 
+# 3a. Flows 46/47 (deep-link sign-in hand-off) need a real dog id, resolved
+# at run time by their pre-hook (pre/46-resolve-dog-id.sh) since it's a
+# cuid2 assigned at seed insert time, not a constant. The pre-hook runs in
+# its own subshell above, so it can't export DOG_ID back into this shell —
+# it drops it in a cache file instead, which is read here if present.
+# Harmless for every other flow: an unused `-e` var is a no-op for Maestro.
+MAESTRO_DOG_ID_CACHE="${TMPDIR:-/tmp}/pegada-maestro-dog-id"
+if [[ -z "${DOG_ID:-}" && -f "$MAESTRO_DOG_ID_CACHE" ]]; then
+  DOG_ID="$(cat "$MAESTRO_DOG_ID_CACHE")"
+fi
+export DOG_ID="${DOG_ID:-}"
+
 # 3b. Name the device, don't let anything downstream infer it.
 #
 # This wrapper is the iOS one. Its Android counterpart already exports
@@ -154,7 +166,8 @@ echo ""
 echo "==> maestro test $FLOW_PATH"
 set +e
 maestro "${MAESTRO_DEVICE_ARGS[@]}" test \
-  -e APP_ID="$APP_ID" -e APP_SCHEME="$APP_SCHEME" "$FLOW_PATH" "$@"
+  -e APP_ID="$APP_ID" -e APP_SCHEME="$APP_SCHEME" -e DOG_ID="$DOG_ID" \
+  "$FLOW_PATH" "$@"
 MAESTRO_RC=$?
 set -e
 

--- a/apps/mobile/__tests__/app/dog/[id].test.tsx
+++ b/apps/mobile/__tests__/app/dog/[id].test.tsx
@@ -4,6 +4,18 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { router } from "expo-router";
 
 /**
+ * Deliberately NOT colocated next to `src/app/dog/[id].tsx`, the way every
+ * other test in this package sits next to its subject. `src/app` is
+ * expo-router's route root, and its `require.context` (expo-router/_ctx.ios.js)
+ * matches EVERY `.tsx` under it except `+api`/`+html`/`+middleware` — there is
+ * no exclusion for `.test.`/`.spec.`. A test file left in there becomes a real
+ * route in dev AND release, and the router eagerly requires every route module
+ * at startup. This file's top-level `react-dom/server` import then resolves to
+ * `server.browser.js`, which touches `MessageChannel` — a global Hermes does
+ * not have — so the app threw `ReferenceError: Property 'MessageChannel'
+ * doesn't exist` before it painted a single frame and died on launch.
+ * `no-test-files-in-router-root.test.ts` is the guard that keeps it out.
+ *
  * The defect this file guards: a warm `pegada://dog/<id>` link (app already
  * running, e.g. sitting on SignIn while logged out) gets PUSHED on top of
  * the running app. This screen renders `null`, and root `_layout.tsx`'s
@@ -56,11 +68,10 @@ jest.mock<Record<string, unknown>>("react", () => {
   return { ...actual, useEffect: (effect: () => void) => effect() };
 });
 
+import DogLink from "@/app/dog/[id]";
+import LocalizedDogLink from "@/app/pt-br/dog/[id]";
 import { analytics } from "@/services/analytics";
 import { setPendingDogProfile } from "@/services/linking/handlers/pending-dog-profile";
-
-import LocalizedDogLink from "../pt-br/dog/[id]";
-import DogLink from "./[id]";
 
 const canGoBack = jest.mocked(router.canGoBack);
 const back = jest.mocked(router.back);

--- a/apps/mobile/__tests__/app/no-test-files-in-router-root.test.ts
+++ b/apps/mobile/__tests__/app/no-test-files-in-router-root.test.ts
@@ -1,0 +1,36 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * `src/app` is expo-router's route root. Its `require.context`
+ * (expo-router/_ctx.ios.js) matches every `.tsx`/`.ts` under it and excludes
+ * only `+api`, `+html` and `+middleware` — nothing filters `.test.` or
+ * `.spec.`. So a colocated test file is not inert: it is registered as a
+ * route, and the router requires every route module eagerly at startup, in
+ * release builds as much as in dev.
+ *
+ * That is a crash, not a cosmetic warning. A test's top-level
+ * `react-dom/server` import resolves to `server.browser.js`, which reads
+ * `MessageChannel` — a global Hermes does not have — and the app died with
+ * `ReferenceError: Property 'MessageChannel' doesn't exist` before painting
+ * its first frame. `jest.mock` at module scope would blow up the same way,
+ * with `jest` undefined.
+ *
+ * Route tests therefore live under `__tests__/app/`, importing their subject
+ * through the `@/app/...` alias.
+ */
+const ROUTER_ROOT = join(__dirname, "..", "..", "src", "app");
+
+const collect = (dir: string, prefix = ""): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+    return entry.isDirectory() ? collect(join(dir, entry.name), path) : [path];
+  });
+
+test("no test or spec files live inside expo-router's route root", () => {
+  const offenders = collect(ROUTER_ROOT).filter((path) =>
+    /\.(test|spec)\.[jt]sx?$/.test(path),
+  );
+
+  expect(offenders).toStrictEqual([]);
+});

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -42,7 +42,7 @@ const config: ExpoConfig = {
    * That affects eas updates and makes sure the app doesn't
    * break when updating Over The Air
    */
-  version: "1.6.2",
+  version: "1.7.1",
   runtimeVersion: {
     policy: "appVersion",
   },
@@ -274,20 +274,20 @@ const config: ExpoConfig = {
       backgroundColor: "#FFFFFF",
     },
     package: "app.pegada",
-    // intentFilters: [
-    //   {
-    //     action: 'VIEW',
-    //     autoVerify: true,
-    //     data: [
-    //       {
-    //         scheme: 'https',
-    //         host: '*.pegada.app',
-    //         pathPrefix: '/',
-    //       },
-    //     ],
-    //     category: ['BROWSABLE', 'DEFAULT'],
-    //   },
-    // ],
+    intentFilters: [
+      {
+        action: "VIEW",
+        autoVerify: true,
+        data: [
+          {
+            scheme: "https",
+            host: "*.pegada.app",
+            pathPrefix: "/",
+          },
+        ],
+        category: ["BROWSABLE", "DEFAULT"],
+      },
+    ],
   },
   userInterfaceStyle: "automatic",
   locales: {
@@ -322,10 +322,7 @@ const config: ExpoConfig = {
       usesNonExemptEncryption: false,
     },
     bundleIdentifier: "app.pegada",
-    // associatedDomains: [
-    //   'applinks:pegada.app',
-    //   'applinks:www.pegada.app',
-    // ],
+    associatedDomains: ["applinks:pegada.app", "applinks:www.pegada.app"],
   },
   extra: {
     oneSignalAppId: "",

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -278,11 +278,19 @@ const config: ExpoConfig = {
       {
         action: "VIEW",
         autoVerify: true,
+        // A wildcard host ("*.pegada.app") makes Android's autoVerify
+        // handshake against /.well-known/assetlinks.json unreliable, so the
+        // hosts that actually serve that file are listed explicitly instead.
         data: [
           {
             scheme: "https",
-            host: "*.pegada.app",
-            pathPrefix: "/",
+            host: "pegada.app",
+            pathPrefix: "/dog",
+          },
+          {
+            scheme: "https",
+            host: "www.pegada.app",
+            pathPrefix: "/dog",
           },
         ],
         category: ["BROWSABLE", "DEFAULT"],

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -281,6 +281,14 @@ const config: ExpoConfig = {
         // A wildcard host ("*.pegada.app") makes Android's autoVerify
         // handshake against /.well-known/assetlinks.json unreliable, so the
         // hosts that actually serve that file are listed explicitly instead.
+        //
+        // "/pt-br/dog" is listed beside "/dog" because next-intl runs with
+        // `localePrefix: "as-needed"` and 307s a `Accept-Language: pt-BR`
+        // browser from /dog/<id> to /pt-br/dog/<id>, so that is the URL a
+        // Brazilian user copies and shares. Kept in step with the iOS AASA
+        // (apps/nextjs .well-known/apple-app-site-association) and with the
+        // expo-router routes under src/app by the consistency test in
+        // apps/nextjs/tests/apple-app-site-association.test.mjs.
         data: [
           {
             scheme: "https",
@@ -289,8 +297,18 @@ const config: ExpoConfig = {
           },
           {
             scheme: "https",
+            host: "pegada.app",
+            pathPrefix: "/pt-br/dog",
+          },
+          {
+            scheme: "https",
             host: "www.pegada.app",
             pathPrefix: "/dog",
+          },
+          {
+            scheme: "https",
+            host: "www.pegada.app",
+            pathPrefix: "/pt-br/dog",
           },
         ],
         category: ["BROWSABLE", "DEFAULT"],

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -127,6 +127,9 @@ const App = () => {
                 <Stack.Screen name="(app)" />
                 <Stack.Screen name="(auth)" />
                 <Stack.Screen name="dog/[id]" />
+                {/* Same screen, mounted under the pt-BR locale prefix the
+                    web app redirects Brazilian browsers to. */}
+                <Stack.Screen name="pt-br/dog/[id]" />
               </Stack>
             </Provider>
             <MagicModalPortal />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -21,7 +21,10 @@ import { useProtectedRoute } from "@/hooks/use-protected-route";
 import { useTrackScreens } from "@/hooks/use-track-screens";
 import { config } from "@/services/config";
 import { sendError } from "@/services/error-tracking";
-import { useGetInitialNotifications } from "@/services/linking";
+import {
+  useGetInitialNotifications,
+  usePendingDogProfile,
+} from "@/services/linking";
 import { getExpoPostHog } from "@/services/observability";
 import { useQuickActions } from "@/services/quick-actions";
 import { useCaptureReferral } from "@/services/referral";
@@ -82,6 +85,9 @@ const App = () => {
   useCaptureReferral();
   // Wait for authentication and onboarding before following a shortcut.
   useQuickActions(initialRouteName === SceneName.Swipe);
+  // Same gate: a pending /dog/<id> link is only followed once the user has
+  // landed on Swipe, so it never pushes a protected screen while logged out.
+  usePendingDogProfile(initialRouteName === SceneName.Swipe);
 
   // MAESTRO_E2E only: render magic modals inside the main window instead
   // of RNScreens' FullWindowOverlay. The overlay is a separate native
@@ -120,6 +126,7 @@ const App = () => {
                 <Stack.Screen name="index" />
                 <Stack.Screen name="(app)" />
                 <Stack.Screen name="(auth)" />
+                <Stack.Screen name="dog/[id]" />
               </Stack>
             </Provider>
             <MagicModalPortal />

--- a/apps/mobile/src/app/dog/[id].test.tsx
+++ b/apps/mobile/src/app/dog/[id].test.tsx
@@ -1,0 +1,165 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { router } from "expo-router";
+
+/**
+ * The defect this file guards: a warm `pegada://dog/<id>` link (app already
+ * running, e.g. sitting on SignIn while logged out) gets PUSHED on top of
+ * the running app. This screen renders `null`, and root `_layout.tsx`'s
+ * auth-redirect effect keys on `initialRouteName`, which does not change
+ * for a logged out user, so nothing ever navigated away from the invisible
+ * frame. It was a permanent blank screen that `back` could not recover.
+ */
+
+let mockId: string | undefined = "dog-1";
+
+jest.mock<Partial<typeof import("expo-router")>>("expo-router", () => ({
+  // Cast because the real signature promises `string`, which is the very
+  // lie the screen guards against: expo-router hands back `undefined` for a
+  // malformed link and for the render before it has parsed the URL.
+  useLocalSearchParams: (() => ({
+    id: mockId,
+  })) as unknown as typeof import("expo-router").useLocalSearchParams,
+  router: {
+    canGoBack: jest.fn(() => false),
+    back: jest.fn(),
+  } as unknown as typeof import("expo-router").router,
+}));
+
+jest.mock<Record<string, unknown>>(
+  "@/services/linking/handlers/pending-dog-profile",
+  () => ({ setPendingDogProfile: jest.fn() }),
+);
+
+let mockToken: string | undefined;
+
+jest.mock<Record<string, unknown>>("@/services/storage", () => ({
+  StorageKeys: { Token: "token" },
+  getData: jest.fn(() => Promise.resolve(mockToken)),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { track: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+// Same reason as services/linking/index.test.ts: `renderToStaticMarkup` is
+// the only renderer this package has and it has no commit phase, so a real
+// `useEffect` would never fire. Running it inline stands in for "the effect
+// ran".
+jest.mock<Record<string, unknown>>("react", () => {
+  const actual = jest.requireActual("react") as typeof React;
+  return { ...actual, useEffect: (effect: () => void) => effect() };
+});
+
+import { analytics } from "@/services/analytics";
+import { setPendingDogProfile } from "@/services/linking/handlers/pending-dog-profile";
+
+import LocalizedDogLink from "../pt-br/dog/[id]";
+import DogLink from "./[id]";
+
+const canGoBack = jest.mocked(router.canGoBack);
+const back = jest.mocked(router.back);
+const track = jest.mocked(analytics.track);
+const setPending = jest.mocked(setPendingDogProfile);
+
+// `clearMocks` is on, so the return value has to be re-declared per test.
+beforeEach(() => {
+  mockId = "dog-1";
+  mockToken = undefined;
+  canGoBack.mockReturnValue(false);
+});
+
+const render = () => renderToStaticMarkup(React.createElement(DogLink));
+
+// The effect fires `trackLinkOpened`, whose first await is the stored token.
+const flush = () =>
+  new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+
+test("cold start leaves the route in place for _layout to replace", () => {
+  canGoBack.mockReturnValue(false);
+
+  render();
+
+  expect(back).not.toHaveBeenCalled();
+  expect(setPending).toHaveBeenCalledWith("dog-1");
+});
+
+test("a warm link pops itself off, so the screen underneath comes back", () => {
+  canGoBack.mockReturnValue(true);
+
+  render();
+
+  expect(back).toHaveBeenCalledTimes(1);
+});
+
+test("a warm link pops BEFORE storing the id, never after", () => {
+  canGoBack.mockReturnValue(true);
+
+  render();
+
+  // Reversed, storing the id would push the profile (usePendingDogProfile
+  // reacts to it) and the pop would then take that profile straight off
+  // again. `invocationCallOrder` is jest's global, monotonic call counter,
+  // so it orders calls across two separate mocks.
+  expect(back.mock.invocationCallOrder[0]).toBeLessThan(
+    setPending.mock.invocationCallOrder[0]!,
+  );
+});
+
+test("stores the id either way, so the pending hand off still happens", () => {
+  canGoBack.mockReturnValue(true);
+
+  render();
+
+  expect(setPending).toHaveBeenCalledWith("dog-1");
+});
+
+test("a link with no id does nothing at all", () => {
+  canGoBack.mockReturnValue(true);
+  mockId = undefined;
+
+  render();
+
+  // Popping here would throw away a screen for a link that names no dog,
+  // and clearing the store would drop an id a previous link had just set.
+  expect(back).not.toHaveBeenCalled();
+  expect(setPending).not.toHaveBeenCalled();
+  expect(track).not.toHaveBeenCalled();
+});
+
+test("reports the link as opened, logged out", async () => {
+  render();
+  await flush();
+
+  expect(track).toHaveBeenCalledWith({
+    event_type: "Dog Link Opened",
+    event_properties: { authenticated: false },
+  });
+});
+
+test("reports the link as opened, logged in", async () => {
+  mockToken = "a-token";
+
+  render();
+  await flush();
+
+  expect(track).toHaveBeenCalledWith({
+    event_type: "Dog Link Opened",
+    event_properties: { authenticated: true },
+  });
+});
+
+// iOS and Android both claim `/pt-br/dog/*` (see the AASA route and
+// app.config.ts). A route file has to exist at that exact path or the link
+// opens the app onto expo-router's Unmatched Route, and it has to be this
+// screen or the localized link behaves differently from the plain one.
+test("the pt-br locale prefix resolves to the very same screen", () => {
+  expect(LocalizedDogLink).toBe(DogLink);
+});

--- a/apps/mobile/src/app/dog/[id].tsx
+++ b/apps/mobile/src/app/dog/[id].tsx
@@ -51,6 +51,13 @@ const DogLink = () => {
   const { id } = useLocalSearchParams<{ id: string }>();
 
   useEffect(() => {
+    // `useLocalSearchParams` is typed as if the param is always there, but a
+    // malformed link (`pegada://dog/`) and the render before expo-router has
+    // parsed the URL both hand back `undefined`. Passing that straight
+    // through would clear a pending id that a previous link had just set,
+    // and would file a funnel event for a link that names no dog.
+    if (!id) return;
+
     setPendingDogProfile(id);
     trackLinkOpened().catch(sendError);
   }, [id]);

--- a/apps/mobile/src/app/dog/[id].tsx
+++ b/apps/mobile/src/app/dog/[id].tsx
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 
 import { useLocalSearchParams } from "expo-router";
 
+import { analytics } from "@/services/analytics";
+import { sendError } from "@/services/error-tracking";
 import { setPendingDogProfile } from "@/services/linking/handlers/pending-dog-profile";
+import { getData, StorageKeys } from "@/services/storage";
 
 /**
  * Entry point for `pegada://dog/<id>` and `https://www.pegada.app/dog/<id>`.
@@ -24,11 +27,32 @@ import { setPendingDogProfile } from "@/services/linking/handlers/pending-dog-pr
  * link it sits, still invisible, one `back` behind the profile
  * `usePendingDogProfile` pushes on top of it.
  */
+/**
+ * First step of the shared-link funnel: "Dog Link Opened" ->
+ * "Dog Link Sign In Banner Shown" (logged out only) -> "Dog Link Profile
+ * Opened". Without this event there is no way to tell a link that never
+ * opened the app from one that opened it and lost the user on sign in.
+ *
+ * `authenticated` is read off the stored token rather than waiting for
+ * `getInitialRouteName`'s round trip, so the event fires on the same tick
+ * the link lands. An expired token still counts as authenticated here; the
+ * funnel's second step is what separates the two in practice.
+ */
+const trackLinkOpened = async () => {
+  const token = await getData(StorageKeys.Token);
+
+  analytics.track({
+    event_type: "Dog Link Opened",
+    event_properties: { authenticated: Boolean(token) },
+  });
+};
+
 const DogLink = () => {
   const { id } = useLocalSearchParams<{ id: string }>();
 
   useEffect(() => {
     setPendingDogProfile(id);
+    trackLinkOpened().catch(sendError);
   }, [id]);
 
   return null;

--- a/apps/mobile/src/app/dog/[id].tsx
+++ b/apps/mobile/src/app/dog/[id].tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+
+import { useLocalSearchParams } from "expo-router";
+
+import { setPendingDogProfile } from "@/services/linking/handlers/pending-dog-profile";
+
+/**
+ * Entry point for `pegada://dog/<id>` and `https://www.pegada.app/dog/<id>`.
+ * Renders nothing and does not navigate itself -- it only stashes the id for
+ * `usePendingDogProfile` (services/linking/index.ts) to push once the app
+ * reaches its authenticated home route.
+ *
+ * Deliberately does NOT `router.replace` anywhere from here. It used to
+ * replace to `/`, reasoning that would hand the moment back to the same
+ * index/splash route a plain cold launch goes through. That broke the warm
+ * case: this screen sits *on top of* the already-mounted app (e.g. the
+ * Swipe tab), and root `_layout.tsx`'s auth-redirect effect only reruns when
+ * `useSegments()`'s first segment toggles into/out of "(auth)" -- replacing
+ * to `/` doesn't trigger that, so nothing ever navigated the user off the
+ * splash screen and a `back` from the pushed dog profile stranded them
+ * there. Left unhandled, this screen just stays as an inert, invisible
+ * frame in the stack: harmless on cold start (the auth-redirect effect
+ * that already runs on `_layout` mount replaces it directly), and on a warm
+ * link it sits, still invisible, one `back` behind the profile
+ * `usePendingDogProfile` pushes on top of it.
+ */
+const DogLink = () => {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  useEffect(() => {
+    setPendingDogProfile(id);
+  }, [id]);
+
+  return null;
+};
+
+export default DogLink;

--- a/apps/mobile/src/app/dog/[id].tsx
+++ b/apps/mobile/src/app/dog/[id].tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { useLocalSearchParams } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
@@ -8,24 +8,35 @@ import { setPendingDogProfile } from "@/services/linking/handlers/pending-dog-pr
 import { getData, StorageKeys } from "@/services/storage";
 
 /**
- * Entry point for `pegada://dog/<id>` and `https://www.pegada.app/dog/<id>`.
- * Renders nothing and does not navigate itself -- it only stashes the id for
+ * Entry point for `pegada://dog/<id>` and `https://www.pegada.app/dog/<id>`
+ * (plus the localized `/pt-br/dog/<id>`, which re-exports this screen from
+ * app/pt-br/dog/[id].tsx). It renders nothing: the id is stashed for
  * `usePendingDogProfile` (services/linking/index.ts) to push once the app
  * reaches its authenticated home route.
  *
- * Deliberately does NOT `router.replace` anywhere from here. It used to
- * replace to `/`, reasoning that would hand the moment back to the same
- * index/splash route a plain cold launch goes through. That broke the warm
- * case: this screen sits *on top of* the already-mounted app (e.g. the
- * Swipe tab), and root `_layout.tsx`'s auth-redirect effect only reruns when
- * `useSegments()`'s first segment toggles into/out of "(auth)" -- replacing
- * to `/` doesn't trigger that, so nothing ever navigated the user off the
- * splash screen and a `back` from the pushed dog profile stranded them
- * there. Left unhandled, this screen just stays as an inert, invisible
- * frame in the stack: harmless on cold start (the auth-redirect effect
- * that already runs on `_layout` mount replaces it directly), and on a warm
- * link it sits, still invisible, one `back` behind the profile
- * `usePendingDogProfile` pushes on top of it.
+ * Rendering nothing means this route MUST NOT be allowed to stay on top of
+ * the stack, or the user is looking at a blank screen with no way out.
+ * There are two ways it gets there and they need opposite handling:
+ *
+ * - Cold start (the link launched the app): this is the only route, and
+ *   `router.canGoBack()` is false. Root `_layout.tsx`'s auth-redirect
+ *   effect runs on mount and REPLACES it with the resolved initial route,
+ *   so nothing is needed here.
+ *
+ * - Warm link (the app was already running): expo-router PUSHES this route
+ *   on top of whatever was on screen, and `_layout.tsx`'s effect does not
+ *   re-run -- it keys on `initialRouteName`, which is unchanged (a logged
+ *   out user sitting on SignIn resolves to `/sign-in` before and after), so
+ *   `router.replace` is never called and the invisible frame stays on top
+ *   forever. `back` does not recover it either, because the user is already
+ *   at the top of the stack. Popping ourselves is what fixes that: the
+ *   screen underneath is exactly where the app was, which is where the
+ *   redirect logic already put the user -- SignIn (banner and all) while
+ *   logged out, Swipe or wherever they were once authenticated.
+ *
+ * The pop happens BEFORE `setPendingDogProfile`, because storing the id is
+ * what wakes `usePendingDogProfile` up to push the profile: popping after
+ * that would pop the profile straight back off.
  */
 /**
  * First step of the shared-link funnel: "Dog Link Opened" ->
@@ -57,6 +68,11 @@ const DogLink = () => {
     // through would clear a pending id that a previous link had just set,
     // and would file a funnel event for a link that names no dog.
     if (!id) return;
+
+    // Warm link: pop this invisible frame off before anything else, so the
+    // screen the app was already showing comes back. Cold start has nothing
+    // underneath, and `_layout.tsx` replaces this route instead.
+    if (router.canGoBack()) router.back();
 
     setPendingDogProfile(id);
     trackLinkOpened().catch(sendError);

--- a/apps/mobile/src/app/pt-br/dog/[id].tsx
+++ b/apps/mobile/src/app/pt-br/dog/[id].tsx
@@ -1,0 +1,19 @@
+/**
+ * The same screen as `app/dog/[id].tsx`, mounted a second time under the
+ * pt-BR locale prefix.
+ *
+ * The web app runs next-intl with `localePrefix: "as-needed"`, so a browser
+ * sending `Accept-Language: pt-BR` gets a 307 from `/dog/<id>` to
+ * `/pt-br/dog/<id>` -- which means `/pt-br/dog/<id>` is the URL a Brazilian
+ * user actually copies out of the address bar and shares. iOS claims it
+ * (see the AASA route in apps/nextjs) and Android's intent filters claim it
+ * too, so without a route at this exact path the app would open the link
+ * onto expo-router's "Unmatched Route" screen.
+ *
+ * Only the non-default locale needs a file: `/en-us/dog/<id>` is redirected
+ * back to the unprefixed `/dog/<id>` by the same next-intl config, so it is
+ * never a shareable URL. If a third locale is ever added, the AASA
+ * consistency test in apps/nextjs/tests fails until it gets a sibling of
+ * this file.
+ */
+export { default } from "@/app/dog/[id]";

--- a/apps/mobile/src/components/PendingDogProfileBanner/index.test.tsx
+++ b/apps/mobile/src/components/PendingDogProfileBanner/index.test.tsx
@@ -113,6 +113,16 @@ test("reports itself once per pending id, across both screens that render it", (
   expect(track).toHaveBeenCalledTimes(2);
 });
 
+// Open a link, log in, log out, open the same link again: the banner is shown
+// a second time, so it has to be reported a second time.
+test("reports the same id again after the pending link was consumed", () => {
+  render("dog-track-3");
+  render(undefined);
+  render("dog-track-3");
+
+  expect(track).toHaveBeenCalledTimes(2);
+});
+
 test("shows the title before the body, matching the bold-first-sentence copy", () => {
   const html = render("dog-1");
 

--- a/apps/mobile/src/components/PendingDogProfileBanner/index.test.tsx
+++ b/apps/mobile/src/components/PendingDogProfileBanner/index.test.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+/**
+ * Rendered through react-dom/server, matching the other component tests in
+ * this package (see NewMatch/index.test.tsx): no React Native transform
+ * here, so every RN-flavoured import is stubbed. `View` records the props it
+ * was given rather than forwarding them to a host element — `testID` is not
+ * a DOM attribute and react-dom logs unknown ones through `console.error`.
+ */
+const capturedViewProps: Record<string, unknown>[] = [];
+
+jest.mock<Record<string, unknown>>("react-native", () => {
+  const { createElement } = require("react") as typeof React;
+
+  return {
+    View: (props: { children?: React.ReactNode; testID?: string }) => {
+      capturedViewProps.push(props);
+      return createElement("div", null, props.children);
+    },
+  };
+});
+
+jest.mock<Record<string, unknown>>("react-native-unistyles", () => ({
+  useUnistyles: () => ({ theme: { colors: { text: "#000" } } }),
+}));
+
+jest.mock<Record<string, unknown>>("./styles", () => ({
+  styles: { banner: {}, textColumn: {}, title: {}, body: {} },
+}));
+
+jest.mock<Record<string, unknown>>("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock<Record<string, unknown>>("@/assets/images/Dog.svg", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/text", () => ({
+  Text: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+let mockPendingDogProfileId: string | undefined;
+
+jest.mock<Record<string, unknown>>(
+  "@/services/linking/handlers/pending-dog-profile",
+  () => ({
+    usePendingDogProfileId: () => mockPendingDogProfileId,
+  }),
+);
+
+import { PendingDogProfileBanner } from ".";
+
+const render = (pendingId: string | undefined) => {
+  capturedViewProps.length = 0;
+  mockPendingDogProfileId = pendingId;
+  return renderToStaticMarkup(React.createElement(PendingDogProfileBanner));
+};
+
+test("renders nothing when there is no pending dog profile", () => {
+  const html = render(undefined);
+
+  expect(html).toBe("");
+  expect(capturedViewProps).toHaveLength(0);
+});
+
+test("renders the banner, keyed by its stable testID, when a dog id is pending", () => {
+  render("dog-1");
+
+  expect(capturedViewProps[0]?.testID).toBe("signin-pending-dog-profile");
+});
+
+test("shows the title before the body, matching the bold-first-sentence copy", () => {
+  const html = render("dog-1");
+
+  expect(
+    html.indexOf("insertEmail.pendingDogProfileBanner.title"),
+  ).toBeLessThan(html.indexOf("insertEmail.pendingDogProfileBanner.body"));
+});

--- a/apps/mobile/src/components/PendingDogProfileBanner/index.test.tsx
+++ b/apps/mobile/src/components/PendingDogProfileBanner/index.test.tsx
@@ -42,6 +42,22 @@ jest.mock<Record<string, unknown>>("@/components/text", () => ({
   Text: ({ children }: { children?: React.ReactNode }) => children,
 }));
 
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { track: jest.fn() },
+}));
+
+// The banner reports itself from a `useEffect`, and `renderToStaticMarkup`
+// has no commit phase, so the real one never fires. Running the callback
+// inline is how the other tests in this package stub effect-shaped hooks
+// (see services/linking/index.test.ts).
+jest.mock<Record<string, unknown>>("react", () => {
+  const actual = jest.requireActual("react") as typeof React;
+  return {
+    ...actual,
+    useEffect: (effect: () => void) => effect(),
+  };
+});
+
 let mockPendingDogProfileId: string | undefined;
 
 jest.mock<Record<string, unknown>>(
@@ -51,7 +67,11 @@ jest.mock<Record<string, unknown>>(
   }),
 );
 
+import { analytics } from "@/services/analytics";
+
 import { PendingDogProfileBanner } from ".";
+
+const track = jest.mocked(analytics.track);
 
 const render = (pendingId: string | undefined) => {
   capturedViewProps.length = 0;
@@ -59,17 +79,38 @@ const render = (pendingId: string | undefined) => {
   return renderToStaticMarkup(React.createElement(PendingDogProfileBanner));
 };
 
+afterEach(() => {
+  track.mockClear();
+});
+
 test("renders nothing when there is no pending dog profile", () => {
   const html = render(undefined);
 
   expect(html).toBe("");
   expect(capturedViewProps).toHaveLength(0);
+  expect(track).not.toHaveBeenCalled();
 });
 
 test("renders the banner, keyed by its stable testID, when a dog id is pending", () => {
   render("dog-1");
 
   expect(capturedViewProps[0]?.testID).toBe("signin-pending-dog-profile");
+});
+
+// SignIn and OneTimeCode both render this banner for one pending id, so the
+// naive "track on mount" would double count every sign in hand off.
+test("reports itself once per pending id, across both screens that render it", () => {
+  render("dog-track-1");
+  render("dog-track-1");
+
+  expect(track).toHaveBeenCalledTimes(1);
+  expect(track).toHaveBeenCalledWith({
+    event_type: "Dog Link Sign In Banner Shown",
+  });
+
+  render("dog-track-2");
+
+  expect(track).toHaveBeenCalledTimes(2);
 });
 
 test("shows the title before the body, matching the bold-first-sentence copy", () => {

--- a/apps/mobile/src/components/PendingDogProfileBanner/index.tsx
+++ b/apps/mobile/src/components/PendingDogProfileBanner/index.tsx
@@ -1,0 +1,45 @@
+import { View } from "react-native";
+
+import { useTranslation } from "react-i18next";
+import { useUnistyles } from "react-native-unistyles";
+
+import Dog from "@/assets/images/Dog.svg";
+import { Text } from "@/components/text";
+import { usePendingDogProfileId } from "@/services/linking/handlers/pending-dog-profile";
+
+import { styles } from "./styles";
+
+/**
+ * Sits above the title on SignIn and above the OTP input on OneTimeCode
+ * when a `/dog/<id>` deep link (see app/dog/[id].tsx) is waiting for the
+ * user to finish logging in.
+ *
+ * Product ask: cold-opening a shared dog profile while logged out must not
+ * look like the app did nothing. No tap and no dismiss — the banner is a
+ * passive notice, not an affordance, so it never disappears until the
+ * pending id itself is consumed (by `usePendingDogProfile` in
+ * services/linking/index.ts, once the user reaches Swipe after login).
+ */
+export const PendingDogProfileBanner = () => {
+  const pendingDogProfileId = usePendingDogProfileId();
+  const { t } = useTranslation();
+  const { theme } = useUnistyles();
+
+  if (!pendingDogProfileId) return null;
+
+  return (
+    <View testID="signin-pending-dog-profile" style={styles.banner}>
+      <Dog width={20} height={20} fill={theme.colors.text} />
+      <View style={styles.textColumn}>
+        <Text fontWeight="bold" style={styles.title}>
+          {t("insertEmail.pendingDogProfileBanner.title")}
+        </Text>
+        <Text style={styles.body}>
+          {t("insertEmail.pendingDogProfileBanner.body")}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+export default PendingDogProfileBanner;

--- a/apps/mobile/src/components/PendingDogProfileBanner/index.tsx
+++ b/apps/mobile/src/components/PendingDogProfileBanner/index.tsx
@@ -28,6 +28,11 @@ import { styles } from "./styles";
  * is concerned: "the user was told their link is waiting". Reported once per
  * id so the raw event count means what it reads like, not only the unique
  * user count a PostHog funnel would collapse it to anyway.
+ *
+ * Cleared as soon as nothing is pending, so the sentinel only ever spans one
+ * hand off. Keeping the id past that point would silently swallow the event
+ * for the second hand off of the SAME dog in one session (open a link, log
+ * in, log out, open it again), which is a real sequence and a real banner.
  */
 let lastReportedId: string | undefined;
 
@@ -37,7 +42,12 @@ export const PendingDogProfileBanner = () => {
   const { theme } = useUnistyles();
 
   useEffect(() => {
-    if (!pendingDogProfileId || pendingDogProfileId === lastReportedId) return;
+    if (!pendingDogProfileId) {
+      lastReportedId = undefined;
+      return;
+    }
+
+    if (pendingDogProfileId === lastReportedId) return;
 
     lastReportedId = pendingDogProfileId;
     analytics.track({ event_type: "Dog Link Sign In Banner Shown" });

--- a/apps/mobile/src/components/PendingDogProfileBanner/index.tsx
+++ b/apps/mobile/src/components/PendingDogProfileBanner/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { View } from "react-native";
 
 import { useTranslation } from "react-i18next";
@@ -5,6 +6,7 @@ import { useUnistyles } from "react-native-unistyles";
 
 import Dog from "@/assets/images/Dog.svg";
 import { Text } from "@/components/text";
+import { analytics } from "@/services/analytics";
 import { usePendingDogProfileId } from "@/services/linking/handlers/pending-dog-profile";
 
 import { styles } from "./styles";
@@ -20,10 +22,26 @@ import { styles } from "./styles";
  * pending id itself is consumed (by `usePendingDogProfile` in
  * services/linking/index.ts, once the user reaches Swipe after login).
  */
+/**
+ * The banner mounts twice per sign in (SignIn, then OneTimeCode) for the
+ * same pending id, and both mounts are the same moment as far as the funnel
+ * is concerned: "the user was told their link is waiting". Reported once per
+ * id so the raw event count means what it reads like, not only the unique
+ * user count a PostHog funnel would collapse it to anyway.
+ */
+let lastReportedId: string | undefined;
+
 export const PendingDogProfileBanner = () => {
   const pendingDogProfileId = usePendingDogProfileId();
   const { t } = useTranslation();
   const { theme } = useUnistyles();
+
+  useEffect(() => {
+    if (!pendingDogProfileId || pendingDogProfileId === lastReportedId) return;
+
+    lastReportedId = pendingDogProfileId;
+    analytics.track({ event_type: "Dog Link Sign In Banner Shown" });
+  }, [pendingDogProfileId]);
 
   if (!pendingDogProfileId) return null;
 

--- a/apps/mobile/src/components/PendingDogProfileBanner/styles.ts
+++ b/apps/mobile/src/components/PendingDogProfileBanner/styles.ts
@@ -1,0 +1,29 @@
+import { StyleSheet } from "react-native-unistyles";
+
+export const styles = StyleSheet.create((theme) => ({
+  banner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[2.5],
+    backgroundColor: theme.colors.secondary,
+    borderTopLeftRadius: theme.radii.md,
+    borderTopRightRadius: theme.radii.md,
+    borderBottomRightRadius: theme.radii.md,
+    borderBottomLeftRadius: theme.radii.md,
+    paddingTop: theme.spacing[3],
+    paddingRight: theme.spacing[3],
+    paddingBottom: theme.spacing[3],
+    paddingLeft: theme.spacing[3],
+    marginBottom: theme.spacing[3],
+  },
+  textColumn: {
+    flexShrink: 1,
+    gap: theme.spacing[0.5],
+  },
+  title: {
+    color: theme.colors.text,
+  },
+  body: {
+    color: theme.colors.text,
+  },
+}));

--- a/apps/mobile/src/services/linking/handlers/pending-dog-profile.test.ts
+++ b/apps/mobile/src/services/linking/handlers/pending-dog-profile.test.ts
@@ -13,6 +13,12 @@ import { renderToStaticMarkup } from "react-dom/server";
  */
 let capturedSubscribe: ((listener: () => void) => () => void) | undefined;
 
+// Flipped by the one test that needs the genuine `useSyncExternalStore`
+// (see "renders under a server renderer"), which is the only way to prove
+// the `getServerSnapshot` argument is actually there: the stub below would
+// happily ignore a missing one.
+let mockUseRealSyncExternalStore = false;
+
 jest.mock<Record<string, unknown>>("react", () => {
   const actual = jest.requireActual("react") as typeof React;
   return {
@@ -20,8 +26,16 @@ jest.mock<Record<string, unknown>>("react", () => {
     useSyncExternalStore: (
       subscribe: (listener: () => void) => () => void,
       getSnapshot: () => unknown,
+      getServerSnapshot?: () => unknown,
     ) => {
       capturedSubscribe = subscribe;
+      if (mockUseRealSyncExternalStore) {
+        return actual.useSyncExternalStore(
+          subscribe,
+          getSnapshot as () => never,
+          getServerSnapshot as (() => never) | undefined,
+        );
+      }
       return getSnapshot();
     },
   };
@@ -43,6 +57,7 @@ const render = () => renderToStaticMarkup(React.createElement(Harness));
 afterEach(() => {
   setPendingDogProfile(undefined);
   capturedSubscribe = undefined;
+  mockUseRealSyncExternalStore = false;
 });
 
 test("has no pending id by default", () => {
@@ -71,6 +86,17 @@ test("usePendingDogProfileId reflects the current value at render time", () => {
 
 test("usePendingDogProfileId is undefined when nothing is pending", () => {
   expect(render()).toContain("none");
+});
+
+// React throws "Missing getServerSnapshot, which is required for
+// server-rendered content" if the hook is rendered on the server without a
+// third argument. Nothing ships server rendered here, but every renderer
+// this package has is a server one, so the hook has to survive it.
+test("renders under a server renderer, reading the same value", () => {
+  mockUseRealSyncExternalStore = true;
+  setPendingDogProfile("dog-ssr");
+
+  expect(render()).toContain("dog-ssr");
 });
 
 test("notifies every subscriber when the id changes, stops after unsubscribe", () => {

--- a/apps/mobile/src/services/linking/handlers/pending-dog-profile.test.ts
+++ b/apps/mobile/src/services/linking/handlers/pending-dog-profile.test.ts
@@ -1,0 +1,100 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+/**
+ * `usePendingDogProfileId` is a thin `useSyncExternalStore(subscribe, get)`
+ * wrapper, and `subscribe` is a module-private closure over the `listeners`
+ * Set — never exported, so there is nothing to call directly to prove
+ * subscribers actually get notified. Capturing the `subscribe` argument
+ * React would otherwise receive gives a handle on that exact closure
+ * without needing a live renderer: this package has none (see the other
+ * tests under src/ for why `renderToStaticMarkup` is the only renderer on
+ * hand, and it has no commit phase to run a real subscription through).
+ */
+let capturedSubscribe: ((listener: () => void) => () => void) | undefined;
+
+jest.mock<Record<string, unknown>>("react", () => {
+  const actual = jest.requireActual("react") as typeof React;
+  return {
+    ...actual,
+    useSyncExternalStore: (
+      subscribe: (listener: () => void) => () => void,
+      getSnapshot: () => unknown,
+    ) => {
+      capturedSubscribe = subscribe;
+      return getSnapshot();
+    },
+  };
+});
+
+import {
+  getPendingDogProfile,
+  setPendingDogProfile,
+  usePendingDogProfileId,
+} from "./pending-dog-profile";
+
+const Harness = () => {
+  const id = usePendingDogProfileId();
+  return React.createElement("span", null, id ?? "none");
+};
+
+const render = () => renderToStaticMarkup(React.createElement(Harness));
+
+afterEach(() => {
+  setPendingDogProfile(undefined);
+  capturedSubscribe = undefined;
+});
+
+test("has no pending id by default", () => {
+  expect(getPendingDogProfile()).toBeUndefined();
+});
+
+test("set stores the id", () => {
+  setPendingDogProfile("dog-1");
+
+  expect(getPendingDogProfile()).toBe("dog-1");
+});
+
+test("set with no argument clears the id", () => {
+  setPendingDogProfile("dog-1");
+
+  setPendingDogProfile(undefined);
+
+  expect(getPendingDogProfile()).toBeUndefined();
+});
+
+test("usePendingDogProfileId reflects the current value at render time", () => {
+  setPendingDogProfile("dog-2");
+
+  expect(render()).toContain("dog-2");
+});
+
+test("usePendingDogProfileId is undefined when nothing is pending", () => {
+  expect(render()).toContain("none");
+});
+
+test("notifies every subscriber when the id changes, stops after unsubscribe", () => {
+  render();
+  expect(capturedSubscribe).toBeDefined();
+
+  const listenerA = jest.fn();
+  const listenerB = jest.fn();
+  const unsubscribeA = capturedSubscribe!(listenerA);
+  const unsubscribeB = capturedSubscribe!(listenerB);
+
+  setPendingDogProfile("dog-3");
+
+  expect(listenerA).toHaveBeenCalledTimes(1);
+  expect(listenerB).toHaveBeenCalledTimes(1);
+
+  unsubscribeA();
+  setPendingDogProfile("dog-4");
+
+  expect(listenerA).toHaveBeenCalledTimes(1);
+  expect(listenerB).toHaveBeenCalledTimes(2);
+
+  unsubscribeB();
+  setPendingDogProfile("dog-5");
+
+  expect(listenerB).toHaveBeenCalledTimes(2);
+});

--- a/apps/mobile/src/services/linking/handlers/pending-dog-profile.ts
+++ b/apps/mobile/src/services/linking/handlers/pending-dog-profile.ts
@@ -1,0 +1,30 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * The dog id from a `/dog/<id>` deep link that arrived before, or during,
+ * authentication. Held in a module-local binding with an accessor rather
+ * than exported as a `let` (see initial-notification.ts for why), plus a
+ * subscription list on top of that shape: a *warm* link can arrive while the
+ * app is already sitting on its authenticated home route, where nothing else
+ * re-renders on its own to notice the value changed -- `usePendingDogProfileId`
+ * is what lets `usePendingDogProfile` (services/linking/index.ts) react to it.
+ */
+let pendingDogProfileId: string | undefined;
+const listeners = new Set<() => void>();
+
+export const getPendingDogProfile = () => pendingDogProfileId;
+
+export const setPendingDogProfile = (id?: string) => {
+  pendingDogProfileId = id;
+  for (const listener of listeners) listener();
+};
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const usePendingDogProfileId = () =>
+  useSyncExternalStore(subscribe, getPendingDogProfile);

--- a/apps/mobile/src/services/linking/handlers/pending-dog-profile.ts
+++ b/apps/mobile/src/services/linking/handlers/pending-dog-profile.ts
@@ -26,5 +26,11 @@ const subscribe = (listener: () => void) => {
   };
 };
 
+// The third argument is the server snapshot. Nothing here is server
+// rendered on device, but React throws "Missing getServerSnapshot" the
+// moment this hook runs under any server renderer, which is exactly what
+// the tests in this package use (`react-dom/server`). Reading the same
+// module-local binding keeps runtime behaviour identical and makes the
+// hook safe to render anywhere.
 export const usePendingDogProfileId = () =>
-  useSyncExternalStore(subscribe, getPendingDogProfile);
+  useSyncExternalStore(subscribe, getPendingDogProfile, getPendingDogProfile);

--- a/apps/mobile/src/services/linking/index.test.ts
+++ b/apps/mobile/src/services/linking/index.test.ts
@@ -24,14 +24,15 @@ jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
   sendError: jest.fn(),
 }));
 
-// The real `usePendingDogProfileId` is `useSyncExternalStore` without a
-// `getServerSnapshot` argument — fine on React Native, but
-// `react-dom/server`'s renderer refuses to run it without one ("Missing
-// getServerSnapshot, which is required for server-rendered content").
-// pending-dog-profile.test.ts already covers that hook and its store in
-// isolation; here the pending id is just an input to usePendingDogProfile,
-// so it is driven directly through this mock rather than through a second
-// SSR-hostile subscription.
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { track: jest.fn() },
+}));
+
+// pending-dog-profile.test.ts already covers that store and its hook in
+// isolation. Here the pending id is only an input to usePendingDogProfile,
+// so it is driven directly through this mock: `renderToStaticMarkup` has no
+// commit phase, so a real subscription would never notify between renders
+// and the "id changed while already enabled" case could not be expressed.
 let mockPendingDogProfileId: string | undefined;
 
 jest.mock<Record<string, unknown>>("./handlers/pending-dog-profile", () => ({
@@ -55,9 +56,12 @@ jest.mock<Record<string, unknown>>("react", () => {
   };
 });
 
+import { analytics } from "@/services/analytics";
+
 import { usePendingDogProfile } from ".";
 
 const push = jest.mocked(router.push);
+const track = jest.mocked(analytics.track);
 
 const Harness = ({ enabled }: { enabled: boolean }) => {
   usePendingDogProfile(enabled);
@@ -69,6 +73,7 @@ const render = (enabled: boolean) =>
 
 afterEach(() => {
   mockPendingDogProfileId = undefined;
+  track.mockClear();
 });
 
 test("does not navigate while disabled, even with a pending id", () => {
@@ -103,6 +108,20 @@ test("does not push again on a re-render with nothing new pending", () => {
   render(true);
 
   expect(push).not.toHaveBeenCalled();
+});
+
+test("tracks the profile as reached, once, only when it actually pushes", () => {
+  mockPendingDogProfileId = "dog-1";
+
+  render(false);
+  expect(track).not.toHaveBeenCalled();
+
+  render(true);
+
+  expect(track).toHaveBeenCalledTimes(1);
+  expect(track).toHaveBeenCalledWith({
+    event_type: "Dog Link Profile Opened",
+  });
 });
 
 test("pushes again for a second id that arrives while already enabled", () => {

--- a/apps/mobile/src/services/linking/index.test.ts
+++ b/apps/mobile/src/services/linking/index.test.ts
@@ -1,0 +1,121 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { router } from "expo-router";
+
+jest.mock<Partial<typeof import("expo-router")>>("expo-router", () => ({
+  router: { push: jest.fn() } as unknown as typeof import("expo-router").router,
+}));
+
+// The module under test also wires up notification handling
+// (useGetInitialNotifications / processLinks), which pulls in
+// expo-notifications and the observability stack at import time. Neither
+// runs in this test — only usePendingDogProfile does — so both are stubbed
+// to keep the import side-effect-free, the same way action.test.ts mocks
+// error-tracking for the same reason.
+jest.mock<Record<string, unknown>>("expo-notifications", () => ({
+  addNotificationResponseReceivedListener: jest.fn(() => ({
+    remove: jest.fn(),
+  })),
+  getLastNotificationResponseAsync: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+// The real `usePendingDogProfileId` is `useSyncExternalStore` without a
+// `getServerSnapshot` argument — fine on React Native, but
+// `react-dom/server`'s renderer refuses to run it without one ("Missing
+// getServerSnapshot, which is required for server-rendered content").
+// pending-dog-profile.test.ts already covers that hook and its store in
+// isolation; here the pending id is just an input to usePendingDogProfile,
+// so it is driven directly through this mock rather than through a second
+// SSR-hostile subscription.
+let mockPendingDogProfileId: string | undefined;
+
+jest.mock<Record<string, unknown>>("./handlers/pending-dog-profile", () => ({
+  usePendingDogProfileId: () => mockPendingDogProfileId,
+  setPendingDogProfile: (id?: string) => {
+    mockPendingDogProfileId = id;
+  },
+}));
+
+// `usePendingDogProfile`'s push/clear logic lives inside a plain `useEffect`,
+// and `renderToStaticMarkup` has no commit phase — real `useEffect` never
+// fires under it. Running the callback inline mirrors how this package's
+// other tests stub effect-shaped hooks for the same reason (see NewMatch's
+// `useFocusEffect` stub): a static render already stands in for "the effect
+// ran".
+jest.mock<Record<string, unknown>>("react", () => {
+  const actual = jest.requireActual("react") as typeof React;
+  return {
+    ...actual,
+    useEffect: (effect: () => void) => effect(),
+  };
+});
+
+import { usePendingDogProfile } from ".";
+
+const push = jest.mocked(router.push);
+
+const Harness = ({ enabled }: { enabled: boolean }) => {
+  usePendingDogProfile(enabled);
+  return null;
+};
+
+const render = (enabled: boolean) =>
+  renderToStaticMarkup(React.createElement(Harness, { enabled }));
+
+afterEach(() => {
+  mockPendingDogProfileId = undefined;
+});
+
+test("does not navigate while disabled, even with a pending id", () => {
+  mockPendingDogProfileId = "dog-1";
+
+  render(false);
+
+  expect(push).not.toHaveBeenCalled();
+  // Never enabled, so the pending id is left untouched for whenever it is.
+  expect(mockPendingDogProfileId).toBe("dog-1");
+});
+
+test("pushes the profile once enabled becomes true, and clears the pending id", () => {
+  mockPendingDogProfileId = "dog-1";
+  render(false);
+
+  render(true);
+
+  expect(push).toHaveBeenCalledTimes(1);
+  expect(push).toHaveBeenCalledWith({
+    pathname: "/profile/[id]",
+    params: { id: "dog-1" },
+  });
+  expect(mockPendingDogProfileId).toBeUndefined();
+});
+
+test("does not push again on a re-render with nothing new pending", () => {
+  mockPendingDogProfileId = "dog-1";
+  render(true);
+  push.mockClear();
+
+  render(true);
+
+  expect(push).not.toHaveBeenCalled();
+});
+
+test("pushes again for a second id that arrives while already enabled", () => {
+  mockPendingDogProfileId = "dog-1";
+  render(true);
+  push.mockClear();
+
+  mockPendingDogProfileId = "dog-2";
+  render(true);
+
+  expect(push).toHaveBeenCalledTimes(1);
+  expect(push).toHaveBeenCalledWith({
+    pathname: "/profile/[id]",
+    params: { id: "dog-2" },
+  });
+});

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
 
 import * as Notifications from "expo-notifications";
+import { router } from "expo-router";
 
 import { sendError } from "@/services/error-tracking";
+import { SceneName } from "@/types/scene-name";
 
 import {
   getInitialNotification,
@@ -14,6 +16,10 @@ import {
   getNotificationKind,
   getNotificationUrl,
 } from "./handlers/notification";
+import {
+  setPendingDogProfile,
+  usePendingDogProfileId,
+} from "./handlers/pending-dog-profile";
 
 export const processLinks = () => {
   const initialNotification = getInitialNotification();
@@ -79,4 +85,26 @@ export const useGetInitialNotifications = () => {
       notificationSubscription.remove();
     };
   }, []);
+};
+
+// A `/dog/<id>` link (see app/dog/[id].tsx) can arrive before authentication
+// finishes, or while logged out entirely. `enabled` mirrors useQuickActions:
+// it only goes true once the user has cleared auth + onboarding and landed
+// on Swipe, so this never pushes a protected screen while logged out. Reads
+// the id through the reactive `usePendingDogProfileId` rather than a one-off
+// `getPendingDogProfile()` call, because a *warm* link sets it while
+// `enabled` is already true — only the id itself changing drives the effect
+// in that case; `enabled` never toggles again to do it.
+export const usePendingDogProfile = (enabled: boolean) => {
+  const pendingDogProfileId = usePendingDogProfileId();
+
+  useEffect(() => {
+    if (!enabled || !pendingDogProfileId) return;
+
+    setPendingDogProfile(undefined);
+    router.push({
+      pathname: `${SceneName.Profile}/[id]`,
+      params: { id: pendingDogProfileId },
+    });
+  }, [enabled, pendingDogProfileId]);
 };

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import * as Notifications from "expo-notifications";
 import { router } from "expo-router";
 
+import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
 import { SceneName } from "@/types/scene-name";
 
@@ -102,6 +103,10 @@ export const usePendingDogProfile = (enabled: boolean) => {
     if (!enabled || !pendingDogProfileId) return;
 
     setPendingDogProfile(undefined);
+    // Last step of the funnel started by "Dog Link Opened": the shared
+    // profile is actually on screen. Everything between the two steps (sign
+    // in, onboarding, create profile) shows up as the drop off.
+    analytics.track({ event_type: "Dog Link Profile Opened" });
     router.push({
       pathname: `${SceneName.Profile}/[id]`,
       params: { id: pendingDogProfileId },

--- a/apps/mobile/src/views/(auth)/OneTimeCode/index.tsx
+++ b/apps/mobile/src/views/(auth)/OneTimeCode/index.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { magicToast } from "react-native-magic-toast";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { PendingDogProfileBanner } from "@/components/PendingDogProfileBanner";
 import { Text } from "@/components/text";
 import { api } from "@/contexts/trpc-provider";
 import { useKeyboardOverlap } from "@/hooks/use-keyboard-aware-scroll";
@@ -181,6 +182,8 @@ const OneTimeCode = () => {
         ]}
       >
         <GoBack onPress={() => router.back()} />
+
+        <PendingDogProfileBanner />
 
         <View style={styles.content}>
           <View style={styles.topColumn}>

--- a/apps/mobile/src/views/(auth)/SignIn/index.tsx
+++ b/apps/mobile/src/views/(auth)/SignIn/index.tsx
@@ -10,13 +10,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useUnistyles } from "react-native-unistyles";
 
 import { Button } from "@/components/Button";
+import { PendingDogProfileBanner } from "@/components/PendingDogProfileBanner";
 import { api } from "@/contexts/trpc-provider";
 import { useKeyboardAwareSafeAreaInsets } from "@/hooks/use-keyboard-aware-safe-area-insets";
 import { useKeyboardOverlap } from "@/hooks/use-keyboard-aware-scroll";
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
 import { getError } from "@/services/get-error";
-import { usePendingDogProfileId } from "@/services/linking/handlers/pending-dog-profile";
 import { LOGIN_PLATFORM, usePendingReferral } from "@/services/referral";
 import {
   shouldRetryTransient,
@@ -61,12 +61,6 @@ const InsertEmail = () => {
 
   const router = useRouter();
   const { t } = useTranslation();
-
-  // Set by a `/dog/<id>` deep link the user hit while logged out (see
-  // app/dog/[id].tsx). Only used to decide whether to show the line below —
-  // the actual navigation to that profile happens after login, from
-  // usePendingDogProfile in services/linking/index.ts.
-  const pendingDogProfileId = usePendingDogProfileId();
 
   const [email, setEmail] = useState("");
   const [error, setError] = useState<string | undefined>(undefined);
@@ -154,6 +148,7 @@ const InsertEmail = () => {
             <HeroText />
           </TopCard>
           <View style={[styles.bottomCard, { paddingBottom: bottomInset }]}>
+            <PendingDogProfileBanner />
             <Title style={styles.title} fontSize="xl" fontWeight="bold">
               {/*
                 The leading text is an expression rather than bare JSX text on
@@ -181,14 +176,6 @@ const InsertEmail = () => {
             <Description style={styles.description}>
               {t("insertEmail.accountCode")}
             </Description>
-            {pendingDogProfileId ? (
-              <Description
-                testID="signin-pending-dog-profile"
-                style={styles.pendingDogProfile}
-              >
-                {t("insertEmail.pendingDogProfile")}
-              </Description>
-            ) : null}
             <EmailInput
               enablesReturnKeyAutomatically
               returnKeyType="send"

--- a/apps/mobile/src/views/(auth)/SignIn/index.tsx
+++ b/apps/mobile/src/views/(auth)/SignIn/index.tsx
@@ -16,6 +16,7 @@ import { useKeyboardOverlap } from "@/hooks/use-keyboard-aware-scroll";
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
 import { getError } from "@/services/get-error";
+import { usePendingDogProfileId } from "@/services/linking/handlers/pending-dog-profile";
 import { LOGIN_PLATFORM, usePendingReferral } from "@/services/referral";
 import {
   shouldRetryTransient,
@@ -60,6 +61,12 @@ const InsertEmail = () => {
 
   const router = useRouter();
   const { t } = useTranslation();
+
+  // Set by a `/dog/<id>` deep link the user hit while logged out (see
+  // app/dog/[id].tsx). Only used to decide whether to show the line below —
+  // the actual navigation to that profile happens after login, from
+  // usePendingDogProfile in services/linking/index.ts.
+  const pendingDogProfileId = usePendingDogProfileId();
 
   const [email, setEmail] = useState("");
   const [error, setError] = useState<string | undefined>(undefined);
@@ -174,6 +181,14 @@ const InsertEmail = () => {
             <Description style={styles.description}>
               {t("insertEmail.accountCode")}
             </Description>
+            {pendingDogProfileId ? (
+              <Description
+                testID="signin-pending-dog-profile"
+                style={styles.pendingDogProfile}
+              >
+                {t("insertEmail.pendingDogProfile")}
+              </Description>
+            ) : null}
             <EmailInput
               enablesReturnKeyAutomatically
               returnKeyType="send"

--- a/apps/mobile/src/views/(auth)/SignIn/styles.ts
+++ b/apps/mobile/src/views/(auth)/SignIn/styles.ts
@@ -53,6 +53,10 @@ export const styles = StyleSheet.create((theme) => ({
   description: {
     color: theme.colors.text,
   },
+  pendingDogProfile: {
+    color: theme.colors.text,
+    marginTop: theme.spacing[2],
+  },
 }));
 
 export const Container = withUnistyles(SafeAreaView);

--- a/apps/mobile/src/views/(auth)/SignIn/styles.ts
+++ b/apps/mobile/src/views/(auth)/SignIn/styles.ts
@@ -53,10 +53,6 @@ export const styles = StyleSheet.create((theme) => ({
   description: {
     color: theme.colors.text,
   },
-  pendingDogProfile: {
-    color: theme.colors.text,
-    marginTop: theme.spacing[2],
-  },
 }));
 
 export const Container = withUnistyles(SafeAreaView);

--- a/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
+++ b/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
@@ -1,0 +1,54 @@
+import { APPLE_APP_ID } from "@/lib/app-links";
+
+// Static: iOS fetches this file unauthenticated, over plain HTTPS, with no
+// locale or user context, so there is nothing here that ever needs to vary
+// per request.
+export const dynamic = "force-static";
+
+/**
+ * Apple resolves this file (no `.json` extension, exact path) once per app
+ * install to decide which HTTP(S) links `app.pegada` is allowed to open
+ * in-app instead of in Safari. `components` is the modern replacement for
+ * the deprecated `paths` array — each entry is a URL-component pattern, `*`
+ * matches one or more path segments. The web app serves dog profiles at
+ * both `/dog/:id` (default locale) and `/pt-br/dog/:id` (non-default
+ * locale prefix), so both need an entry.
+ *
+ * `webcredentials` reuses the same `appID` to let iOS offer autofill for
+ * credentials shared between the app and this domain. Nothing on the app
+ * side depends on it yet, but declaring it now is free.
+ */
+const body = {
+  applinks: {
+    details: [
+      {
+        appIDs: [APPLE_APP_ID],
+        components: [
+          {
+            "/": "/dog/*",
+            comment: "Match dog profile share links in the default locale",
+          },
+          {
+            "/": "/pt-br/dog/*",
+            comment: "Match dog profile share links under the pt-BR prefix",
+          },
+        ],
+      },
+    ],
+  },
+  webcredentials: {
+    apps: [APPLE_APP_ID],
+  },
+};
+
+export const GET = () =>
+  Response.json(body, {
+    headers: {
+      // Apple's own crawler ignores Content-Type, but browsers and other
+      // tooling that inspect this URL expect JSON, and the spec calls for it.
+      "Content-Type": "application/json",
+      // Rarely changes, but `APPLE_TEAM_ID` is still a placeholder here, so
+      // `immutable` would be a lie — a long max-age is enough.
+      "Cache-Control": "public, max-age=86400",
+    },
+  });

--- a/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
+++ b/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
@@ -12,7 +12,17 @@ export const dynamic = "force-static";
  * the deprecated `paths` array — each entry is a URL-component pattern, `*`
  * matches one or more path segments. The web app serves dog profiles at
  * both `/dog/:id` (default locale) and `/pt-br/dog/:id` (non-default
- * locale prefix), so both need an entry.
+ * locale prefix), so both need an entry: next-intl runs `localePrefix:
+ * "as-needed"` and 307s a `Accept-Language: pt-BR` browser onto the
+ * prefixed URL, which is then the one that gets copied and shared.
+ *
+ * Claiming a path the app has no route for is worse than not claiming it:
+ * iOS would hand the URL to the app and the app would land on expo-router's
+ * "Unmatched Route" screen instead of letting Safari render the page. Every
+ * pattern here therefore needs a matching expo-router route in
+ * apps/mobile/src/app and a matching Android intent filter in
+ * apps/mobile/app.config.ts. tests/apple-app-site-association.test.mjs is
+ * what keeps those three in step, including when a locale is added.
  *
  * `webcredentials` reuses the same `appID` to let iOS offer autofill for
  * credentials shared between the app and this domain. Nothing on the app

--- a/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
+++ b/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
@@ -47,8 +47,9 @@ export const GET = () =>
       // Apple's own crawler ignores Content-Type, but browsers and other
       // tooling that inspect this URL expect JSON, and the spec calls for it.
       "Content-Type": "application/json",
-      // Rarely changes, but `APPLE_TEAM_ID` is still a placeholder here, so
-      // `immutable` would be a lie — a long max-age is enough.
+      // Rarely changes, but the Android side of universal links still ships
+      // a placeholder fingerprint (see assetlinks.json/route.ts), so
+      // `immutable` would be premature here too — a long max-age is enough.
       "Cache-Control": "public, max-age=86400",
     },
   });

--- a/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
+++ b/apps/nextjs/src/app/.well-known/apple-app-site-association/route.ts
@@ -47,9 +47,8 @@ export const GET = () =>
       // Apple's own crawler ignores Content-Type, but browsers and other
       // tooling that inspect this URL expect JSON, and the spec calls for it.
       "Content-Type": "application/json",
-      // Rarely changes, but the Android side of universal links still ships
-      // a placeholder fingerprint (see assetlinks.json/route.ts), so
-      // `immutable` would be premature here too — a long max-age is enough.
+      // Rarely changes, but not worth the risk of `immutable` breaking a
+      // future rotation, so a long max-age is enough.
       "Cache-Control": "public, max-age=86400",
     },
   });

--- a/apps/nextjs/src/app/.well-known/assetlinks.json/route.ts
+++ b/apps/nextjs/src/app/.well-known/assetlinks.json/route.ts
@@ -1,0 +1,39 @@
+import {
+  ANDROID_SHA256_CERT_FINGERPRINT,
+  APP_BUNDLE_ID,
+} from "@/lib/app-links";
+
+// Static: Android fetches this file unauthenticated, over plain HTTPS, with
+// no locale or user context, so there is nothing here that ever needs to
+// vary per request.
+export const dynamic = "force-static";
+
+/**
+ * Android resolves this file to decide whether `app.pegada` is allowed to
+ * open `www.pegada.app` links directly instead of in the browser. The
+ * `delegate_permission/common.handle_all_urls` relation is Google's fixed
+ * string for that grant; `sha256_cert_fingerprints` must match the
+ * certificate the Play Store release build is signed with, not a debug
+ * keystore, or verification silently fails.
+ */
+const body = [
+  {
+    relation: ["delegate_permission/common.handle_all_urls"],
+    target: {
+      namespace: "android_app",
+      package_name: APP_BUNDLE_ID,
+      sha256_cert_fingerprints: [ANDROID_SHA256_CERT_FINGERPRINT],
+    },
+  },
+];
+
+export const GET = () =>
+  Response.json(body, {
+    headers: {
+      "Content-Type": "application/json",
+      // Rarely changes, but `ANDROID_SHA256_CERT_FINGERPRINT` is still a
+      // placeholder here, so `immutable` would be a lie — a long max-age is
+      // enough.
+      "Cache-Control": "public, max-age=86400",
+    },
+  });

--- a/apps/nextjs/src/app/.well-known/assetlinks.json/route.ts
+++ b/apps/nextjs/src/app/.well-known/assetlinks.json/route.ts
@@ -1,5 +1,5 @@
 import {
-  ANDROID_SHA256_CERT_FINGERPRINT,
+  ANDROID_SHA256_CERT_FINGERPRINTS,
   APP_BUNDLE_ID,
 } from "@/lib/app-links";
 
@@ -22,7 +22,7 @@ const body = [
     target: {
       namespace: "android_app",
       package_name: APP_BUNDLE_ID,
-      sha256_cert_fingerprints: [ANDROID_SHA256_CERT_FINGERPRINT],
+      sha256_cert_fingerprints: [...ANDROID_SHA256_CERT_FINGERPRINTS],
     },
   },
 ];
@@ -31,7 +31,7 @@ export const GET = () =>
   Response.json(body, {
     headers: {
       "Content-Type": "application/json",
-      // Rarely changes, but `ANDROID_SHA256_CERT_FINGERPRINT` is still a
+      // Rarely changes, but `ANDROID_SHA256_CERT_FINGERPRINTS` is still a
       // placeholder here, so `immutable` would be a lie — a long max-age is
       // enough.
       "Cache-Control": "public, max-age=86400",

--- a/apps/nextjs/src/app/.well-known/assetlinks.json/route.ts
+++ b/apps/nextjs/src/app/.well-known/assetlinks.json/route.ts
@@ -31,8 +31,8 @@ export const GET = () =>
   Response.json(body, {
     headers: {
       "Content-Type": "application/json",
-      // Rarely changes, but `ANDROID_SHA256_CERT_FINGERPRINTS` is still a
-      // placeholder here, so `immutable` would be a lie — a long max-age is
+      // Rarely changes, but a rotated or added signing key would need this
+      // to pick it up without waiting out `immutable`, so a long max-age is
       // enough.
       "Cache-Control": "public, max-age=86400",
     },

--- a/apps/nextjs/src/lib/app-links.ts
+++ b/apps/nextjs/src/lib/app-links.ts
@@ -8,17 +8,19 @@
  * removed from `appleTeamId` there in favor of an EAS build secret).
  *
  * Android SHA256 fingerprint(s) are different: they live in EAS credentials,
- * not in this repo, and can't be guessed — a wrong value silently fails
- * verification instead of erroring, so a placeholder that obviously needs
- * replacing beats a plausible-looking one. `eas credentials` → Android →
- * select the `app.pegada` app → "Keystore" → prints "SHA256 Fingerprint"
- * for the release-signing keystore.
+ * not in this repo. The entry below is the EAS upload key (`eas credentials`
+ * -> Android -> select the `app.pegada` app -> "Keystore" -> "SHA256
+ * Fingerprint"). If Google Play App Signing is on for this app, Play
+ * re-signs the uploaded bundle with its own app signing key before
+ * distributing it, and that key's fingerprint (Play Console -> Setup -> App
+ * integrity -> App signing key certificate) must be appended here too, or
+ * devices that installed from Play will fail verification.
  */
 export const APPLE_TEAM_ID = "23DRM684H8";
 
-// Will hold both the Play app-signing certificate and the EAS upload key
-// fingerprints once they're pulled from EAS credentials.
-export const ANDROID_SHA256_CERT_FINGERPRINTS = ["REPLACE_WITH_ANDROID_SHA256"];
+export const ANDROID_SHA256_CERT_FINGERPRINTS = [
+  "36:51:99:FC:45:EF:55:03:38:23:04:05:C5:B6:C9:F1:C9:39:69:10:9D:64:8D:4D:DC:C3:01:E4:70:E1:9A:8B",
+];
 
 export const APP_BUNDLE_ID = "app.pegada";
 

--- a/apps/nextjs/src/lib/app-links.ts
+++ b/apps/nextjs/src/lib/app-links.ts
@@ -1,0 +1,22 @@
+/**
+ * Values Apple's App Site Association and Android's Digital Asset Links need
+ * to prove `app.pegada` owns `www.pegada.app`. Both live in EAS credentials,
+ * not in this repo, and neither can be guessed — a wrong value silently
+ * fails verification instead of erroring, so a placeholder that obviously
+ * needs replacing beats a plausible-looking one.
+ *
+ * Apple Team ID: `eas credentials` → iOS → select the `app.pegada` app →
+ * the build credentials screen prints "Team ID" next to the Apple Team name.
+ * (Also visible on developer.apple.com under Membership.)
+ *
+ * Android SHA256 fingerprint: `eas credentials` → Android → select the
+ * `app.pegada` app → "Keystore" → prints "SHA256 Fingerprint" for the
+ * release-signing keystore.
+ */
+export const APPLE_TEAM_ID = "REPLACE_WITH_APPLE_TEAM_ID";
+
+export const ANDROID_SHA256_CERT_FINGERPRINT = "REPLACE_WITH_ANDROID_SHA256";
+
+export const APP_BUNDLE_ID = "app.pegada";
+
+export const APPLE_APP_ID = `${APPLE_TEAM_ID}.${APP_BUNDLE_ID}`;

--- a/apps/nextjs/src/lib/app-links.ts
+++ b/apps/nextjs/src/lib/app-links.ts
@@ -1,21 +1,24 @@
 /**
  * Values Apple's App Site Association and Android's Digital Asset Links need
- * to prove `app.pegada` owns `www.pegada.app`. Both live in EAS credentials,
- * not in this repo, and neither can be guessed — a wrong value silently
- * fails verification instead of erroring, so a placeholder that obviously
- * needs replacing beats a plausible-looking one.
+ * to prove `app.pegada` owns `www.pegada.app`.
  *
- * Apple Team ID: `eas credentials` → iOS → select the `app.pegada` app →
- * the build credentials screen prints "Team ID" next to the Apple Team name.
- * (Also visible on developer.apple.com under Membership.)
+ * The Apple Team ID is not a secret: the AASA file that embeds it is served
+ * unauthenticated to anyone who asks, by definition, so committing it here
+ * is fine even though the build keeps it out of app.config.ts (it was
+ * removed from `appleTeamId` there in favor of an EAS build secret).
  *
- * Android SHA256 fingerprint: `eas credentials` → Android → select the
- * `app.pegada` app → "Keystore" → prints "SHA256 Fingerprint" for the
- * release-signing keystore.
+ * Android SHA256 fingerprint(s) are different: they live in EAS credentials,
+ * not in this repo, and can't be guessed — a wrong value silently fails
+ * verification instead of erroring, so a placeholder that obviously needs
+ * replacing beats a plausible-looking one. `eas credentials` → Android →
+ * select the `app.pegada` app → "Keystore" → prints "SHA256 Fingerprint"
+ * for the release-signing keystore.
  */
-export const APPLE_TEAM_ID = "REPLACE_WITH_APPLE_TEAM_ID";
+export const APPLE_TEAM_ID = "23DRM684H8";
 
-export const ANDROID_SHA256_CERT_FINGERPRINT = "REPLACE_WITH_ANDROID_SHA256";
+// Will hold both the Play app-signing certificate and the EAS upload key
+// fingerprints once they're pulled from EAS credentials.
+export const ANDROID_SHA256_CERT_FINGERPRINTS = ["REPLACE_WITH_ANDROID_SHA256"];
 
 export const APP_BUNDLE_ID = "app.pegada";
 

--- a/apps/nextjs/tests/apple-app-site-association.test.mjs
+++ b/apps/nextjs/tests/apple-app-site-association.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+/**
+ * The defect: the AASA claimed `/pt-br/dog/*` while the app had no route at
+ * that path. Claiming a path is not a hint, it is a promise. iOS hands the
+ * URL to the app instead of to Safari, and the app then had nothing to
+ * render it with, so a Brazilian user tapping a shared link landed on
+ * expo-router's "Unmatched Route" screen. That URL is not a curiosity:
+ * next-intl runs `localePrefix: "as-needed"` and 307s an
+ * `Accept-Language: pt-BR` browser from /dog/<id> to /pt-br/dog/<id>, so it
+ * is the URL that ends up in the clipboard.
+ *
+ * Three files have to agree for a link to work, and they live in two apps
+ * with nothing importing across the boundary (app.config.ts is loaded by
+ * Expo's own config loader and cannot pull in Next's module graph), so they
+ * are compared here as text. Any of them drifting, or a new locale being
+ * added to the shared Language enum, fails this file.
+ */
+
+const repoRoot = path.join(import.meta.dirname, "..", "..", "..");
+const MOBILE_APP_DIR = path.join(repoRoot, "apps", "mobile", "src", "app");
+
+const read = (...segments) =>
+  fs.readFileSync(path.join(repoRoot, ...segments), "utf8");
+
+const aasaSource = read(
+  "apps",
+  "nextjs",
+  "src",
+  "app",
+  ".well-known",
+  "apple-app-site-association",
+  "route.ts",
+);
+const appConfigSource = read("apps", "mobile", "app.config.ts");
+
+/** The `"/": "<pattern>"` URL-component patterns the AASA claims. */
+const claimedPatterns = [...aasaSource.matchAll(/"\/":\s*"([^"]+)"/g)].map(
+  ([, pattern]) => pattern,
+);
+
+/**
+ * Locale segments as the router spells them, derived from the same enum
+ * apps/nextjs/src/lib/locales.ts derives LOCALE_SEGMENTS from. `Default`
+ * aliases another member, hence the dedupe.
+ */
+const localeSegments = () => {
+  const source = read("packages", "shared", "i18n", "types", "types.ts");
+  const body = /export enum Language \{([^}]*)\}/.exec(source);
+  assert.ok(body, "could not find the Language enum to read locales from");
+
+  const members = [...body[1].matchAll(/(\w+)\s*=\s*"([^"]+)"/g)].map(
+    ([, name, value]) => ({ name, segment: value.toLowerCase() }),
+  );
+  const fallback = members.find(({ name }) => name === "Default");
+  assert.ok(fallback, "Language enum has no Default member");
+
+  return {
+    all: [...new Set(members.map(({ segment }) => segment))],
+    // `localePrefix: "as-needed"` serves the default locale unprefixed and
+    // redirects /<default>/... back to it, so it is never a shared URL.
+    prefixed: [
+      ...new Set(
+        members
+          .filter(({ segment }) => segment !== fallback.segment)
+          .map(({ segment }) => segment),
+      ),
+    ],
+  };
+};
+
+test("claims the unprefixed dog path and every non-default locale prefix", () => {
+  const { prefixed } = localeSegments();
+
+  assert.deepEqual(
+    [...claimedPatterns].sort(),
+    ["/dog/*", ...prefixed.map((segment) => `/${segment}/dog/*`)].sort(),
+  );
+});
+
+test("every claimed path has an expo-router route to render it", () => {
+  for (const pattern of claimedPatterns) {
+    const route = path.join(
+      MOBILE_APP_DIR,
+      pattern.replace(/^\//, "").replace(/\/\*$/, ""),
+      "[id].tsx",
+    );
+
+    assert.ok(
+      fs.existsSync(route),
+      `AASA claims ${pattern} but ${path.relative(repoRoot, route)} does not exist, so iOS would open the app onto the Unmatched Route screen`,
+    );
+  }
+});
+
+test("Android claims the same paths on every verified host", () => {
+  const filters = /intentFilters: \[([\s\S]*?)\n {4}\],/.exec(appConfigSource);
+  assert.ok(filters, "could not find the Android intentFilters block");
+
+  const hosts = new Set(
+    [...filters[1].matchAll(/host: "([^"]+)"/g)].map(([, host]) => host),
+  );
+  assert.ok(hosts.size > 0, "no verified hosts declared");
+
+  const prefixes = [...filters[1].matchAll(/pathPrefix: "([^"]+)"/g)].map(
+    ([, prefix]) => prefix,
+  );
+
+  for (const pattern of claimedPatterns) {
+    const prefix = pattern.replace(/\/\*$/, "");
+    const declared = prefixes.filter((candidate) => candidate === prefix);
+
+    assert.equal(
+      declared.length,
+      hosts.size,
+      `iOS claims ${pattern}, so every one of the ${hosts.size} Android hosts needs a "${prefix}" pathPrefix`,
+    );
+  }
+});
+
+test("declares the app for applinks and webcredentials", () => {
+  assert.match(aasaSource, /appIDs: \[APPLE_APP_ID\]/);
+  assert.match(aasaSource, /webcredentials: \{\s*apps: \[APPLE_APP_ID\]/);
+  // Apple fetches this unauthenticated with no locale or user context, so
+  // per-request rendering would only cost a cold start on the crawl.
+  assert.match(aasaSource, /export const dynamic = "force-static"/);
+});

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -25,6 +25,9 @@ export const ANALYTICS_EVENTS = {
   DELETE_ACCOUNT_CANCELED: "Delete Account Canceled",
   DELETE_ACCOUNT_CONFIRMED: "Delete Account Confirmed",
   DELETE_ACCOUNT_PRESSED: "Delete Account Pressed",
+  DOG_LINK_OPENED: "Dog Link Opened",
+  DOG_LINK_PROFILE_OPENED: "Dog Link Profile Opened",
+  DOG_LINK_SIGN_IN_BANNER_SHOWN: "Dog Link Sign In Banner Shown",
   EMPTY_DECK_ACTION_TAPPED: "Empty Deck Action Tapped",
   EMPTY_DECK_SHOWN: "Empty Deck Shown",
   FEEDBACK: "Feedback",
@@ -165,6 +168,15 @@ export type MobileEventProperties = {
   [ANALYTICS_EVENTS.DELETE_ACCOUNT_CANCELED]: undefined;
   [ANALYTICS_EVENTS.DELETE_ACCOUNT_CONFIRMED]: undefined;
   [ANALYTICS_EVENTS.DELETE_ACCOUNT_PRESSED]: undefined;
+  /**
+   * The three steps of the shared dog link funnel, in order: the link landed,
+   * the sign in hand off was shown, the shared profile finally opened.
+   * `authenticated` on the first step is what splits the people who have to
+   * sign in from the ones who go straight through.
+   */
+  [ANALYTICS_EVENTS.DOG_LINK_OPENED]: { authenticated: boolean };
+  [ANALYTICS_EVENTS.DOG_LINK_PROFILE_OPENED]: undefined;
+  [ANALYTICS_EVENTS.DOG_LINK_SIGN_IN_BANNER_SHOWN]: undefined;
   /**
    * One per tap on an empty deck action. `push_permission` rides on the notify
    * action and `share_result` on the invite, so the funnel reads both the
@@ -389,6 +401,9 @@ export const MOBILE_EVENT_NAMES = [
   ANALYTICS_EVENTS.DELETE_ACCOUNT_CANCELED,
   ANALYTICS_EVENTS.DELETE_ACCOUNT_CONFIRMED,
   ANALYTICS_EVENTS.DELETE_ACCOUNT_PRESSED,
+  ANALYTICS_EVENTS.DOG_LINK_OPENED,
+  ANALYTICS_EVENTS.DOG_LINK_PROFILE_OPENED,
+  ANALYTICS_EVENTS.DOG_LINK_SIGN_IN_BANNER_SHOWN,
   ANALYTICS_EVENTS.EMPTY_DECK_ACTION_TAPPED,
   ANALYTICS_EVENTS.EMPTY_DECK_SHOWN,
   ANALYTICS_EVENTS.FEEDBACK,

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -164,6 +164,7 @@
     "findDogsNearYou": "<view><title>Find </title><highlight>Dogs</highlight></view><view><title>Near </title><highlight>You</highlight><view/>",
     "insertEmail": "Insert your <1>email</1>",
     "loginError": "An error occurred while logging in.",
+    "pendingDogProfile": "Log in or sign up to see this profile.",
     "validEmail": "Please enter a valid email"
   },
   "locationMap": {

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -164,7 +164,10 @@
     "findDogsNearYou": "<view><title>Find </title><highlight>Dogs</highlight></view><view><title>Near </title><highlight>You</highlight><view/>",
     "insertEmail": "Insert your <1>email</1>",
     "loginError": "An error occurred while logging in.",
-    "pendingDogProfile": "Log in or sign up to see this profile.",
+    "pendingDogProfileBanner": {
+      "body": "Log in or sign up and we'll take you straight there.",
+      "title": "You opened a dog's profile."
+    },
     "validEmail": "Please enter a valid email"
   },
   "locationMap": {

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -164,7 +164,10 @@
     "findDogsNearYou": "<view><title>Encontre </title><highlight>Dogs</highlight></view><view><title>perto de </title><highlight>Você</highlight><view/>",
     "insertEmail": "Insira seu <1>email</1>",
     "loginError": "Ocorreu um erro ao fazer login.",
-    "pendingDogProfile": "Entra ou cria uma conta pra ver esse perfil.",
+    "pendingDogProfileBanner": {
+      "body": "Entra ou cria sua conta e a gente te leva direto pra lá.",
+      "title": "Você abriu o perfil de um dog."
+    },
     "validEmail": "Insira um email válido"
   },
   "locationMap": {

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -165,7 +165,7 @@
     "insertEmail": "Insira seu <1>email</1>",
     "loginError": "Ocorreu um erro ao fazer login.",
     "pendingDogProfileBanner": {
-      "body": "Entra ou cria sua conta e a gente te leva direto pra lá.",
+      "body": "Entre ou crie sua conta e nós te levamos direto para lá.",
       "title": "Você abriu o perfil de um dog."
     },
     "validEmail": "Insira um email válido"

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -164,6 +164,7 @@
     "findDogsNearYou": "<view><title>Encontre </title><highlight>Dogs</highlight></view><view><title>perto de </title><highlight>Você</highlight><view/>",
     "insertEmail": "Insira seu <1>email</1>",
     "loginError": "Ocorreu um erro ao fazer login.",
+    "pendingDogProfile": "Entra ou cria uma conta pra ver esse perfil.",
     "validEmail": "Insira um email válido"
   },
   "locationMap": {


### PR DESCRIPTION
## Summary

Dog profile links now open inside the app instead of a browser tab, and if someone isn't signed in yet, they land on the profile right after they log in. The web half that proves pegada.app and the app belong together is in place; both the Apple team id and the Android EAS upload key fingerprint are filled in and served. If Google Play App Signing is on for this app, the Play Console app signing certificate still needs to be appended before Android verification works for people who install from the Play Store.

## Details

- **Hypothesis:** a shared dog link currently dead ends in a browser page with no way into the app, so every share leaks. Sending the link into the app should raise the share to profile conversion rate, measured as the share of `Dog Link Opened` events that reach `Dog Link Profile Opened`, and it should produce signups that would not otherwise happen, measured as sign ins whose session contains a `Dog Link Opened`. The logged out path is where the loss is expected, so the number to watch is the logged out slice of that conversion.
- **Baseline:** there is none, and this PR is what creates it. Nothing in the deep link flow emitted an event before this branch, so PostHog has zero rows for a dog link open, and the web `/dog/[id]` page cannot fill the gap either because `NEXT_PUBLIC_POSTHOG_KEY` is unset and `initWebAnalytics` returns a no op client. The first deliverable is therefore the instrumentation itself: `Dog Link Opened` (property `authenticated`, whether a token was already stored), `Dog Link Sign In Banner Shown`, `Dog Link Profile Opened`. The first two weeks after release establish the number; nothing here claims to beat a figure that does not exist yet.
- **Readout:** a PostHog funnel over `Dog Link Opened` -> `Dog Link Sign In Banner Shown` -> `Dog Link Profile Opened`, read 14 days after the release that carries these events, broken down by the `authenticated` property on step one. Two numbers come out of it: overall link to profile conversion, and the logged out conversion specifically. `Dog Link Opened` where `authenticated` is false, minus the users who reach `Dog Link Profile Opened`, is the sign in drop off this feature exists to shrink. If the logged out conversion sits far under the logged in one, the sign in hand off is the thing to fix next, not the linking.
- Two route handlers serve `/.well-known/apple-app-site-association` and `/.well-known/assetlinks.json`. Both are route handlers rather than static files because Apple's file has no extension and needs its content type set to JSON explicitly, which a static file can't do.
- One module holds the Apple Team ID and the Android signing fingerprints. The Team ID is real and committed (an AASA file is public by definition, so there's nothing to hide there); the Android entry now carries the real EAS upload key fingerprint, pulled straight from EAS credentials rather than typed by hand. If Play App Signing is on for this app, Google re-signs the uploaded bundle with its own app signing key before distributing it, and that key's fingerprint (Play Console, Setup, App integrity, App signing key certificate) has to be added to the same array or verification will fail silently for anyone who installed from the Play Store.
- A new `dog/[id]` route stores the incoming dog id and renders nothing. Once the app finishes its normal startup and lands on the swipe screen, it pushes the profile for that id. On a cold launch the app's own startup redirect replaces that empty route. On a link opened while the app is already running the route pops itself instead, because the startup redirect never re runs for someone whose destination has not changed, and a signed out person's destination is the sign in screen before and after the link.
- If the person is signed out, they now see a proper banner at the top of the sign in card, with a paw icon and a bold first line, telling them a dog's profile is waiting and that logging in or signing up takes them straight there. The same banner shows on the one time code screen so the reason doesn't disappear once they enter their email. It was checked in both light and dark themes.
- Android intent filters and iOS associated domains, both previously commented out, are turned on, and the app version was bumped to 1.7.1 because that's what changes in the build's entitlements.
- Portuguese links open the app as well. The site serves locale prefixes as needed, so a browser asking for pt-BR is redirected from `/dog/<id>` to `/pt-br/dog/<id>`, and that prefixed address is the one a Brazilian user copies out of the address bar and shares. iOS was already claiming it while the app had no screen for it, which takes the link away from Safari and lands it on the app's unmatched route screen. The app now serves the same dog screen under the locale prefix, and Android claims the same path on both verified hosts. A test reads the association file, the Android config and the shared language list together, and fails if a claimed address has no screen behind it, if Android does not claim it too, or if a new locale is added without one.
- Opening a link while the app was already running and signed out used to leave a blank screen with no way out: nothing navigated away from the empty route, and back could not recover it because there was nothing above it to go back from. The route now pops itself, which puts the person back on the sign in screen with the banner, exactly where a cold link already put them. That pop also clears the stray screen a signed in warm link used to leave behind the profile, so back from the profile returns to the screen the person was actually on. An earlier attempt replaced the route with the app root, which is what got the app stuck on the splash screen; popping keeps the stack the person already had instead of rebuilding it.
- Verified in the simulator using the app's custom link scheme, cold start and warm start, signed in and signed out, and confirmed the pending link is used once and then forgotten. The real https links can't be tested from a dev build. They only start working after this deploys and a new store build ships, and only for everyone if the Play Console app signing certificate is appended alongside the upload key fingerprint.
- The three funnel events above are emitted from the link route, the banner and the navigation hook, with unit tests covering that the profile event only fires when the push actually happens and that the banner reports once per pending id rather than once per screen (SignIn and OneTimeCode both render it for the same hand off).
- Two end to end flows run on every core CI shard: one opens a dog link while signed out and checks the banner appears then the profile loads right after login, the other opens a dog link while already signed in and checks it lands on the profile with no banner involved. The signed out flow now opens the link warm first, with the app already sitting on sign in, and asserts the banner and the sign in form are both on screen before killing the app and repeating it cold. It used to kill the app before the only link it opened, so the warm path, the broken one, was never exercised. Unit tests cover the pending profile store, the navigation hook, the banner, and the link route itself, including that the pop happens before the pending id is stored, since the reverse order would push the profile and then take it straight back off.

## Testing steps

1. Install the app on a simulator or device from this branch.
2. While logged in, open a dog profile link from a message or notes app. The app should open directly to that dog's profile instead of a browser.
3. Close the app fully, then open a dog profile link again. The app should launch straight into that profile.
4. Log out, then open a dog profile link. You should land on the sign in screen with a banner at the top explaining you're there because of that link. Enter your email and the code, and the banner should also show on that step. Once you finish logging in, you should be taken straight to the profile afterward.
5. Still logged out and with the app open on the sign in screen, open another dog profile link. You should stay on sign in with the banner showing, never on a blank screen, and you should not have to press back to get anything to appear.
6. Set the device language to Portuguese, open the shared web address for a dog in a browser, and confirm the address bar shows the `/pt-br/dog/` form. Opening that address should land on the dog's profile in the app, not on a page saying the route is unmatched.
7. The web links people actually get when they share a profile can only be checked once this is deployed and a new build goes out to the app stores. If Play App Signing is on, that check is only complete once the Play Console app signing certificate is also added to the fingerprint array.

## Screenshots

![Sign in screen with the pending dog profile banner](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-universal-links/shots/signin-prompt.png)
Signed out, opening a dog link shows the banner explaining why you landed on sign in.

![Sign in screen with the pending dog profile banner in dark theme](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-universal-links/shots/signin-banner-dark.png)
The same banner in dark theme, checked for contrast and legibility.

![Bella's profile right after login](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-universal-links/shots/after-login-profile.png)
Right after logging in, the app goes straight to the pending profile.

![Bella's profile from a cold link while logged in](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-universal-links/shots/logged-in-cold-link.png)
Already logged in, opening the link from a cold start lands on the profile directly.





