### PR TITLE
fix(mobile): drop 17+ age rating and dating signals from store metadata

### DIFF
--- a/apps/mobile/store.config.json
+++ b/apps/mobile/store.config.json
@@ -8,38 +8,31 @@
     },
     "info": {
       "pt-BR": {
-        "description": "Oi, humano! Cansado de ver seu amigo de quatro patas olhando para os pássaros no parque com aquela expressão de quem precisa de companhia? Então você chegou ao lugar certo. Pegada é o app de relacionamentos caninos mais legal do mercado.\n\nMas calma, isso não é só um Tinder para cachorros. Pegada é uma plataforma criada pensando na socialização dos nossos aumigos. Aqui, nossos usuários não são os humanos, mas sim os cães! Isso mesmo, é o perfil do seu pet que estará arrasando por aqui!\n\n- Inclusivo para todos\n\nNão importa se seu cachorro é de raça ou um autêntico vira-lata, aqui todas as patas são bem-vindas!\n\nEntão, que tal ajudar seu pet a dar um passo importante em sua vida social canina? Baixe o Pegada e dê a ele a chance de encontrar a amizade peluda dos sonhos dele!\n\nO mundo é muito mais divertido com um amigo, e seu pet com certeza concorda. Venha para o Pegada, onde cada dia é dia de encontrar um novo melhor amigo!",
+        "description": "Oi, humano! Cansado de ver seu amigo de quatro patas olhando para os pássaros no parque com aquela expressão de quem precisa de companhia? Então você chegou ao lugar certo. Pegada é o app de amizades caninas mais legal do mercado.\n\nPegada é uma plataforma criada pensando na socialização dos nossos aumigos. Aqui, nossos usuários não são os humanos, mas sim os cães! Isso mesmo, é o perfil do seu pet que estará arrasando por aqui!\n\n- Inclusivo para todos\n\nNão importa se seu cachorro é de raça ou um autêntico vira-lata, aqui todas as patas são bem-vindas!\n\nEntão, que tal ajudar seu pet a dar um passo importante em sua vida social canina? Baixe o Pegada e dê a ele a chance de encontrar a amizade peluda dos sonhos dele!\n\nO mundo é muito mais divertido com um amigo, e seu pet com certeza concorda. Venha para o Pegada, onde cada dia é dia de encontrar um novo melhor amigo!",
         "keywords": [
           "Cachorro",
           "Pet",
           "Amizade",
-          "Encontro",
           "Comunidade",
-          "Parceiro",
-          "Relacionamento",
           "Companheiro",
-          "Namoro",
-          "Cruzar"
+          "Passeio"
         ],
         "releaseNotes": "Obrigado por usar o Pegada! Nessa versão, fizemos algumas melhorias e correções de bugs para deixar o app ainda melhor.\n\nSe você tiver alguma dúvida ou sugestão, entre em contato conosco pelo email",
         "marketingUrl": "https://www.pegada.app/pt-br",
         "supportUrl": "https://www.pegada.app/pt-br",
         "title": "Pegada",
-        "subtitle": "Encontros para Doguinhos",
+        "subtitle": "Amizades para Doguinhos",
         "privacyPolicyUrl": "https://www.pegada.app/pt-br/privacy-policy",
         "privacyChoicesUrl": "https://www.pegada.app/pt-br/delete-account"
       },
       "en-GB": {
-        "description": "Hey, human! Tired of seeing your four-legged friend gazing at the birds in the park with that look of needing company? Then you've come to the right place.\n\nPegada is the coolest canine relationship app on the market.\n\nBut hold on, this isn't only a Tinder for dogs. Pegada is a platform designed for the socialization of our furriends. Here, our users aren't the humans, but the dogs! That's right, it's your pet's profile that will be rocking it here!\n\n- Inclusive for all\n\nIt doesn't matter if your dog is a pedigree or a genuine mixed breed, here all paws are welcome!\n\nSo, how about helping your pet take an important step in their canine social life? Download Pegada and give them a chance to find their dream paw friendship!\n\nThe world is much more fun with a friend, and your pet surely agrees. Come to Pegada, where every day is a day to find a new best friend!",
+        "description": "Hey, human! Tired of seeing your four-legged friend gazing at the birds in the park with that look of needing company? Then you've come to the right place.\n\nPegada is the coolest canine friendship app on the market.\n\nPegada is a platform designed for the socialization of our furriends. Here, our users aren't the humans, but the dogs! That's right, it's your pet's profile that will be rocking it here!\n\n- Inclusive for all\n\nIt doesn't matter if your dog is a pedigree or a genuine mixed breed, here all paws are welcome!\n\nSo, how about helping your pet take an important step in their canine social life? Download Pegada and give them a chance to find their dream paw friendship!\n\nThe world is much more fun with a friend, and your pet surely agrees. Come to Pegada, where every day is a day to find a new best friend!",
         "keywords": [
           "Dog",
           "Pet",
           "Friendship",
           "Meetup",
-          "Partner",
-          "Relationship",
           "Companion",
-          "Dating",
           "Match",
           "Doggie",
           "Puppy",
@@ -54,7 +47,7 @@
         "privacyChoicesUrl": "https://www.pegada.app/delete-account"
       }
     },
-    "categories": ["LIFESTYLE", "SOCIAL_NETWORKING"],
+    "categories": ["SOCIAL_NETWORKING", "LIFESTYLE"],
     "advisory": {
       "alcoholTobaccoOrDrugUseOrReferences": "NONE",
       "contests": "NONE",
@@ -68,10 +61,19 @@
       "violenceCartoonOrFantasy": "NONE",
       "violenceRealistic": "NONE",
       "violenceRealisticProlongedGraphicOrSadistic": "NONE",
+      "gunsOrOtherWeapons": "NONE",
       "gambling": false,
+      "lootBox": false,
+      "advertising": false,
+      "healthOrWellnessTopics": false,
+      "messagingAndChat": true,
+      "userGeneratedContent": true,
+      "parentalControls": false,
+      "ageAssurance": false,
       "unrestrictedWebAccess": false,
       "kidsAgeBand": null,
-      "seventeenPlus": true
+      "ageRatingOverride": "NONE",
+      "koreaAgeRatingOverride": "NONE"
     },
     "review": {
       "firstName": "Gabriel",


### PR DESCRIPTION
## Summary

The App Store age rating questionnaire in the repo forces Pegada to 17+ and the listing copy reads like a dating app. This fixes the questionnaire answers so they match what the app actually does, and takes the dating wording out of the store text.

## Details

- Hypothesis: the 17+ rating and the Dating positioning suppress impression to install conversion, because a large share of the audience for a dog friendship app is filtered out by the rating and mismatched by the category. Removing both should raise conversion. Part of #210.
- Baseline: App Store Connect impression to install conversion and Play Console store listing visitor to acquisition conversion, last 28 days, exported by Gabriel before anything ships. There is no in repo baseline for store funnel data, so the consoles are the only source. Issue #210 holds the export.
- Readout: same two reports 28 days after the new listing is approved, compared against the frozen pre change window. Primary number is product page view to install conversion per store, secondary is impressions, split by Search and Browse on iOS. No other store visible change during that window.
- Replaced the deprecated `seventeenPlus` flag with `ageRatingOverride` set to none, and added the Korea override at none. The questionnaire fields that were already answered stay at none, since the app has no mature, sexual, violent, gambling or drug content.
- Filled in the newer questionnaire fields Apple added, answered truthfully rather than defensively: the app does have chat and does show user generated content (dog photos and bios), so both are yes. Advertising, loot boxes, parental controls, age assurance, health topics, weapons and unrestricted web access are all no. Answering the chat and user content questions honestly may still land the computed rating above the minimum, but it is the answer that survives review.
- The advisory block was missing two fields that the current EAS Metadata schema requires, so `eas metadata:lint` failed on main. It passes now.
- Swapped the App Store categories so Social Networking is primary and Lifestyle is secondary.
- Took the dating and romance wording out of both localisations: the pt-BR description no longer calls the app a canine relationships app or compares it to Tinder, the en description no longer says relationship app, and the keyword lists no longer carry namoro, cruzar, relacionamento, encontro, dating, relationship or partner. The pt-BR subtitle moves off "Encontros", which is the exact name of the Dating category on Play in Brazil.
- Only the age rating and dating signals were touched. The stale `version` field, the keyword strategy, the new titles and the screenshots stay with #210.

## Testing steps

Pushing the store text from the repo only covers the App Store listing, and that push is not part of the release process yet, so most of this has to be done by hand in the two consoles.

App Store Connect

1. Open App Store Connect, pick Pegada, then App Information, then Age Rating, then Edit.
2. Answer every question with None or No, except the two about chat and about user generated content, which are yes.
3. Make sure the manual 17+ override is switched off, and the Korea override is off too.
4. Save, and confirm the rating shown on the app page is no longer 17+.
5. In App Information, set the primary category to Social Networking and the secondary to Lifestyle.
6. Submit the changes with the next release and confirm the public store page shows the new rating once it is approved.

Play Console

1. Open Play Console, pick Pegada, then Policy, then App content, then Content ratings, and start a new questionnaire.
2. Choose the Social, Communication or Dating questionnaire type, then answer no to every sexual and suggestive content question. Answer yes to the questions about users interacting and sharing content, since the app has chat and profile photos.
3. Submit and confirm the Sexual descriptor is gone from the listing.
4. Go to Grow, then Store presence, then Store settings, and change the app category from Dating to Social. Save and confirm the public listing no longer sits in Encontros.
5. Note the date both changes go live, since the 28 day readout window starts there.

Before and after, export the 28 day funnel numbers from both consoles and paste them into #210.

## Screenshots

Not applicable. This change is store metadata only, nothing in the app UI changes. The visible result is on the App Store and Play listings, which are covered by the console steps above and tracked in #210.
