### PR TITLE
feat(api): scheduled re-engagement pushes

### DIFF
--- a/apps/mobile/src/services/linking/handlers/initial-notification.ts
+++ b/apps/mobile/src/services/linking/handlers/initial-notification.ts
@@ -7,9 +7,18 @@
  * stop, and callers only ever need "read it" and "clear it".
  */
 let initialNotificationUrl: string | undefined;
+let initialNotificationKind: string | undefined;
 
 export const getInitialNotification = () => initialNotificationUrl;
 
-export const setInitialNotification = (url?: string) => {
+/**
+ * Which scheduled nudge the cold-start notification came from, if any. Kept
+ * beside the url so the open reported on launch carries the same breakdown the
+ * one reported while the app runs does.
+ */
+export const getInitialNotificationKind = () => initialNotificationKind;
+
+export const setInitialNotification = (url?: string, kind?: string) => {
   initialNotificationUrl = url;
+  initialNotificationKind = kind;
 };

--- a/apps/mobile/src/services/linking/handlers/notification.test.ts
+++ b/apps/mobile/src/services/linking/handlers/notification.test.ts
@@ -1,10 +1,9 @@
-import type * as Notifications from "expo-notifications";
+import { router } from "expo-router";
 
-/**
- * Stands in for the device's storage, so it survives the module reset that
- * stands in for closing and reopening the app.
- */
-const mockStoredValues = new Map<string, string>();
+import { analytics } from "@/services/analytics";
+import { SceneName } from "@/types/scene-name";
+
+import { customNotificationHandler } from "./notification";
 
 jest.mock<Partial<typeof import("expo-router")>>("expo-router", () => ({
   router: { push: jest.fn() } as unknown as typeof import("expo-router").router,
@@ -20,126 +19,29 @@ jest.mock<Partial<typeof import("@/services/analytics")>>(
   () => ({ analytics: { track: jest.fn() } as never }),
 );
 
-jest.mock<Partial<typeof import("@/services/storage")>>(
-  "@/services/storage",
-  () => ({
-    StorageKeys: {
-      LastOpenedNotificationId: "lastOpenedNotificationId",
-    } as never,
-    getData: jest.fn((key: string) =>
-      Promise.resolve(mockStoredValues.get(key) ?? null),
-    ) as never,
-    storeData: jest.fn((key: string, value: string) => {
-      mockStoredValues.set(key, value);
-      return Promise.resolve(value);
-    }) as never,
-  }),
-);
+const track = jest.mocked(analytics.track);
+const push = jest.mocked(router.push);
 
-/**
- * A fresh launch: the module's in-memory guard is gone, the stored identifier
- * is not.
- */
-const launchApp = () => {
-  jest.resetModules();
-
-  const handlers = require("./notification") as typeof import("./notification");
-  const { analytics } = require("@/services/analytics") as {
-    analytics: { track: jest.Mock };
-  };
-
-  return { ...handlers, track: analytics.track };
-};
-
-const notificationResponse = (identifier: string, kind?: string) =>
-  ({
-    notification: {
-      request: {
-        identifier,
-        content: { data: { url: "swipe", kind } },
-      },
-    },
-  }) as unknown as Notifications.NotificationResponse;
-
-/** The report is fire and forget, so let its promise chain drain. */
-const flush = () =>
-  new Promise<void>((resolve) => {
-    setImmediate(resolve);
-  });
-
-beforeEach(() => {
-  mockStoredValues.clear();
-});
-
-test("reports an open with the kind the server sent", async () => {
-  const { trackNotificationOpened, track } = launchApp();
-
-  trackNotificationOpened(notificationResponse("abc", "new_dogs_nearby"));
-  await flush();
-
-  expect(track).toHaveBeenCalledTimes(1);
-  expect(track).toHaveBeenCalledWith({
-    event_type: "push_notification_opened",
-    event_properties: { kind: "new_dogs_nearby" },
-  });
-});
-
-test("reports an open with no kind for a notification that carries none", async () => {
-  const { trackNotificationOpened, track } = launchApp();
-
-  trackNotificationOpened(notificationResponse("abc"));
-  await flush();
+test("carries the kind of the scheduled nudge into the open", () => {
+  customNotificationHandler("swipe", "new_dogs_nearby");
 
   expect(track).toHaveBeenCalledWith({
-    event_type: "push_notification_opened",
-    event_properties: { kind: undefined },
+    event_type: "Push Notification Opened",
+    event_properties: { kind: "new_dogs_nearby", url: "swipe" },
   });
 });
 
-test("counts one tap once even though two listeners see it", async () => {
-  const { trackNotificationOpened, track } = launchApp();
+test("reports an open with no kind for a push that carries none", () => {
+  customNotificationHandler("match/match-1/dog-1");
 
-  const response = notificationResponse("abc", "likes_waiting");
-  trackNotificationOpened(response);
-  trackNotificationOpened(response);
-  await flush();
-
-  expect(track).toHaveBeenCalledTimes(1);
+  expect(track).toHaveBeenCalledWith({
+    event_type: "Push Notification Opened",
+    event_properties: { kind: undefined, url: "match/match-1/dog-1" },
+  });
 });
 
-test("does not count the same notification again on the next launch", async () => {
-  const first = launchApp();
+test("sends the new dogs nudge to the deck", () => {
+  customNotificationHandler("swipe", "new_dogs_nearby");
 
-  first.trackNotificationOpened(
-    notificationResponse("abc", "unanswered_match"),
-  );
-  await flush();
-
-  expect(first.track).toHaveBeenCalledTimes(1);
-
-  // `getLastNotificationResponseAsync` hands back the same response on every
-  // cold start until a newer notification arrives, so this is the launch that
-  // used to double count.
-  const second = launchApp();
-
-  second.trackNotificationOpened(
-    notificationResponse("abc", "unanswered_match"),
-  );
-  await flush();
-
-  expect(second.track).not.toHaveBeenCalled();
-});
-
-test("counts a different notification on a later launch", async () => {
-  const first = launchApp();
-
-  first.trackNotificationOpened(notificationResponse("abc", "likes_waiting"));
-  await flush();
-
-  const second = launchApp();
-
-  second.trackNotificationOpened(notificationResponse("xyz", "likes_waiting"));
-  await flush();
-
-  expect(second.track).toHaveBeenCalledTimes(1);
+  expect(push).toHaveBeenCalledWith(SceneName.Swipe);
 });

--- a/apps/mobile/src/services/linking/handlers/notification.test.ts
+++ b/apps/mobile/src/services/linking/handlers/notification.test.ts
@@ -1,0 +1,145 @@
+import type * as Notifications from "expo-notifications";
+
+/**
+ * Stands in for the device's storage, so it survives the module reset that
+ * stands in for closing and reopening the app.
+ */
+const mockStoredValues = new Map<string, string>();
+
+jest.mock<Partial<typeof import("expo-router")>>("expo-router", () => ({
+  router: { push: jest.fn() } as unknown as typeof import("expo-router").router,
+}));
+
+jest.mock<Partial<typeof import("@/services/error-tracking")>>(
+  "@/services/error-tracking",
+  () => ({ sendError: jest.fn() }),
+);
+
+jest.mock<Partial<typeof import("@/services/analytics")>>(
+  "@/services/analytics",
+  () => ({ analytics: { track: jest.fn() } as never }),
+);
+
+jest.mock<Partial<typeof import("@/services/storage")>>(
+  "@/services/storage",
+  () => ({
+    StorageKeys: {
+      LastOpenedNotificationId: "lastOpenedNotificationId",
+    } as never,
+    getData: jest.fn((key: string) =>
+      Promise.resolve(mockStoredValues.get(key) ?? null),
+    ) as never,
+    storeData: jest.fn((key: string, value: string) => {
+      mockStoredValues.set(key, value);
+      return Promise.resolve(value);
+    }) as never,
+  }),
+);
+
+/**
+ * A fresh launch: the module's in-memory guard is gone, the stored identifier
+ * is not.
+ */
+const launchApp = () => {
+  jest.resetModules();
+
+  const handlers = require("./notification") as typeof import("./notification");
+  const { analytics } = require("@/services/analytics") as {
+    analytics: { track: jest.Mock };
+  };
+
+  return { ...handlers, track: analytics.track };
+};
+
+const notificationResponse = (identifier: string, kind?: string) =>
+  ({
+    notification: {
+      request: {
+        identifier,
+        content: { data: { url: "swipe", kind } },
+      },
+    },
+  }) as unknown as Notifications.NotificationResponse;
+
+/** The report is fire and forget, so let its promise chain drain. */
+const flush = () =>
+  new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+
+beforeEach(() => {
+  mockStoredValues.clear();
+});
+
+test("reports an open with the kind the server sent", async () => {
+  const { trackNotificationOpened, track } = launchApp();
+
+  trackNotificationOpened(notificationResponse("abc", "new_dogs_nearby"));
+  await flush();
+
+  expect(track).toHaveBeenCalledTimes(1);
+  expect(track).toHaveBeenCalledWith({
+    event_type: "push_notification_opened",
+    event_properties: { kind: "new_dogs_nearby" },
+  });
+});
+
+test("reports an open with no kind for a notification that carries none", async () => {
+  const { trackNotificationOpened, track } = launchApp();
+
+  trackNotificationOpened(notificationResponse("abc"));
+  await flush();
+
+  expect(track).toHaveBeenCalledWith({
+    event_type: "push_notification_opened",
+    event_properties: { kind: undefined },
+  });
+});
+
+test("counts one tap once even though two listeners see it", async () => {
+  const { trackNotificationOpened, track } = launchApp();
+
+  const response = notificationResponse("abc", "likes_waiting");
+  trackNotificationOpened(response);
+  trackNotificationOpened(response);
+  await flush();
+
+  expect(track).toHaveBeenCalledTimes(1);
+});
+
+test("does not count the same notification again on the next launch", async () => {
+  const first = launchApp();
+
+  first.trackNotificationOpened(
+    notificationResponse("abc", "unanswered_match"),
+  );
+  await flush();
+
+  expect(first.track).toHaveBeenCalledTimes(1);
+
+  // `getLastNotificationResponseAsync` hands back the same response on every
+  // cold start until a newer notification arrives, so this is the launch that
+  // used to double count.
+  const second = launchApp();
+
+  second.trackNotificationOpened(
+    notificationResponse("abc", "unanswered_match"),
+  );
+  await flush();
+
+  expect(second.track).not.toHaveBeenCalled();
+});
+
+test("counts a different notification on a later launch", async () => {
+  const first = launchApp();
+
+  first.trackNotificationOpened(notificationResponse("abc", "likes_waiting"));
+  await flush();
+
+  const second = launchApp();
+
+  second.trackNotificationOpened(notificationResponse("xyz", "likes_waiting"));
+  await flush();
+
+  expect(second.track).toHaveBeenCalledTimes(1);
+});

--- a/apps/mobile/src/services/linking/handlers/notification.ts
+++ b/apps/mobile/src/services/linking/handlers/notification.ts
@@ -10,12 +10,25 @@ enum NotificationUrl {
   Match = "match/",
   Chat = "chat/",
   Like = "like",
+  Swipe = "swipe",
 }
 
 export const getNotificationUrl = (
   response: Notifications.NotificationResponse,
 ): string | undefined => {
   return response.notification.request.content.data?.url as string | undefined;
+};
+
+/**
+ * Which scheduled nudge this push came from, when it came from one.
+ *
+ * Only the re-engagement cron sets it. Reactive pushes have no kind, and the
+ * open is still reported for them, just without the breakdown.
+ */
+export const getNotificationKind = (
+  response: Notifications.NotificationResponse,
+): string | undefined => {
+  return response.notification.request.content.data?.kind as string | undefined;
 };
 
 const handleUnknownNotification = (url: string) => {
@@ -37,14 +50,15 @@ const handleChatNotification = (matchId: string, dogId: string) => {
 };
 
 /**
- * A received like has no screen of its own: the dog that liked us stays hidden
- * until we like them back, so the tap lands on the deck where that can happen.
+ * Both urls land on the deck. A received like has no screen of its own, since
+ * the dog that liked us stays hidden until we like them back, and the "new dogs
+ * nearby" nudge is about the deck itself.
  */
-const handleLikeNotification = () => {
+const handleDeckNotification = () => {
   return router.push(SceneName.Swipe);
 };
 
-export const customNotificationHandler = (url?: string) => {
+export const customNotificationHandler = (url?: string, kind?: string) => {
   if (!url) return;
 
   // Both events fire from the same place because on this app they are the same
@@ -53,7 +67,7 @@ export const customNotificationHandler = (url?: string) => {
   // dog page, an email) has somewhere to land without splitting push history.
   analytics.track({
     event_type: "Push Notification Opened",
-    event_properties: { url },
+    event_properties: { kind, url },
   });
   analytics.track({
     event_type: "Deep Link Opened",
@@ -69,8 +83,8 @@ export const customNotificationHandler = (url?: string) => {
     return handleMatchNotification(matchId, dogId);
   }
 
-  if (url === NotificationUrl.Like) {
-    return handleLikeNotification();
+  if (url === NotificationUrl.Like || url === NotificationUrl.Swipe) {
+    return handleDeckNotification();
   }
 
   if (url.startsWith(NotificationUrl.Chat)) {

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -23,7 +23,10 @@ export const processLinks = () => {
     // promise was never the failure mode here; a thrown "Invalid notification
     // url" was, and `.catch` never saw it.
     try {
-      customNotificationHandler(initialNotification, getInitialNotificationKind());
+      customNotificationHandler(
+        initialNotification,
+        getInitialNotificationKind(),
+      );
     } catch (error) {
       sendError(error);
     }

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -6,10 +6,12 @@ import { sendError } from "@/services/error-tracking";
 
 import {
   getInitialNotification,
+  getInitialNotificationKind,
   setInitialNotification,
 } from "./handlers/initial-notification";
 import {
   customNotificationHandler,
+  getNotificationKind,
   getNotificationUrl,
 } from "./handlers/notification";
 
@@ -21,7 +23,7 @@ export const processLinks = () => {
     // promise was never the failure mode here; a thrown "Invalid notification
     // url" was, and `.catch` never saw it.
     try {
-      customNotificationHandler(initialNotification);
+      customNotificationHandler(initialNotification, getInitialNotificationKind());
     } catch (error) {
       sendError(error);
     }
@@ -34,7 +36,7 @@ export const processLinks = () => {
     Notifications.addNotificationResponseReceivedListener((response) => {
       const url = getNotificationUrl(response);
       try {
-        customNotificationHandler(url);
+        customNotificationHandler(url, getNotificationKind(response));
       } catch (error) {
         sendError(error);
       }
@@ -53,8 +55,10 @@ export const useGetInitialNotifications = () => {
     Notifications.getLastNotificationResponseAsync()
       .then((response) => {
         if (!response) return;
-        const url = getNotificationUrl(response);
-        setInitialNotification(url);
+        setInitialNotification(
+          getNotificationUrl(response),
+          getNotificationKind(response),
+        );
         return undefined;
       })
       .catch(sendError);
@@ -62,8 +66,10 @@ export const useGetInitialNotifications = () => {
     // When the app is already running, and the user clicks on a notification
     const notificationSubscription =
       Notifications.addNotificationResponseReceivedListener((response) => {
-        const url = getNotificationUrl(response);
-        setInitialNotification(url);
+        setInitialNotification(
+          getNotificationUrl(response),
+          getNotificationKind(response),
+        );
       });
 
     return () => {

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -9,6 +9,7 @@ export enum StorageKeys {
   Language = "language",
   AppReviewRequestDate = "appReviewRequestDate",
   AppReviewStatus = "appReviewStatus",
+  LastOpenedNotificationId = "lastOpenedNotificationId",
 }
 
 export enum Theme {
@@ -23,6 +24,7 @@ export type StorageDataTypes = {
   [StorageKeys.Language]: string;
   [StorageKeys.AppReviewRequestDate]: string;
   [StorageKeys.AppReviewStatus]: "completed";
+  [StorageKeys.LastOpenedNotificationId]: string;
 };
 
 export const storeData = async <T extends StorageKeys>(

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -9,7 +9,6 @@ export enum StorageKeys {
   Language = "language",
   AppReviewRequestDate = "appReviewRequestDate",
   AppReviewStatus = "appReviewStatus",
-  LastOpenedNotificationId = "lastOpenedNotificationId",
 }
 
 export enum Theme {
@@ -24,7 +23,6 @@ export type StorageDataTypes = {
   [StorageKeys.Language]: string;
   [StorageKeys.AppReviewRequestDate]: string;
   [StorageKeys.AppReviewStatus]: "completed";
-  [StorageKeys.LastOpenedNotificationId]: string;
 };
 
 export const storeData = async <T extends StorageKeys>(

--- a/apps/nextjs/src/app/api/cron/reengagement/route.ts
+++ b/apps/nextjs/src/app/api/cron/reengagement/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from "next/server";
+
+import { ReengagementService } from "@pegada/api/services/reengagement-service";
+import { isAuthorizedCronRequest } from "@pegada/api/shared/cron-auth";
+
+/**
+ * Vercel Cron hits this every hour (see `crons` in vercel.json). Hourly is not
+ * how often a user is nudged: it is what lets the service honour a per-user
+ * local time window, since 18:00 happens at twelve different UTC hours across
+ * the timezones the app has users in. The service decides who is actually due.
+ */
+export const GET = async (request: NextRequest) => {
+  if (!isAuthorizedCronRequest(request.headers.get("authorization"))) {
+    return new Response(null, { status: 401 });
+  }
+
+  const summary = await ReengagementService.run();
+
+  return Response.json(summary);
+};

--- a/apps/nextjs/src/app/api/cron/reengagement/route.ts
+++ b/apps/nextjs/src/app/api/cron/reengagement/route.ts
@@ -4,18 +4,18 @@ import { ReengagementService } from "@pegada/api/services/reengagement-service";
 import { isAuthorizedCronRequest } from "@pegada/api/shared/cron-auth";
 
 /**
- * Vercel Cron hits this every hour (see `crons` in vercel.json). Hourly is not
- * how often a user is nudged: it is what lets the service honour a per-user
- * local time window, since 18:00 happens at twelve different UTC hours across
- * the timezones the app has users in. The service decides who is actually due.
- */
-/**
  * Each send is a database write plus a queue publish, and the run does them in
  * sequence so the per-user daily cap cannot be raced. At the cap of 200 pushes
  * that is comfortably inside a minute and nowhere near the default budget.
  */
 export const maxDuration = 60;
 
+/**
+ * Vercel Cron hits this every hour (see `crons` in vercel.json). Hourly is not
+ * how often a user is nudged: it is what lets the service honour a per-user
+ * local time window, since 18:00 happens at twelve different UTC hours across
+ * the timezones the app has users in. The service decides who is actually due.
+ */
 export const GET = async (request: NextRequest) => {
   if (!isAuthorizedCronRequest(request.headers.get("authorization"))) {
     return new Response(null, { status: 401 });

--- a/apps/nextjs/src/app/api/cron/reengagement/route.ts
+++ b/apps/nextjs/src/app/api/cron/reengagement/route.ts
@@ -9,6 +9,13 @@ import { isAuthorizedCronRequest } from "@pegada/api/shared/cron-auth";
  * local time window, since 18:00 happens at twelve different UTC hours across
  * the timezones the app has users in. The service decides who is actually due.
  */
+/**
+ * Each send is a database write plus a queue publish, and the run does them in
+ * sequence so the per-user daily cap cannot be raced. At the cap of 200 pushes
+ * that is comfortably inside a minute and nowhere near the default budget.
+ */
+export const maxDuration = 60;
+
 export const GET = async (request: NextRequest) => {
   if (!isAuthorizedCronRequest(request.headers.get("authorization"))) {
     return new Response(null, { status: 401 });

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -301,6 +301,33 @@ describe("selectNewDogsNearbyCandidates", () => {
     expect(candidates[0]?.dedupeKey).toContain(":requested:");
     expect(candidates[0]?.clearsNewDogsAlert).toBe(true);
   });
+
+  it("drops a user whose token was blacklisted", async () => {
+    const { user } = await seedInactiveOwnerWithNewDogs(3);
+
+    // `blacklistPushToken` writes an empty string rather than null.
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { pushToken: "" },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("does not select a user who was already told about this anchor", async () => {
+    const { user } = await seedInactiveOwnerWithNewDogs(3);
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: user.id,
+        kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+        dedupeKey: "already-told",
+        sentAt: hoursAgo(2),
+      },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+  });
 });
 
 describe("selectLikesWaitingCandidates", () => {
@@ -358,6 +385,32 @@ describe("selectLikesWaitingCandidates", () => {
         requesterId: liked.id,
         responderId: admirer.id,
         swipeType: "NOT_INTERESTED",
+      },
+    });
+
+    await expect(selectLikesWaitingCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("skips a like from a dog the deck would no longer show", async () => {
+    const { admirer } = await seedWaitingLike(30);
+
+    await prisma.dog.update({
+      where: { id: admirer.id },
+      data: { banned: true },
+    });
+
+    await expect(selectLikesWaitingCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("does not repeat itself once the oldest waiting like was announced", async () => {
+    const { user, interest } = await seedWaitingLike(30);
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: user.id,
+        kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+        dedupeKey: `${REENGAGEMENT_KINDS.LIKES_WAITING}:${user.id}:${interest.id}`,
+        sentAt: hoursAgo(2),
       },
     });
 
@@ -425,5 +478,27 @@ describe("ReengagementService.run", () => {
         select: { newDogsAlertRequestedAt: true },
       }),
     ).resolves.toEqual({ newDogsAlertRequestedAt: null });
+
+    // Clearing the request moves the anchor back to the last positive swipe,
+    // which is what used to re-qualify the user under the inactivity rule the
+    // moment the daily cap expired.
+    const tomorrow = new Date(NOW.getTime() + 25 * 60 * 60 * 1000);
+    const nextDay = await ReengagementService.run(tomorrow);
+
+    expect(nextDay.sent).toBe(0);
+  });
+
+  it("does not count a push to a token Expo will reject", async () => {
+    await seedSilentMatch(25);
+    await prisma.user.updateMany({ data: { pushToken: "not-a-real-token" } });
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary.sent).toBe(0);
+    expect(summary.skippedUnreachable).toBe(2);
+    expect(await prisma.notificationLog.count()).toBe(0);
+    expect(
+      PushNotificationService.enqueuePushNotification,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -1,0 +1,429 @@
+import prisma from "@pegada/database";
+import { breedData } from "@pegada/database/fixtures/breed-data";
+import { generateFakeUserWithDog } from "@pegada/database/fixtures/generate-fake-user-with-dog";
+
+import {
+  isWithinSendWindow,
+  localHourFromLongitude,
+  REENGAGEMENT_KINDS,
+  ReengagementService,
+  selectLikesWaitingCandidates,
+  selectNewDogsNearbyCandidates,
+  selectUnansweredMatchCandidates,
+} from "./reengagement-service";
+
+jest.mock("../shared/observability", () => ({
+  observability: {
+    enabled: false,
+    disabledReason: "explicitly-disabled",
+    capture: jest.fn(),
+    captureError: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    register: jest.fn(),
+    flush: jest.fn(),
+    shutdown: jest.fn(),
+  },
+  getPostHogNode: jest.fn(() => null),
+}));
+
+jest.mock("./push-notification-service", () => ({
+  PushNotificationService: { enqueuePushNotification: jest.fn() },
+}));
+
+const { PushNotificationService } = jest.requireMock(
+  "./push-notification-service",
+) as { PushNotificationService: { enqueuePushNotification: jest.Mock } };
+
+const PUSH_TOKEN = "ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]";
+
+/** Salvador, Bahia. Longitude -38.5 puts the fixtures three hours behind UTC. */
+const LONGITUDE = -38.5;
+const LATITUDE = -12.97;
+
+/** 15:00 in UTC-3, comfortably inside the send window. */
+const NOW = new Date("2026-09-01T18:00:00.000Z");
+
+/** 03:00 in UTC-3, inside quiet hours. */
+const NIGHT = new Date("2026-09-01T06:00:00.000Z");
+
+const hoursBefore = (reference: Date, hours: number) =>
+  new Date(reference.getTime() - hours * 60 * 60 * 1000);
+
+const hoursAgo = (hours: number) => hoursBefore(NOW, hours);
+
+const daysAgo = (days: number) => hoursAgo(days * 24);
+
+const reachableUser = (overrides: Record<string, unknown> = {}) => ({
+  pushToken: PUSH_TOKEN,
+  latitude: LATITUDE,
+  longitude: LONGITUDE,
+  ...overrides,
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeAll(async () => {
+  await prisma.breed.deleteMany();
+  await prisma.breed.createMany({ data: breedData });
+});
+
+beforeEach(async () => {
+  // One statement rather than a chain of `deleteMany`s: `relationMode =
+  // "prisma"` makes Prisma police the relations itself, and these fixtures
+  // wire Interest to both Dog and Match, so there is no delete order that does
+  // not trip over one of them.
+  await prisma.$executeRawUnsafe(
+    'TRUNCATE TABLE "NotificationLog", "Message", "Interest", "Match", "Image", "Dog", "User" CASCADE',
+  );
+});
+
+/** Two dogs that matched `hours` before `reference` and never spoke. */
+const seedSilentMatch = async (hours: number, reference = NOW) => {
+  const [{ dog: requester }, { dog: responder }] = await Promise.all([
+    generateFakeUserWithDog({ gender: "MALE" }, reachableUser()),
+    generateFakeUserWithDog({ gender: "FEMALE" }, reachableUser()),
+  ]);
+
+  const match = await prisma.match.create({
+    data: { requesterId: requester.id, responderId: responder.id },
+  });
+
+  await prisma.match.update({
+    where: { id: match.id },
+    data: { createdAt: hoursBefore(reference, hours) },
+  });
+
+  return { match, requester, responder };
+};
+
+describe("localHourFromLongitude", () => {
+  it("reads the hour from the longitude offset", () => {
+    expect(localHourFromLongitude(LONGITUDE, NOW)).toBe(15);
+    expect(localHourFromLongitude(0, NOW)).toBe(18);
+    expect(localHourFromLongitude(150, NOW)).toBe(4);
+  });
+
+  it("has no hour without a longitude", () => {
+    expect(localHourFromLongitude(null, NOW)).toBeNull();
+    expect(localHourFromLongitude(undefined, NOW)).toBeNull();
+  });
+});
+
+describe("isWithinSendWindow", () => {
+  it("sends during the day and stays quiet at night", () => {
+    expect(isWithinSendWindow(LONGITUDE, NOW)).toBe(true);
+    // 23:00 local.
+    expect(
+      isWithinSendWindow(LONGITUDE, new Date("2026-09-02T02:00:00.000Z")),
+    ).toBe(false);
+    // 06:00 local.
+    expect(isWithinSendWindow(LONGITUDE, NIGHT)).toBe(false);
+  });
+
+  it("falls back to the single 18:00 Sao Paulo slot without coordinates", () => {
+    // 18:00 in UTC-3.
+    expect(isWithinSendWindow(null, new Date("2026-09-01T21:00:00.000Z"))).toBe(
+      true,
+    );
+    // 15:00 in UTC-3, fine for a located user but not for this one.
+    expect(isWithinSendWindow(null, NOW)).toBe(false);
+  });
+});
+
+describe("selectUnansweredMatchCandidates", () => {
+  it("nudges both sides of a match that went silent", async () => {
+    const { match, requester, responder } = await seedSilentMatch(25);
+
+    const candidates = await selectUnansweredMatchCandidates(NOW);
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates.map((candidate) => candidate.kind)).toEqual([
+      REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+      REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+    ]);
+    expect(candidates.map((candidate) => candidate.url).sort()).toEqual(
+      [
+        `chat/${match.id}/${requester.id}`,
+        `chat/${match.id}/${responder.id}`,
+      ].sort(),
+    );
+    expect(
+      candidates.every((candidate) => candidate.dedupeKey.endsWith(":24h")),
+    ).toBe(true);
+  });
+
+  it("skips a match that is not old enough yet", async () => {
+    await seedSilentMatch(3);
+
+    await expect(selectUnansweredMatchCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("skips a match somebody already spoke on", async () => {
+    const { match, requester, responder } = await seedSilentMatch(25);
+
+    await prisma.message.create({
+      data: {
+        content: "oi",
+        senderId: requester.id,
+        receiverId: responder.id,
+        matchId: match.id,
+      },
+    });
+
+    await expect(selectUnansweredMatchCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("adds the 72 hour nudge once the match is older", async () => {
+    await seedSilentMatch(80);
+
+    const candidates = await selectUnansweredMatchCandidates(NOW);
+
+    expect(candidates).toHaveLength(2);
+    expect(
+      candidates.every((candidate) => candidate.dedupeKey.endsWith(":72h")),
+    ).toBe(true);
+  });
+
+  it("skips a user with no push token", async () => {
+    const { match } = await seedSilentMatch(25);
+    const silent = await prisma.match.findUniqueOrThrow({
+      where: { id: match.id },
+      select: { requester: { select: { userId: true } } },
+    });
+
+    await prisma.user.update({
+      where: { id: silent.requester.userId },
+      data: { pushToken: null },
+    });
+
+    await expect(selectUnansweredMatchCandidates(NOW)).resolves.toHaveLength(1);
+  });
+});
+
+describe("selectNewDogsNearbyCandidates", () => {
+  /** An inactive owner plus `count` dogs created since they stopped swiping. */
+  const seedInactiveOwnerWithNewDogs = async (count: number) => {
+    const { user, dog } = await generateFakeUserWithDog(
+      { gender: "MALE" },
+      reachableUser(),
+    );
+
+    // Somebody they already swiped on, four days ago.
+    const { dog: swiped } = await generateFakeUserWithDog(
+      { gender: "FEMALE" },
+      reachableUser({ pushToken: null }),
+    );
+
+    await prisma.interest.create({
+      data: {
+        requesterId: dog.id,
+        responderId: swiped.id,
+        swipeType: "INTERESTED",
+        lastPositiveAt: daysAgo(4),
+      },
+    });
+
+    const newDogs = [];
+    for (const index of Array.from({ length: count }, (_value, i) => i)) {
+      // oxlint-disable-next-line no-await-in-loop -- Fixture rows are created in order so their timestamps stay distinct.
+      const { dog: newDog } = await generateFakeUserWithDog(
+        { gender: "FEMALE", name: `New ${index}` },
+        reachableUser({ pushToken: null }),
+      );
+      newDogs.push(newDog);
+    }
+
+    await prisma.dog.updateMany({
+      where: { id: { in: newDogs.map(({ id }) => id) } },
+      data: { createdAt: daysAgo(1) },
+    });
+
+    return { user, dog };
+  };
+
+  it("selects an inactive owner once enough new dogs arrived", async () => {
+    const { user } = await seedInactiveOwnerWithNewDogs(3);
+
+    const candidates = await selectNewDogsNearbyCandidates(NOW);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+      userId: user.id,
+      url: "swipe",
+    });
+    expect(candidates[0]?.dedupeKey).toContain(`:${user.id}:3d:`);
+  });
+
+  it("stays quiet when fewer than three new dogs arrived", async () => {
+    await seedInactiveOwnerWithNewDogs(2);
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("ignores new dogs outside the preferred distance", async () => {
+    const { dog } = await seedInactiveOwnerWithNewDogs(3);
+
+    await prisma.dog.update({
+      where: { id: dog.id },
+      data: { preferredMaxDistance: 1 },
+    });
+
+    await prisma.user.updateMany({
+      where: { pushToken: null },
+      data: { latitude: -23.55, longitude: -46.63 },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("selects a user who asked to be told even though they are active", async () => {
+    const { user } = await seedInactiveOwnerWithNewDogs(3);
+
+    await prisma.interest.updateMany({
+      where: { requester: { userId: user.id } },
+      data: { lastPositiveAt: hoursAgo(1) },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { newDogsAlertRequestedAt: daysAgo(2) },
+    });
+
+    const candidates = await selectNewDogsNearbyCandidates(NOW);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.dedupeKey).toContain(":requested:");
+    expect(candidates[0]?.clearsNewDogsAlert).toBe(true);
+  });
+});
+
+describe("selectLikesWaitingCandidates", () => {
+  const seedWaitingLike = async (hours: number) => {
+    const [{ user, dog: liked }, { dog: admirer }] = await Promise.all([
+      generateFakeUserWithDog({ gender: "FEMALE" }, reachableUser()),
+      generateFakeUserWithDog(
+        { gender: "MALE" },
+        reachableUser({ pushToken: null }),
+      ),
+    ]);
+
+    const interest = await prisma.interest.create({
+      data: {
+        requesterId: admirer.id,
+        responderId: liked.id,
+        swipeType: "INTERESTED",
+        lastPositiveAt: hoursAgo(hours),
+      },
+    });
+
+    await prisma.interest.update({
+      where: { id: interest.id },
+      data: { createdAt: hoursAgo(hours) },
+    });
+
+    return { user, liked, admirer, interest };
+  };
+
+  it("selects an owner sitting on a like older than a day", async () => {
+    const { user, interest } = await seedWaitingLike(30);
+
+    const candidates = await selectLikesWaitingCandidates(NOW);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+      userId: user.id,
+      url: "swipe",
+      dedupeKey: `${REENGAGEMENT_KINDS.LIKES_WAITING}:${user.id}:${interest.id}`,
+    });
+  });
+
+  it("skips a like that is still fresh", async () => {
+    await seedWaitingLike(2);
+
+    await expect(selectLikesWaitingCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("skips a like the owner already answered", async () => {
+    const { liked, admirer } = await seedWaitingLike(30);
+
+    await prisma.interest.create({
+      data: {
+        requesterId: liked.id,
+        responderId: admirer.id,
+        swipeType: "NOT_INTERESTED",
+      },
+    });
+
+    await expect(selectLikesWaitingCandidates(NOW)).resolves.toEqual([]);
+  });
+});
+
+describe("ReengagementService.run", () => {
+  it("sends each nudge once and never twice in the same day", async () => {
+    await seedSilentMatch(25);
+
+    const first = await ReengagementService.run(NOW);
+
+    expect(first.sent).toBe(2);
+    expect(first.byKind[REENGAGEMENT_KINDS.UNANSWERED_MATCH]).toBe(2);
+    expect(
+      PushNotificationService.enqueuePushNotification,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      PushNotificationService.enqueuePushNotification.mock.calls[0]?.[0].data,
+    ).toMatchObject({ kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH });
+
+    const second = await ReengagementService.run(NOW);
+
+    expect(second.sent).toBe(0);
+    expect(second.skippedCooldown).toBe(2);
+    expect(await prisma.notificationLog.count()).toBe(2);
+  });
+
+  it("sends nothing during quiet hours", async () => {
+    await seedSilentMatch(25, NIGHT);
+
+    const summary = await ReengagementService.run(NIGHT);
+
+    expect(summary.sent).toBe(0);
+    expect(summary.skippedQuietHours).toBe(2);
+    expect(
+      PushNotificationService.enqueuePushNotification,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("clears the alert request after answering it", async () => {
+    const { user, dog } = await generateFakeUserWithDog(
+      { gender: "MALE" },
+      reachableUser({ newDogsAlertRequestedAt: daysAgo(2) }),
+    );
+
+    for (const index of [0, 1, 2]) {
+      // oxlint-disable-next-line no-await-in-loop -- Fixture rows are created in order so their timestamps stay distinct.
+      await generateFakeUserWithDog(
+        { gender: "FEMALE", name: `New ${index}` },
+        reachableUser({ pushToken: null }),
+      );
+    }
+
+    expect(dog.userId).toBe(user.id);
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary.sent).toBe(1);
+    expect(summary.byKind[REENGAGEMENT_KINDS.NEW_DOGS_NEARBY]).toBe(1);
+    await expect(
+      prisma.user.findUniqueOrThrow({
+        where: { id: user.id },
+        select: { newDogsAlertRequestedAt: true },
+      }),
+    ).resolves.toEqual({ newDogsAlertRequestedAt: null });
+  });
+});

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -535,6 +535,44 @@ describe("ReengagementService.run", () => {
     expect(requester.id).not.toBe(responder.id);
   });
 
+  it("does not let the daily cap drift out of the evening slot", async () => {
+    // 18:00 in Sao Paulo, the first of the two fallback hours.
+    const eveningSlot = new Date("2026-09-01T21:00:00.000Z");
+    const { requester } = await seedSilentMatch(25, eveningSlot);
+
+    // No coordinates, so this user only ever gets the evening slot.
+    await prisma.user.updateMany({
+      data: { latitude: null, longitude: null },
+    });
+
+    /** Nudged at yesterday's 19:00 slot, then run at today's 18:00 one. */
+    const runAfterPreviousNudge = async (hoursSince: number) => {
+      await prisma.notificationLog.deleteMany();
+      await prisma.notificationLog.create({
+        data: {
+          userId: requester.userId,
+          kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+          dedupeKey: `yesterday:${hoursSince}`,
+          sentAt: hoursBefore(eveningSlot, hoursSince),
+        },
+      });
+
+      return ReengagementService.run(eveningSlot);
+    };
+
+    // An hour earlier in the evening than yesterday's send is exactly the
+    // case a 24 hour window pushed into the following day.
+    const onTime = await runAfterPreviousNudge(23);
+
+    expect(onTime.skippedCooldown).toBe(0);
+    expect(onTime.sent).toBe(2);
+
+    // Well inside the same day, still held back.
+    const tooSoon = await runAfterPreviousNudge(2);
+
+    expect(tooSoon.skippedCooldown).toBe(1);
+  });
+
   it("falls through to the next kind once the cap expires", async () => {
     const { responder } = await seedSilentMatch(25);
 

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -123,10 +123,18 @@ describe("isWithinSendWindow", () => {
     expect(isWithinSendWindow(LONGITUDE, NIGHT)).toBe(false);
   });
 
-  it("falls back to the single 18:00 Sao Paulo slot without coordinates", () => {
-    // 18:00 in UTC-3.
+  it("falls back to the early evening Sao Paulo slot without coordinates", () => {
+    // 18:00 in UTC-3, and 19:00 so one missed cron run does not drop the
+    // whole cohort for the day.
     expect(isWithinSendWindow(null, new Date("2026-09-01T21:00:00.000Z"))).toBe(
       true,
+    );
+    expect(isWithinSendWindow(null, new Date("2026-09-01T22:00:00.000Z"))).toBe(
+      true,
+    );
+    // 20:00 in UTC-3, past the slot.
+    expect(isWithinSendWindow(null, new Date("2026-09-01T23:00:00.000Z"))).toBe(
+      false,
     );
     // 15:00 in UTC-3, fine for a located user but not for this one.
     expect(isWithinSendWindow(null, NOW)).toBe(false);
@@ -278,6 +286,59 @@ describe("selectNewDogsNearbyCandidates", () => {
     });
 
     await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+  });
+
+  it("reads a zero preferred distance as no preference, like the deck does", async () => {
+    const { dog } = await seedInactiveOwnerWithNewDogs(3);
+
+    await prisma.dog.update({
+      where: { id: dog.id },
+      data: { preferredMaxDistance: 0 },
+    });
+
+    await prisma.user.updateMany({
+      where: { pushToken: null },
+      data: { latitude: -23.55, longitude: -46.63 },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toHaveLength(1);
+  });
+
+  it("lets a user who never swiped be nudged again in the next period", async () => {
+    const { user } = await seedInactiveOwnerWithNewDogs(3);
+
+    // No positive swipe at all, so there is no anchor to rate limit them.
+    await prisma.interest.deleteMany({
+      where: { requester: { userId: user.id } },
+    });
+
+    const [candidate] = await selectNewDogsNearbyCandidates(NOW);
+
+    expect(candidate?.dedupeKey).toMatch(/:never:\d+$/);
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: user.id,
+        kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+        dedupeKey: candidate?.dedupeKey ?? "",
+        sentAt: hoursAgo(1),
+      },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+
+    // A period later the key names a new period and the filter lets them back.
+    const nextPeriod = new Date(NOW.getTime() + 31 * 24 * 60 * 60 * 1000);
+
+    await prisma.dog.updateMany({
+      where: { userId: { not: user.id } },
+      data: { createdAt: hoursBefore(nextPeriod, 24) },
+    });
+
+    const later = await selectNewDogsNearbyCandidates(nextPeriod);
+
+    expect(later).toHaveLength(1);
+    expect(later[0]?.dedupeKey).not.toBe(candidate?.dedupeKey);
   });
 
   it("selects a user who asked to be told even though they are active", async () => {
@@ -436,8 +497,75 @@ describe("ReengagementService.run", () => {
     const second = await ReengagementService.run(NOW);
 
     expect(second.sent).toBe(0);
-    expect(second.skippedCooldown).toBe(2);
+    expect(second.skippedAlreadySent).toBe(2);
     expect(await prisma.notificationLog.count()).toBe(2);
+  });
+
+  it("holds a user to one push a day across different kinds", async () => {
+    const { requester, responder } = await seedSilentMatch(25);
+
+    // A waiting like for the same user, so there is a second kind queued.
+    const { dog: admirer } = await generateFakeUserWithDog(
+      { gender: "MALE" },
+      reachableUser({ pushToken: null }),
+    );
+    const like = await prisma.interest.create({
+      data: {
+        requesterId: admirer.id,
+        responderId: responder.id,
+        swipeType: "INTERESTED",
+        lastPositiveAt: hoursAgo(30),
+      },
+    });
+    await prisma.interest.update({
+      where: { id: like.id },
+      data: { createdAt: hoursAgo(30) },
+    });
+
+    expect((await ReengagementService.run(NOW)).sent).toBe(2);
+
+    // Two hours later the match keys are claimed but the like key is not, and
+    // the daily cap is what has to stop it.
+    const summary = await ReengagementService.run(
+      new Date(NOW.getTime() + 2 * 60 * 60 * 1000),
+    );
+
+    expect(summary.sent).toBe(0);
+    expect(summary.skippedCooldown).toBe(1);
+    expect(requester.id).not.toBe(responder.id);
+  });
+
+  it("falls through to the next kind once the cap expires", async () => {
+    const { responder } = await seedSilentMatch(25);
+
+    const { dog: admirer } = await generateFakeUserWithDog(
+      { gender: "MALE" },
+      reachableUser({ pushToken: null }),
+    );
+    const like = await prisma.interest.create({
+      data: {
+        requesterId: admirer.id,
+        responderId: responder.id,
+        swipeType: "INTERESTED",
+        lastPositiveAt: hoursAgo(30),
+      },
+    });
+    await prisma.interest.update({
+      where: { id: like.id },
+      data: { createdAt: hoursAgo(30) },
+    });
+
+    await ReengagementService.run(NOW);
+
+    // Age the log past the daily cap. The match nudge is still claimed, so a
+    // user whose best candidate is spent has to reach their next one rather
+    // than lose the day to it.
+    await prisma.notificationLog.updateMany({ data: { sentAt: hoursAgo(30) } });
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary.sent).toBe(1);
+    expect(summary.byKind[REENGAGEMENT_KINDS.LIKES_WAITING]).toBe(1);
   });
 
   it("sends nothing during quiet hours", async () => {

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -35,6 +35,10 @@ const { PushNotificationService } = jest.requireMock(
   "./push-notification-service",
 ) as { PushNotificationService: { enqueuePushNotification: jest.Mock } };
 
+const { observability } = jest.requireMock("../shared/observability") as {
+  observability: { capture: jest.Mock };
+};
+
 const PUSH_TOKEN = "ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]";
 
 /** Salvador, Bahia. Longitude -38.5 puts the fixtures three hours behind UTC. */
@@ -193,6 +197,22 @@ describe("selectUnansweredMatchCandidates", () => {
     expect(
       candidates.every((candidate) => candidate.dedupeKey.endsWith(":72h")),
     ).toBe(true);
+  });
+
+  it("leaves alone the side that has been in the app today", async () => {
+    const { requester } = await seedSilentMatch(25);
+
+    // The proxy still says "went silent": nobody has spoken on the match. The
+    // column says this one never left, so only the other side is worth a push.
+    await prisma.user.update({
+      where: { id: requester.userId },
+      data: { lastActiveAt: hoursAgo(2) },
+    });
+
+    const candidates = await selectUnansweredMatchCandidates(NOW);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.userId).not.toBe(requester.userId);
   });
 
   it("skips a user with no push token", async () => {
@@ -363,6 +383,26 @@ describe("selectNewDogsNearbyCandidates", () => {
     expect(candidates[0]?.clearsNewDogsAlert).toBe(true);
   });
 
+  it("leaves alone an owner who opened the app in the last day", async () => {
+    const { user } = await seedInactiveOwnerWithNewDogs(3);
+
+    // Still no positive swipe for four days, so the proxy would nudge them.
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { lastActiveAt: hoursAgo(2) },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toEqual([]);
+
+    // Older than the window, so the proxy decides again.
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { lastActiveAt: daysAgo(2) },
+    });
+
+    await expect(selectNewDogsNearbyCandidates(NOW)).resolves.toHaveLength(1);
+  });
+
   it("drops a user whose token was blacklisted", async () => {
     const { user } = await seedInactiveOwnerWithNewDogs(3);
 
@@ -493,6 +533,18 @@ describe("ReengagementService.run", () => {
     expect(
       PushNotificationService.enqueuePushNotification.mock.calls[0]?.[0].data,
     ).toMatchObject({ kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH });
+
+    // The send half of the open rate. `dedupe_key` is what pairs it with the
+    // "Push Notification Opened" the tap produces.
+    expect(observability.capture).toHaveBeenCalledWith(
+      "Reengagement Push Sent",
+      expect.objectContaining({
+        kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+        dedupe_key: expect.stringContaining(
+          REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+        ),
+      }),
+    );
 
     const second = await ReengagementService.run(NOW);
 

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -1,19 +1,27 @@
+import type { ReengagementPushKind } from "@pegada/shared/analytics/events";
+
 import { Expo } from "expo-server-sdk";
 
 import prisma from "@pegada/database";
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { Language } from "@pegada/shared/i18n/types/types";
 import { Prisma } from "@prisma/client";
 
 import { sendError } from "../errors/errors";
-import { observability } from "../shared/observability";
+import { captureEvent } from "../shared/analytics";
 import { PushNotificationService } from "./push-notification-service";
 import { TranslationService } from "./translation-service";
 
+/**
+ * `satisfies` rather than a bare `as const`: the catalogue restates these three
+ * values (it cannot import them without a cycle), and this is what makes a new
+ * kind added here a compile error until the catalogue knows about it too.
+ */
 export const REENGAGEMENT_KINDS = {
   UNANSWERED_MATCH: "unanswered_match",
   NEW_DOGS_NEARBY: "new_dogs_nearby",
   LIKES_WAITING: "likes_waiting",
-} as const;
+} as const satisfies Record<string, ReengagementPushKind>;
 
 export type ReengagementKind =
   (typeof REENGAGEMENT_KINDS)[keyof typeof REENGAGEMENT_KINDS];
@@ -31,6 +39,17 @@ const UNANSWERED_MATCH_MAX_AGE_HOURS = 14 * 24;
 
 /** Days without a positive swipe that make a user eligible for new dogs. */
 export const INACTIVE_DAYS = [3, 7] as const;
+
+/**
+ * How recently someone has to have used the app to be left alone.
+ *
+ * Every selector below infers "gone quiet" from a proxy (no positive swipe, a
+ * match nobody spoke on, a like nobody answered), and each proxy misses the
+ * person who is in the app right now doing something else. `lastActiveAt` is
+ * the direct signal, written on authenticated requests, so it is the guard that
+ * keeps a win-back push off the screen of someone who never left.
+ */
+export const RECENT_ACTIVITY_HOURS = 24;
 
 /** New dogs that have to exist nearby before the nudge is worth sending. */
 export const MIN_NEW_DOGS = 3;
@@ -115,6 +134,28 @@ export type ReengagementRunSummary = {
   skippedAlreadySent: number;
   skippedUnreachable: number;
 };
+
+/**
+ * The instant before which a user counts as away.
+ *
+ * A null `lastActiveAt` is unknown rather than active: the column is only
+ * written once a user makes an authenticated request after #217 shipped, so
+ * reading null as "here" would mute the whole cron until everyone came back on
+ * their own. The proxy each selector already applies decides those users.
+ */
+const recentActivityFloor = (now: Date) =>
+  new Date(now.getTime() - RECENT_ACTIVITY_HOURS * HOUR_MS);
+
+const isRecentlyActive = (lastActiveAt: Date | null, now: Date) =>
+  lastActiveAt !== null && lastActiveAt > recentActivityFloor(now);
+
+/** The same rule in SQL, for the selectors that run as raw queries. */
+const notRecentlyActive = (now: Date) => Prisma.sql`
+  (
+    "User"."lastActiveAt" IS NULL
+    OR "User"."lastActiveAt" <= ${recentActivityFloor(now)}
+  )
+`;
 
 const hourInOffset = (now: Date, offsetHours: number) =>
   (((now.getUTCHours() + offsetHours) % 24) + 24) % 24;
@@ -203,7 +244,14 @@ export const selectUnansweredMatchCandidates = async (
       const dogSelect = {
         id: true,
         name: true,
-        user: { select: { id: true, pushToken: true, longitude: true } },
+        user: {
+          select: {
+            id: true,
+            pushToken: true,
+            longitude: true,
+            lastActiveAt: true,
+          },
+        },
       } as const;
 
       const matches = await prisma.match.findMany({
@@ -239,7 +287,7 @@ export const selectUnansweredMatchCandidates = async (
           { self: match.requester, other: match.responder },
           { self: match.responder, other: match.requester },
         ].flatMap(({ self, other }) =>
-          self.user.pushToken
+          self.user.pushToken && !isRecentlyActive(self.user.lastActiveAt, now)
             ? [
                 {
                   kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
@@ -357,6 +405,7 @@ export const selectNewDogsNearbyCandidates = async (
         label: `${days}d`,
         eligibility: Prisma.sql`
           "User"."newDogsAlertRequestedAt" IS NULL
+          AND ${notRecentlyActive(now)}
           AND NOT ${swipedPositivelySince(new Date(now.getTime() - days * DAY_MS))}
           ${lowerBound}
         `,
@@ -535,6 +584,7 @@ export const selectLikesWaitingCandidates = async (
       JOIN "User" AS "AdmirerUser" ON "AdmirerUser"."id" = "Admirer"."userId"
         AND "AdmirerUser"."deletedAt" IS NULL
       WHERE ${REACHABLE_USER}
+      AND ${notRecentlyActive(now)}
       AND "Interest"."deletedAt" IS NULL
       AND "Interest"."matchId" IS NULL
       AND "Interest"."swipeType" IN ('INTERESTED'::"SwipeType", 'MAYBE'::"SwipeType")
@@ -804,10 +854,9 @@ export class ReengagementService {
       }
     }
 
-    observability.capture("reengagement_push_sent", {
-      distinctId: candidate.userId,
+    captureEvent(candidate.userId, ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT, {
+      dedupe_key: candidate.dedupeKey,
       kind: candidate.kind,
-      dedupeKey: candidate.dedupeKey,
     });
 
     return "sent";

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -73,7 +73,18 @@ const FALLBACK_OFFSET_HOURS = -3;
 const FALLBACK_SEND_HOURS = new Set([18, 19]);
 
 /** One re-engagement push per user per rolling day. */
-const USER_COOLDOWN_HOURS = 24;
+/**
+ * One re-engagement push per user per day.
+ *
+ * 23 hours rather than 24, and strictly greater than rather than inclusive,
+ * because the job runs hourly and the cap is measured against the previous
+ * send. At exactly 24 a user nudged at 19:00 is still inside the window at
+ * 18:00 the next day, so their slot slides an hour later each time until it
+ * falls out of the evening entirely and they end up on every other day. The
+ * hour of slack absorbs that without ever allowing two sends in a calendar
+ * day, since the earliest either can land is 09:00 local.
+ */
+const USER_COOLDOWN_HOURS = 23;
 
 /** Bounds one invocation so a backlog cannot outrun the function budget. */
 const MAX_CANDIDATES_PER_QUERY = 500;
@@ -682,7 +693,7 @@ export class ReengagementService {
       where: {
         userId: { in: due.map(([userId]) => userId) },
         sentAt: {
-          gte: new Date(now.getTime() - USER_COOLDOWN_HOURS * HOUR_MS),
+          gt: new Date(now.getTime() - USER_COOLDOWN_HOURS * HOUR_MS),
         },
       },
       select: { userId: true },

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -1,0 +1,649 @@
+import prisma from "@pegada/database";
+import { Language } from "@pegada/shared/i18n/types/types";
+import { Prisma } from "@prisma/client";
+
+import { sendError } from "../errors/errors";
+import { observability } from "../shared/observability";
+import { PushNotificationService } from "./push-notification-service";
+import { TranslationService } from "./translation-service";
+
+export const REENGAGEMENT_KINDS = {
+  UNANSWERED_MATCH: "unanswered_match",
+  NEW_DOGS_NEARBY: "new_dogs_nearby",
+  LIKES_WAITING: "likes_waiting",
+} as const;
+
+export type ReengagementKind =
+  (typeof REENGAGEMENT_KINDS)[keyof typeof REENGAGEMENT_KINDS];
+
+/** Hours after a silent match at which the two sides get nudged. */
+export const UNANSWERED_MATCH_HOURS = [24, 72] as const;
+
+/**
+ * How far back each unanswered-match bucket reaches. Without a floor, the
+ * first run after deploy would nudge every silent match ever created; with it,
+ * a match is only ever eligible inside the window that follows its own
+ * threshold.
+ */
+const UNANSWERED_MATCH_MAX_AGE_HOURS = 14 * 24;
+
+/** Days without a positive swipe that make a user eligible for new dogs. */
+export const INACTIVE_DAYS = [3, 7] as const;
+
+/** New dogs that have to exist nearby before the nudge is worth sending. */
+export const MIN_NEW_DOGS = 3;
+
+/** How old a like has to be before it counts as waiting. */
+const LIKES_WAITING_HOURS = 24;
+
+/**
+ * When a user has never swiped positively there is no anchor to count new dogs
+ * from, so the count starts here instead.
+ */
+const NEW_DOGS_FALLBACK_WINDOW_DAYS = 30;
+
+/**
+ * Above this, `preferredMaxDistance` means "anywhere" and no distance filter
+ * is applied. Same threshold the swipe deck uses in SuggestionService, so the
+ * count in the copy matches the deck the user lands on.
+ */
+const UNLIMITED_DISTANCE_KM = 295;
+
+/** Local hours between which nothing is sent. */
+const QUIET_HOURS_START = 21;
+const QUIET_HOURS_END = 9;
+
+/** America/Sao_Paulo, for users whose coordinates we do not have. */
+const FALLBACK_OFFSET_HOURS = -3;
+const FALLBACK_SEND_HOUR = 18;
+
+/** One re-engagement push per user per rolling day. */
+const USER_COOLDOWN_HOURS = 24;
+
+/** Bounds one invocation so a backlog cannot outrun the function budget. */
+const MAX_CANDIDATES_PER_QUERY = 500;
+const MAX_PUSHES_PER_RUN = 200;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+type Candidate = {
+  kind: ReengagementKind;
+  userId: string;
+  pushToken: string;
+  longitude: number | null;
+  dedupeKey: string;
+  title: string;
+  body: string;
+  url: string;
+  /** Set on the "tell me when a new dog shows up" path, cleared once sent. */
+  clearsNewDogsAlert?: boolean;
+};
+
+export type ReengagementRunSummary = {
+  sent: number;
+  byKind: Record<ReengagementKind, number>;
+  candidates: number;
+  skippedQuietHours: number;
+  skippedCooldown: number;
+  skippedAlreadySent: number;
+};
+
+const hourInOffset = (now: Date, offsetHours: number) =>
+  (((now.getUTCHours() + offsetHours) % 24) + 24) % 24;
+
+/**
+ * The user's local hour, derived from longitude.
+ *
+ * Longitude over 15 is the solar offset, and it is deliberately the whole
+ * timezone story here: a real tz lookup means shipping a coordinate-to-zone
+ * dataset (tens of megabytes into a serverless bundle) to decide whether a
+ * nudge goes out at 18:00 or 19:00. Political zones drift from solar time by
+ * an hour or two at the edges, which the twelve hour send window absorbs, and
+ * Brazil (where nearly all the users are) sits close to its solar offset.
+ *
+ * `null` when there is no longitude, which is the caller's cue to fall back to
+ * America/Sao_Paulo.
+ */
+export const localHourFromLongitude = (
+  longitude: number | null | undefined,
+  now: Date,
+): number | null => {
+  if (longitude === null || longitude === undefined) return null;
+
+  return hourInOffset(now, Math.round(longitude / 15));
+};
+
+/**
+ * Is now a decent moment to interrupt this user?
+ *
+ * With coordinates: any local hour outside 21:00 to 09:00. Without: only the
+ * single 18:00 America/Sao_Paulo slot, because guessing a whole day of
+ * waking hours for someone whose location we do not know is how a retention
+ * push becomes a 3am push.
+ */
+export const isWithinSendWindow = (
+  longitude: number | null | undefined,
+  now: Date,
+): boolean => {
+  const localHour = localHourFromLongitude(longitude, now);
+
+  if (localHour === null) {
+    return hourInOffset(now, FALLBACK_OFFSET_HOURS) === FALLBACK_SEND_HOUR;
+  }
+
+  return localHour >= QUIET_HOURS_END && localHour < QUIET_HOURS_START;
+};
+
+type ReengagementCopyKey =
+  | "server:notification.reengagement.unansweredMatch.title"
+  | "server:notification.reengagement.unansweredMatch.body"
+  | "server:notification.reengagement.newDogsNearby.title"
+  | "server:notification.reengagement.newDogsNearby.body"
+  | "server:notification.reengagement.likesWaiting.title"
+  | "server:notification.reengagement.likesWaiting.body";
+
+/**
+ * The cron has no request to read a language from and `User` has no language
+ * column, so every re-engagement push goes out in pt-BR, which is where
+ * essentially all of the users are. A per-user language is the follow up, and
+ * it belongs on the model rather than being guessed at here.
+ */
+const translate = (
+  key: ReengagementCopyKey,
+  replace?: Record<string, unknown>,
+): string => TranslationService.translate(key, { lng: Language.PtBr, replace });
+
+/**
+ * Matches that went silent, one candidate per side that can be reached.
+ *
+ * Both sides get the nudge because either of them can break the silence and
+ * neither knows the other is waiting.
+ */
+export const selectUnansweredMatchCandidates = async (
+  now: Date,
+): Promise<Candidate[]> => {
+  const buckets = await Promise.all(
+    UNANSWERED_MATCH_HOURS.map(async (hours, index) => {
+      // Each bucket stops where the next one starts, so a four day old silent
+      // match is only ever in the 72 hour bucket and never in both.
+      const upperAgeHours =
+        UNANSWERED_MATCH_HOURS[index + 1] ?? UNANSWERED_MATCH_MAX_AGE_HOURS;
+
+      const olderThan = new Date(now.getTime() - hours * HOUR_MS);
+      const newerThan = new Date(now.getTime() - upperAgeHours * HOUR_MS);
+
+      const dogSelect = {
+        id: true,
+        name: true,
+        user: { select: { id: true, pushToken: true, longitude: true } },
+      } as const;
+
+      const matches = await prisma.match.findMany({
+        where: {
+          deletedAt: null,
+          createdAt: { gte: newerThan, lt: olderThan },
+          messages: { none: { deletedAt: null } },
+          requester: {
+            deletedAt: null,
+            banned: false,
+            user: { deletedAt: null },
+          },
+          responder: {
+            deletedAt: null,
+            banned: false,
+            user: { deletedAt: null },
+          },
+        },
+        select: {
+          id: true,
+          requester: { select: dogSelect },
+          responder: { select: dogSelect },
+        },
+        orderBy: { createdAt: "asc" },
+        take: MAX_CANDIDATES_PER_QUERY,
+      });
+
+      return matches.flatMap((match) =>
+        [
+          { self: match.requester, other: match.responder },
+          { self: match.responder, other: match.requester },
+        ].flatMap(({ self, other }) =>
+          self.user.pushToken
+            ? [
+                {
+                  kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+                  userId: self.user.id,
+                  pushToken: self.user.pushToken,
+                  longitude: self.user.longitude,
+                  dedupeKey: `${REENGAGEMENT_KINDS.UNANSWERED_MATCH}:${match.id}:${self.user.id}:${hours}h`,
+                  title: translate(
+                    "server:notification.reengagement.unansweredMatch.title",
+                    { name: other.name },
+                  ),
+                  body: translate(
+                    "server:notification.reengagement.unansweredMatch.body",
+                    { name: other.name },
+                  ),
+                  url: `chat/${match.id}/${other.id}`,
+                } satisfies Candidate,
+              ]
+            : [],
+        ),
+      );
+    }),
+  );
+
+  return buckets.flat();
+};
+
+/**
+ * Has this user liked anybody since `since`? Correlates against the enclosing
+ * query's `"User"` row, so it only composes inside the candidate select below.
+ */
+const swipedPositivelySince = (since: Date) => Prisma.sql`
+  EXISTS (
+    SELECT 1 FROM "Interest"
+    JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "Interest"."requesterId"
+    WHERE "OwnDog"."userId" = "User"."id"
+    AND "Interest"."lastPositiveAt" > ${since}
+  )
+`;
+
+type NewDogsRow = {
+  userId: string;
+  pushToken: string;
+  longitude: number | null;
+  newDogs: number;
+  requested: boolean;
+  anchor: Date | null;
+};
+
+/**
+ * Users worth pulling back into the deck, with the real number of dogs waiting
+ * for them.
+ *
+ * Two ways in, and they are mutually exclusive so nobody is selected twice.
+ * Either the user asked to be told (`newDogsAlertRequestedAt`, the fake door in
+ * #191), in which case the inactivity rule does not apply and the count is
+ * measured from the moment they asked; or they have gone quiet, in which case
+ * they land in exactly one inactivity bucket. Both still need
+ * {@link MIN_NEW_DOGS} dogs to exist: "come back, there is nothing new" is
+ * worse than silence.
+ *
+ * The dog count mirrors the swipe deck's hard filters (opposite gender, not
+ * banned or deleted, an approved image and no rejected one, inside the
+ * preferred distance, not already swiped). The deck's soft preferences (color,
+ * size, age, breed) are left out, so the number in the copy is an upper bound
+ * when a user has set those.
+ */
+export const selectNewDogsNearbyCandidates = async (
+  now: Date,
+): Promise<Candidate[]> => {
+  const newDogsFloor = new Date(
+    now.getTime() - NEW_DOGS_FALLBACK_WINDOW_DAYS * DAY_MS,
+  );
+
+  const buckets = [
+    {
+      label: "requested",
+      eligibility: Prisma.sql`"User"."newDogsAlertRequestedAt" IS NOT NULL`,
+    },
+    ...INACTIVE_DAYS.map((days, index) => {
+      const nextDays = INACTIVE_DAYS[index + 1];
+
+      // Each bucket ends where the next begins: quiet for 3 days but not yet 7
+      // is the 3 day nudge, quiet for 7 or more is the 7 day one. Without the
+      // lower bound a user who has been away a month is in both.
+      const lowerBound = nextDays
+        ? Prisma.sql`AND ${swipedPositivelySince(new Date(now.getTime() - nextDays * DAY_MS))}`
+        : Prisma.empty;
+
+      return {
+        label: `${days}d`,
+        eligibility: Prisma.sql`
+          "User"."newDogsAlertRequestedAt" IS NULL
+          AND NOT ${swipedPositivelySince(new Date(now.getTime() - days * DAY_MS))}
+          ${lowerBound}
+        `,
+      };
+    }),
+  ];
+
+  const rows = await Promise.all(
+    buckets.map(({ label, eligibility }) =>
+      prisma.$queryRaw<NewDogsRow[]>`
+        WITH "candidate" AS (
+          SELECT
+            "User"."id" AS "userId",
+            "User"."pushToken" AS "pushToken",
+            "User"."longitude" AS "longitude",
+            "User"."latitude" AS "latitude",
+            ("User"."newDogsAlertRequestedAt" IS NOT NULL) AS "requested",
+            /* Count from the moment they asked, otherwise from their last
+               positive swipe, otherwise from a fixed floor. */
+            COALESCE(
+              "User"."newDogsAlertRequestedAt",
+              (
+                SELECT MAX("Interest"."lastPositiveAt")
+                FROM "Interest"
+                JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "Interest"."requesterId"
+                WHERE "OwnDog"."userId" = "User"."id"
+              )
+            ) AS "anchor",
+            /* The viewer's own dog, used for the gender rule and the distance
+               preference. */
+            (
+              SELECT "OwnDog"."id" FROM "Dog" AS "OwnDog"
+              WHERE "OwnDog"."userId" = "User"."id"
+              AND "OwnDog"."deletedAt" IS NULL AND "OwnDog"."banned" = false
+              ORDER BY "OwnDog"."createdAt" ASC LIMIT 1
+            ) AS "ownDogId"
+          FROM "User"
+          WHERE "User"."deletedAt" IS NULL
+          AND "User"."pushToken" IS NOT NULL
+          AND (${eligibility})
+        )
+        SELECT
+          "candidate"."userId",
+          "candidate"."pushToken",
+          "candidate"."longitude",
+          "candidate"."requested",
+          "candidate"."anchor",
+          "counted"."newDogs"
+        FROM "candidate"
+        JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "candidate"."ownDogId"
+        CROSS JOIN LATERAL (
+          SELECT COUNT(*)::int AS "newDogs"
+          FROM "Dog"
+          JOIN "User" AS "Owner" ON "Owner"."id" = "Dog"."userId"
+          WHERE "Dog"."userId" <> "candidate"."userId"
+          AND "Dog"."deletedAt" IS NULL
+          AND "Dog"."banned" = false
+          AND "Owner"."deletedAt" IS NULL
+          AND "Dog"."createdAt" > COALESCE("candidate"."anchor", ${newDogsFloor})
+          AND "Dog"."gender" <> "OwnDog"."gender"
+          /* Shadowban gate, same shape as the deck. */
+          AND EXISTS (
+            SELECT 1 FROM "Image"
+            WHERE "Image"."dogId" = "Dog"."id"
+            AND "Image"."status" = 'APPROVED'::"ImageStatus"
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM "Image"
+            WHERE "Image"."dogId" = "Dog"."id"
+            AND "Image"."status" = 'REJECTED'::"ImageStatus"
+          )
+          /* Already swiped is already seen. */
+          AND NOT EXISTS (
+            SELECT 1 FROM "Interest"
+            WHERE "Interest"."requesterId" = "OwnDog"."id"
+            AND "Interest"."responderId" = "Dog"."id"
+          )
+          AND (
+            "OwnDog"."preferredMaxDistance" IS NULL
+            OR "OwnDog"."preferredMaxDistance" >= ${UNLIMITED_DISTANCE_KM}
+            OR "candidate"."latitude" IS NULL
+            OR "candidate"."longitude" IS NULL
+            OR "Owner"."latitude" IS NULL
+            OR "Owner"."longitude" IS NULL
+            OR ST_DistanceSphere(
+              ST_MakePoint("Owner"."longitude", "Owner"."latitude"),
+              ST_MakePoint("candidate"."longitude", "candidate"."latitude")
+            ) / 1000 <= "OwnDog"."preferredMaxDistance"
+          )
+        ) AS "counted"
+        WHERE "counted"."newDogs" >= ${MIN_NEW_DOGS}
+        LIMIT ${MAX_CANDIDATES_PER_QUERY}
+      `.then((result) => ({ label, result })),
+    ),
+  );
+
+  return rows.flatMap(({ label, result }) =>
+    result.map((row) => ({
+      kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+      userId: row.userId,
+      pushToken: row.pushToken,
+      longitude: row.longitude,
+      /* Keying on the anchor is what stops the nudge repeating: it only moves
+         once the user swipes positively again or asks again. */
+      dedupeKey: `${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}:${row.userId}:${label}:${row.anchor?.toISOString() ?? "never"}`,
+      title: translate("server:notification.reengagement.newDogsNearby.title", {
+        amount: row.newDogs,
+      }),
+      body: translate("server:notification.reengagement.newDogsNearby.body"),
+      url: "swipe",
+      clearsNewDogsAlert: row.requested,
+    })),
+  );
+};
+
+type LikesWaitingRow = {
+  userId: string;
+  pushToken: string;
+  longitude: number | null;
+  dogName: string;
+  anchorId: string;
+};
+
+/**
+ * Users sitting on likes they have not answered.
+ *
+ * `Interest` has no seen flag, so "unseen" is read as "not yet reciprocated":
+ * an active like pointing at one of your dogs, older than a day, with no match
+ * and nothing back from you. That is the set worth interrupting someone over.
+ *
+ * The dedupe key is the oldest waiting like, so the nudge does not repeat
+ * until that particular like is dealt with.
+ */
+export const selectLikesWaitingCandidates = async (
+  now: Date,
+): Promise<Candidate[]> => {
+  const olderThan = new Date(now.getTime() - LIKES_WAITING_HOURS * HOUR_MS);
+
+  const rows = await prisma.$queryRaw<LikesWaitingRow[]>`
+    SELECT
+      "User"."id" AS "userId",
+      "User"."pushToken" AS "pushToken",
+      "User"."longitude" AS "longitude",
+      "Dog"."name" AS "dogName",
+      (ARRAY_AGG("Interest"."id" ORDER BY "Interest"."createdAt" ASC))[1] AS "anchorId"
+    FROM "User"
+    JOIN "Dog" ON "Dog"."userId" = "User"."id"
+      AND "Dog"."deletedAt" IS NULL AND "Dog"."banned" = false
+    JOIN "Interest" ON "Interest"."responderId" = "Dog"."id"
+    WHERE "User"."deletedAt" IS NULL
+    AND "User"."pushToken" IS NOT NULL
+    AND "Interest"."deletedAt" IS NULL
+    AND "Interest"."matchId" IS NULL
+    AND "Interest"."swipeType" IN ('INTERESTED'::"SwipeType", 'MAYBE'::"SwipeType")
+    AND "Interest"."createdAt" < ${olderThan}
+    /* Nothing back from this dog means the like is still unanswered. */
+    AND NOT EXISTS (
+      SELECT 1 FROM "Interest" AS "Reply"
+      WHERE "Reply"."requesterId" = "Dog"."id"
+      AND "Reply"."responderId" = "Interest"."requesterId"
+      AND "Reply"."deletedAt" IS NULL
+    )
+    /* A like from a dog the deck would never show is not worth a push. */
+    AND EXISTS (
+      SELECT 1 FROM "Image"
+      WHERE "Image"."dogId" = "Interest"."requesterId"
+      AND "Image"."status" = 'APPROVED'::"ImageStatus"
+    )
+    GROUP BY "User"."id", "User"."pushToken", "User"."longitude", "Dog"."id", "Dog"."name"
+    LIMIT ${MAX_CANDIDATES_PER_QUERY}
+  `;
+
+  return rows.map((row) => ({
+    kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+    userId: row.userId,
+    pushToken: row.pushToken,
+    longitude: row.longitude,
+    dedupeKey: `${REENGAGEMENT_KINDS.LIKES_WAITING}:${row.userId}:${row.anchorId}`,
+    title: translate("server:notification.reengagement.likesWaiting.title", {
+      name: row.dogName,
+    }),
+    body: translate("server:notification.reengagement.likesWaiting.body"),
+    url: "swipe",
+  }));
+};
+
+/**
+ * Highest value first. A match nobody spoke on is one tap from a conversation;
+ * an empty deck is the weakest of the three, so it only gets the slot when
+ * nothing better is queued for that user.
+ */
+const collectCandidates = async (now: Date) => {
+  const [unansweredMatch, likesWaiting, newDogsNearby] = await Promise.all([
+    selectUnansweredMatchCandidates(now),
+    selectLikesWaitingCandidates(now),
+    selectNewDogsNearbyCandidates(now),
+  ]);
+
+  const byKey = new Map<string, Candidate>();
+  for (const candidate of [
+    ...unansweredMatch,
+    ...likesWaiting,
+    ...newDogsNearby,
+  ]) {
+    if (!byKey.has(candidate.dedupeKey))
+      byKey.set(candidate.dedupeKey, candidate);
+  }
+
+  return [...byKey.values()];
+};
+
+const PRISMA_UNIQUE_VIOLATION = "P2002";
+
+export class ReengagementService {
+  /**
+   * Select everyone who is due a nudge right now and enqueue one push each.
+   *
+   * Called once an hour by the Vercel Cron so the per-user local time window
+   * can be honoured; this method is what decides who is actually due.
+   */
+  static async run(now = new Date()): Promise<ReengagementRunSummary> {
+    const candidates = await collectCandidates(now);
+
+    const summary: ReengagementRunSummary = {
+      sent: 0,
+      byKind: {
+        [REENGAGEMENT_KINDS.UNANSWERED_MATCH]: 0,
+        [REENGAGEMENT_KINDS.NEW_DOGS_NEARBY]: 0,
+        [REENGAGEMENT_KINDS.LIKES_WAITING]: 0,
+      },
+      candidates: candidates.length,
+      skippedQuietHours: 0,
+      skippedCooldown: 0,
+      skippedAlreadySent: 0,
+    };
+
+    if (candidates.length === 0) return summary;
+
+    // One push per user per run, before the cooldown is even consulted.
+    const perUser = new Map<string, Candidate>();
+    for (const candidate of candidates) {
+      if (!perUser.has(candidate.userId))
+        perUser.set(candidate.userId, candidate);
+    }
+
+    const due = [...perUser.values()].filter((candidate) => {
+      if (isWithinSendWindow(candidate.longitude, now)) return true;
+      summary.skippedQuietHours += 1;
+      return false;
+    });
+
+    if (due.length === 0) return summary;
+
+    const cooledDown = await prisma.notificationLog.findMany({
+      where: {
+        userId: { in: due.map(({ userId }) => userId) },
+        sentAt: {
+          gte: new Date(now.getTime() - USER_COOLDOWN_HOURS * HOUR_MS),
+        },
+      },
+      select: { userId: true },
+    });
+
+    const recentlyNudged = new Set(cooledDown.map(({ userId }) => userId));
+
+    for (const candidate of due) {
+      if (summary.sent >= MAX_PUSHES_PER_RUN) break;
+
+      if (recentlyNudged.has(candidate.userId)) {
+        summary.skippedCooldown += 1;
+      } else {
+        // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cooldown they enforce on each other.
+        const outcome = await ReengagementService.#send(candidate);
+
+        if (outcome === "already-sent") {
+          summary.skippedAlreadySent += 1;
+        } else {
+          recentlyNudged.add(candidate.userId);
+          summary.sent += 1;
+          summary.byKind[candidate.kind] += 1;
+        }
+      }
+    }
+
+    return summary;
+  }
+
+  /**
+   * Claim the dedupe key, then send.
+   *
+   * The write comes first on purpose: a crash between the two costs one push,
+   * while the other order costs a duplicate, and a duplicate re-engagement
+   * push is the thing users uninstall over.
+   */
+  static async #send(candidate: Candidate): Promise<"sent" | "already-sent"> {
+    try {
+      await prisma.notificationLog.create({
+        data: {
+          userId: candidate.userId,
+          kind: candidate.kind,
+          dedupeKey: candidate.dedupeKey,
+        },
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === PRISMA_UNIQUE_VIOLATION
+      ) {
+        return "already-sent";
+      }
+
+      throw error;
+    }
+
+    await PushNotificationService.enqueuePushNotification({
+      to: candidate.pushToken,
+      title: candidate.title,
+      body: candidate.body,
+      data: { url: candidate.url, kind: candidate.kind },
+    });
+
+    if (candidate.clearsNewDogsAlert) {
+      // The request was a one-shot ("avisar quando chegar dog novo"), so it is
+      // cleared once answered. Leaving it set would exempt the user from the
+      // inactivity rule forever and make the fake door's funnel unreadable.
+      try {
+        await prisma.user.update({
+          where: { id: candidate.userId },
+          data: { newDogsAlertRequestedAt: null },
+        });
+      } catch (error) {
+        sendError(error);
+      }
+    }
+
+    observability.capture("reengagement_push_sent", {
+      distinctId: candidate.userId,
+      kind: candidate.kind,
+      dedupeKey: candidate.dedupeKey,
+    });
+
+    return "sent";
+  }
+}

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -67,7 +67,7 @@ const MAX_PUSHES_PER_RUN = 200;
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 
-type Candidate = {
+export type Candidate = {
   kind: ReengagementKind;
   userId: string;
   pushToken: string;

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -1,3 +1,5 @@
+import { Expo } from "expo-server-sdk";
+
 import prisma from "@pegada/database";
 import { Language } from "@pegada/shared/i18n/types/types";
 import { Prisma } from "@prisma/client";
@@ -87,6 +89,7 @@ export type ReengagementRunSummary = {
   skippedQuietHours: number;
   skippedCooldown: number;
   skippedAlreadySent: number;
+  skippedUnreachable: number;
 };
 
 const hourInOffset = (now: Date, offsetHours: number) =>
@@ -200,7 +203,10 @@ export const selectUnansweredMatchCandidates = async (
           requester: { select: dogSelect },
           responder: { select: dogSelect },
         },
-        orderBy: { createdAt: "asc" },
+        // Newest first. The take is a ceiling on one run, and the rows most
+        // likely to be already claimed by a dedupe key are the oldest ones, so
+        // ordering the other way would let a backlog starve fresh matches.
+        orderBy: { createdAt: "desc" },
         take: MAX_CANDIDATES_PER_QUERY,
       });
 
@@ -236,6 +242,21 @@ export const selectUnansweredMatchCandidates = async (
 
   return buckets.flat();
 };
+
+/**
+ * A user we can actually reach.
+ *
+ * The empty string matters: `UserService.blacklistPushToken` clears a dead
+ * token by writing `""` rather than null, so `IS NOT NULL` alone would keep
+ * re-selecting users whose device has already been rejected by Expo, burning
+ * their daily cap and inflating the sent count this whole change exists to
+ * measure.
+ */
+const REACHABLE_USER = Prisma.sql`
+  "User"."deletedAt" IS NULL
+  AND "User"."pushToken" IS NOT NULL
+  AND "User"."pushToken" <> ''
+`;
 
 /**
  * Has this user liked anybody since `since`? Correlates against the enclosing
@@ -340,8 +361,7 @@ export const selectNewDogsNearbyCandidates = async (
               ORDER BY "OwnDog"."createdAt" ASC LIMIT 1
             ) AS "ownDogId"
           FROM "User"
-          WHERE "User"."deletedAt" IS NULL
-          AND "User"."pushToken" IS NOT NULL
+          WHERE ${REACHABLE_USER}
           AND (${eligibility})
         )
         SELECT
@@ -394,6 +414,22 @@ export const selectNewDogsNearbyCandidates = async (
           )
         ) AS "counted"
         WHERE "counted"."newDogs" >= ${MIN_NEW_DOGS}
+        /* Already told since the anchor last moved, so there is nothing new to
+           say. The dedupe key is built from the same anchor, which makes this a
+           faithful pre-filter rather than a second policy: it keeps users who
+           have had their nudge out of the candidate set instead of letting them
+           occupy the limit forever, and it is what stops a cleared alert
+           request from re-qualifying the user under the inactivity rule the
+           next day. */
+        AND NOT EXISTS (
+          SELECT 1 FROM "NotificationLog"
+          WHERE "NotificationLog"."userId" = "candidate"."userId"
+          AND "NotificationLog"."kind" = ${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}
+          AND "NotificationLog"."sentAt" > COALESCE("candidate"."anchor", ${newDogsFloor})
+        )
+        /* Freshest lapsers first, for the same reason matches are ordered
+           newest first. */
+        ORDER BY "candidate"."anchor" DESC NULLS LAST
         LIMIT ${MAX_CANDIDATES_PER_QUERY}
       `.then((result) => ({ label, result })),
     ),
@@ -442,36 +478,65 @@ export const selectLikesWaitingCandidates = async (
   const olderThan = new Date(now.getTime() - LIKES_WAITING_HOURS * HOUR_MS);
 
   const rows = await prisma.$queryRaw<LikesWaitingRow[]>`
+    WITH "waiting" AS (
+      SELECT
+        "User"."id" AS "userId",
+        "User"."pushToken" AS "pushToken",
+        "User"."longitude" AS "longitude",
+        "Dog"."name" AS "dogName",
+        (ARRAY_AGG("Interest"."id" ORDER BY "Interest"."createdAt" ASC))[1] AS "anchorId",
+        MAX("Interest"."createdAt") AS "newestLikeAt"
+      FROM "User"
+      JOIN "Dog" ON "Dog"."userId" = "User"."id"
+        AND "Dog"."deletedAt" IS NULL AND "Dog"."banned" = false
+      JOIN "Interest" ON "Interest"."responderId" = "Dog"."id"
+      /* The dog doing the liking has to be one the deck would still show,
+         otherwise the push names somebody the user can never reach. */
+      JOIN "Dog" AS "Admirer" ON "Admirer"."id" = "Interest"."requesterId"
+        AND "Admirer"."deletedAt" IS NULL AND "Admirer"."banned" = false
+      JOIN "User" AS "AdmirerUser" ON "AdmirerUser"."id" = "Admirer"."userId"
+        AND "AdmirerUser"."deletedAt" IS NULL
+      WHERE ${REACHABLE_USER}
+      AND "Interest"."deletedAt" IS NULL
+      AND "Interest"."matchId" IS NULL
+      AND "Interest"."swipeType" IN ('INTERESTED'::"SwipeType", 'MAYBE'::"SwipeType")
+      AND "Interest"."createdAt" < ${olderThan}
+      /* Nothing back from this dog means the like is still unanswered. */
+      AND NOT EXISTS (
+        SELECT 1 FROM "Interest" AS "Reply"
+        WHERE "Reply"."requesterId" = "Dog"."id"
+        AND "Reply"."responderId" = "Interest"."requesterId"
+        AND "Reply"."deletedAt" IS NULL
+      )
+      /* Shadowban gate on the admirer, same shape as the deck. */
+      AND EXISTS (
+        SELECT 1 FROM "Image"
+        WHERE "Image"."dogId" = "Admirer"."id"
+        AND "Image"."status" = 'APPROVED'::"ImageStatus"
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM "Image"
+        WHERE "Image"."dogId" = "Admirer"."id"
+        AND "Image"."status" = 'REJECTED'::"ImageStatus"
+      )
+      GROUP BY "User"."id", "User"."pushToken", "User"."longitude", "Dog"."id", "Dog"."name"
+    )
     SELECT
-      "User"."id" AS "userId",
-      "User"."pushToken" AS "pushToken",
-      "User"."longitude" AS "longitude",
-      "Dog"."name" AS "dogName",
-      (ARRAY_AGG("Interest"."id" ORDER BY "Interest"."createdAt" ASC))[1] AS "anchorId"
-    FROM "User"
-    JOIN "Dog" ON "Dog"."userId" = "User"."id"
-      AND "Dog"."deletedAt" IS NULL AND "Dog"."banned" = false
-    JOIN "Interest" ON "Interest"."responderId" = "Dog"."id"
-    WHERE "User"."deletedAt" IS NULL
-    AND "User"."pushToken" IS NOT NULL
-    AND "Interest"."deletedAt" IS NULL
-    AND "Interest"."matchId" IS NULL
-    AND "Interest"."swipeType" IN ('INTERESTED'::"SwipeType", 'MAYBE'::"SwipeType")
-    AND "Interest"."createdAt" < ${olderThan}
-    /* Nothing back from this dog means the like is still unanswered. */
-    AND NOT EXISTS (
-      SELECT 1 FROM "Interest" AS "Reply"
-      WHERE "Reply"."requesterId" = "Dog"."id"
-      AND "Reply"."responderId" = "Interest"."requesterId"
-      AND "Reply"."deletedAt" IS NULL
+      "waiting"."userId",
+      "waiting"."pushToken",
+      "waiting"."longitude",
+      "waiting"."dogName",
+      "waiting"."anchorId"
+    FROM "waiting"
+    /* Rebuilds the dedupe key the caller would compute. A user whose oldest
+       waiting like has already been announced stays out of the candidate set
+       rather than occupying the limit until they finally answer it. */
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "NotificationLog"
+      WHERE "NotificationLog"."dedupeKey" =
+        ${`${REENGAGEMENT_KINDS.LIKES_WAITING}:`} || "waiting"."userId" || ':' || "waiting"."anchorId"
     )
-    /* A like from a dog the deck would never show is not worth a push. */
-    AND EXISTS (
-      SELECT 1 FROM "Image"
-      WHERE "Image"."dogId" = "Interest"."requesterId"
-      AND "Image"."status" = 'APPROVED'::"ImageStatus"
-    )
-    GROUP BY "User"."id", "User"."pushToken", "User"."longitude", "Dog"."id", "Dog"."name"
+    ORDER BY "waiting"."newestLikeAt" DESC
     LIMIT ${MAX_CANDIDATES_PER_QUERY}
   `;
 
@@ -537,6 +602,7 @@ export class ReengagementService {
       skippedQuietHours: 0,
       skippedCooldown: 0,
       skippedAlreadySent: 0,
+      skippedUnreachable: 0,
     };
 
     if (candidates.length === 0) return summary;
@@ -571,9 +637,14 @@ export class ReengagementService {
     for (const candidate of due) {
       if (summary.sent >= MAX_PUSHES_PER_RUN) break;
 
+      // A token Expo will reject is a guaranteed dropped push. Counting it as
+      // sent would put it in the denominator of the open rate, which is the
+      // number this whole change exists to produce.
+      const isReachable = Expo.isExpoPushToken(candidate.pushToken);
+
       if (recentlyNudged.has(candidate.userId)) {
         summary.skippedCooldown += 1;
-      } else {
+      } else if (isReachable) {
         // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cooldown they enforce on each other.
         const outcome = await ReengagementService.#send(candidate);
 
@@ -584,6 +655,8 @@ export class ReengagementService {
           summary.sent += 1;
           summary.byKind[candidate.kind] += 1;
         }
+      } else {
+        summary.skippedUnreachable += 1;
       }
     }
 

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -41,6 +41,13 @@ const LIKES_WAITING_HOURS = 24;
 /**
  * When a user has never swiped positively there is no anchor to count new dogs
  * from, so the count starts here instead.
+ *
+ * This doubles as how often that cohort may be nudged again. Every other user
+ * is rate limited by their own anchor moving, which needs them to do something;
+ * someone who has never swiped has nothing that moves, so without a period in
+ * the key they would be a one-time audience forever. A calendar-aligned bucket
+ * rather than a sliding window, because the dedupe key has to name the same
+ * period the already-sent filter is testing.
  */
 const NEW_DOGS_FALLBACK_WINDOW_DAYS = 30;
 
@@ -55,9 +62,15 @@ const UNLIMITED_DISTANCE_KM = 295;
 const QUIET_HOURS_START = 21;
 const QUIET_HOURS_END = 9;
 
-/** America/Sao_Paulo, for users whose coordinates we do not have. */
+/**
+ * America/Sao_Paulo, for users whose coordinates we do not have.
+ *
+ * Two hours rather than one because Vercel Cron is best effort: a single
+ * missed invocation would drop this whole cohort for the day. The dedupe key
+ * and the daily cap are what stop the second hour resending.
+ */
 const FALLBACK_OFFSET_HOURS = -3;
-const FALLBACK_SEND_HOUR = 18;
+const FALLBACK_SEND_HOURS = new Set([18, 19]);
 
 /** One re-engagement push per user per rolling day. */
 const USER_COOLDOWN_HOURS = 24;
@@ -121,7 +134,7 @@ export const localHourFromLongitude = (
  * Is now a decent moment to interrupt this user?
  *
  * With coordinates: any local hour outside 21:00 to 09:00. Without: only the
- * single 18:00 America/Sao_Paulo slot, because guessing a whole day of
+ * early evening America/Sao_Paulo slot, because guessing a whole day of
  * waking hours for someone whose location we do not know is how a retention
  * push becomes a 3am push.
  */
@@ -132,7 +145,7 @@ export const isWithinSendWindow = (
   const localHour = localHourFromLongitude(longitude, now);
 
   if (localHour === null) {
-    return hourInOffset(now, FALLBACK_OFFSET_HOURS) === FALLBACK_SEND_HOUR;
+    return FALLBACK_SEND_HOURS.has(hourInOffset(now, FALLBACK_OFFSET_HOURS));
   }
 
   return localHour >= QUIET_HOURS_END && localHour < QUIET_HOURS_START;
@@ -301,9 +314,18 @@ type NewDogsRow = {
 export const selectNewDogsNearbyCandidates = async (
   now: Date,
 ): Promise<Candidate[]> => {
+  // Sliding, so a user who has never swiped is always shown a full window of
+  // new dogs rather than an emptier and emptier one as a period runs out.
   const newDogsFloor = new Date(
     now.getTime() - NEW_DOGS_FALLBACK_WINDOW_DAYS * DAY_MS,
   );
+
+  // Quantised, and used only to decide whether that cohort has already been
+  // told this period. The dedupe key carries the same period number, so the
+  // key and the filter re-admit the user on exactly the same day.
+  const periodMs = NEW_DOGS_FALLBACK_WINDOW_DAYS * DAY_MS;
+  const period = Math.floor(now.getTime() / periodMs);
+  const periodStart = new Date(period * periodMs);
 
   const buckets = [
     {
@@ -401,7 +423,12 @@ export const selectNewDogsNearbyCandidates = async (
             AND "Interest"."responderId" = "Dog"."id"
           )
           AND (
+            /* Null and zero both mean "no preference" in SuggestionService,
+               where the filter is only applied when the value is truthy.
+               Reading zero as "within zero kilometres" here would silently
+               empty the count for anyone who has it. */
             "OwnDog"."preferredMaxDistance" IS NULL
+            OR "OwnDog"."preferredMaxDistance" <= 0
             OR "OwnDog"."preferredMaxDistance" >= ${UNLIMITED_DISTANCE_KM}
             OR "candidate"."latitude" IS NULL
             OR "candidate"."longitude" IS NULL
@@ -425,7 +452,7 @@ export const selectNewDogsNearbyCandidates = async (
           SELECT 1 FROM "NotificationLog"
           WHERE "NotificationLog"."userId" = "candidate"."userId"
           AND "NotificationLog"."kind" = ${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}
-          AND "NotificationLog"."sentAt" > COALESCE("candidate"."anchor", ${newDogsFloor})
+          AND "NotificationLog"."sentAt" > COALESCE("candidate"."anchor", ${periodStart})
         )
         /* Freshest lapsers first, for the same reason matches are ordered
            newest first. */
@@ -443,7 +470,7 @@ export const selectNewDogsNearbyCandidates = async (
       longitude: row.longitude,
       /* Keying on the anchor is what stops the nudge repeating: it only moves
          once the user swipes positively again or asks again. */
-      dedupeKey: `${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}:${row.userId}:${label}:${row.anchor?.toISOString() ?? "never"}`,
+      dedupeKey: `${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}:${row.userId}:${label}:${row.anchor?.toISOString() ?? `never:${period}`}`,
       title: translate("server:notification.reengagement.newDogsNearby.title", {
         amount: row.newDogs,
       }),
@@ -607,15 +634,44 @@ export class ReengagementService {
 
     if (candidates.length === 0) return summary;
 
-    // One push per user per run, before the cooldown is even consulted.
-    const perUser = new Map<string, Candidate>();
-    for (const candidate of candidates) {
-      if (!perUser.has(candidate.userId))
-        perUser.set(candidate.userId, candidate);
+    // A claimed key is not a candidate. Dropping those here rather than only
+    // discovering them inside #send is what lets a user whose best nudge was
+    // already sent fall through to the next one they qualify for, instead of
+    // spending their whole day on a key that can never fire again.
+    const claimed = await prisma.notificationLog.findMany({
+      where: {
+        dedupeKey: { in: candidates.map(({ dedupeKey }) => dedupeKey) },
+      },
+      select: { dedupeKey: true },
+    });
+
+    const claimedKeys = new Set(claimed.map(({ dedupeKey }) => dedupeKey));
+
+    const unclaimed = candidates.filter((candidate) => {
+      if (!claimedKeys.has(candidate.dedupeKey)) return true;
+      summary.skippedAlreadySent += 1;
+      return false;
+    });
+
+    // Priority order survives the grouping, so a user's queue runs best nudge
+    // first. Only one of them will actually go out.
+    const perUser = new Map<
+      string,
+      { longitude: number | null; queue: Candidate[] }
+    >();
+    for (const candidate of unclaimed) {
+      const existing = perUser.get(candidate.userId);
+
+      if (existing) existing.queue.push(candidate);
+      else
+        perUser.set(candidate.userId, {
+          longitude: candidate.longitude,
+          queue: [candidate],
+        });
     }
 
-    const due = [...perUser.values()].filter((candidate) => {
-      if (isWithinSendWindow(candidate.longitude, now)) return true;
+    const due = [...perUser.entries()].filter(([, { longitude }]) => {
+      if (isWithinSendWindow(longitude, now)) return true;
       summary.skippedQuietHours += 1;
       return false;
     });
@@ -624,7 +680,7 @@ export class ReengagementService {
 
     const cooledDown = await prisma.notificationLog.findMany({
       where: {
-        userId: { in: due.map(({ userId }) => userId) },
+        userId: { in: due.map(([userId]) => userId) },
         sentAt: {
           gte: new Date(now.getTime() - USER_COOLDOWN_HOURS * HOUR_MS),
         },
@@ -634,33 +690,59 @@ export class ReengagementService {
 
     const recentlyNudged = new Set(cooledDown.map(({ userId }) => userId));
 
-    for (const candidate of due) {
+    for (const [userId, { queue }] of due) {
       if (summary.sent >= MAX_PUSHES_PER_RUN) break;
 
-      // A token Expo will reject is a guaranteed dropped push. Counting it as
-      // sent would put it in the denominator of the open rate, which is the
-      // number this whole change exists to produce.
-      const isReachable = Expo.isExpoPushToken(candidate.pushToken);
-
-      if (recentlyNudged.has(candidate.userId)) {
+      if (recentlyNudged.has(userId)) {
         summary.skippedCooldown += 1;
-      } else if (isReachable) {
-        // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cooldown they enforce on each other.
-        const outcome = await ReengagementService.#send(candidate);
-
-        if (outcome === "already-sent") {
-          summary.skippedAlreadySent += 1;
-        } else {
-          recentlyNudged.add(candidate.userId);
-          summary.sent += 1;
-          summary.byKind[candidate.kind] += 1;
-        }
       } else {
-        summary.skippedUnreachable += 1;
+        // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cooldown they enforce on each other.
+        const sent = await ReengagementService.#sendFirstAvailable(
+          queue,
+          summary,
+        );
+
+        if (sent) recentlyNudged.add(userId);
       }
     }
 
     return summary;
+  }
+
+  /**
+   * Walk one user's queue until a nudge actually goes out.
+   *
+   * The queue is already free of keys claimed before the run started; this
+   * loop is what covers a key claimed *during* it, by another instance racing
+   * the same candidate.
+   */
+  static async #sendFirstAvailable(
+    queue: Candidate[],
+    summary: ReengagementRunSummary,
+  ): Promise<boolean> {
+    for (const candidate of queue) {
+      // A token Expo will reject is a guaranteed dropped push, and it is the
+      // same token for every candidate this user has, so there is nothing left
+      // to try. Counting it as sent would put it in the denominator of the
+      // open rate, which is the number this whole change exists to produce.
+      if (!Expo.isExpoPushToken(candidate.pushToken)) {
+        summary.skippedUnreachable += 1;
+        return false;
+      }
+
+      // oxlint-disable-next-line no-await-in-loop -- Sequential by design: the next candidate is only tried when this one turns out to be claimed.
+      const outcome = await ReengagementService.#send(candidate);
+
+      if (outcome === "sent") {
+        summary.sent += 1;
+        summary.byKind[candidate.kind] += 1;
+        return true;
+      }
+
+      summary.skippedAlreadySent += 1;
+    }
+
+    return false;
   }
 
   /**

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -81,6 +81,17 @@ const configSchema = z.object({
   /** PUSH (Expo access token for send + receipt consumers) */
   EXPO_ACCESS_TOKEN: z.string().optional(),
 
+  /**
+   * CRON
+   *
+   * Vercel Cron sends `Authorization: Bearer ${CRON_SECRET}` on every
+   * scheduled invocation. Optional so a fresh clone and the test suite boot
+   * without it, but the cron route refuses every request while it is unset:
+   * an endpoint that enqueues pushes must never be open because a variable is
+   * missing.
+   */
+  CRON_SECRET: z.string().optional(),
+
   /** APP */
   MIN_APP_VERSION: semverSchema,
 

--- a/packages/api/src/shared/cron-auth.test.ts
+++ b/packages/api/src/shared/cron-auth.test.ts
@@ -1,0 +1,47 @@
+const config = { CRON_SECRET: undefined as string | undefined };
+
+jest.mock("./config", () => ({ config }));
+
+// `require` rather than a top-level import: the guard reads `config` when it
+// runs, and the mock above has to be in place first.
+const loadGuard = () => require("./cron-auth") as typeof import("./cron-auth");
+
+describe("isAuthorizedCronRequest", () => {
+  describe("with a secret configured", () => {
+    beforeEach(() => {
+      config.CRON_SECRET = "s3cret";
+    });
+
+    it("accepts the bearer token Vercel Cron sends", () => {
+      const { isAuthorizedCronRequest } = loadGuard();
+
+      expect(isAuthorizedCronRequest("Bearer s3cret")).toBe(true);
+    });
+
+    it("rejects a missing header", () => {
+      const { isAuthorizedCronRequest } = loadGuard();
+
+      expect(isAuthorizedCronRequest(null)).toBe(false);
+      expect(isAuthorizedCronRequest(undefined)).toBe(false);
+      expect(isAuthorizedCronRequest("")).toBe(false);
+    });
+
+    it("rejects a wrong or malformed bearer", () => {
+      const { isAuthorizedCronRequest } = loadGuard();
+
+      expect(isAuthorizedCronRequest("Bearer nope")).toBe(false);
+      expect(isAuthorizedCronRequest("Bearer s3cre")).toBe(false);
+      expect(isAuthorizedCronRequest("Bearer s3cret ")).toBe(false);
+      expect(isAuthorizedCronRequest("s3cret")).toBe(false);
+      expect(isAuthorizedCronRequest("Basic s3cret")).toBe(false);
+    });
+  });
+
+  it("rejects everything when no secret is configured", () => {
+    config.CRON_SECRET = undefined;
+    const { isAuthorizedCronRequest } = loadGuard();
+
+    expect(isAuthorizedCronRequest("Bearer ")).toBe(false);
+    expect(isAuthorizedCronRequest("Bearer anything")).toBe(false);
+  });
+});

--- a/packages/api/src/shared/cron-auth.ts
+++ b/packages/api/src/shared/cron-auth.ts
@@ -1,0 +1,40 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { config } from "./config";
+
+/**
+ * Compare two secrets without leaking their common prefix through timing.
+ * `timingSafeEqual` throws on mismatched lengths, so the length check happens
+ * first and is itself the only thing an attacker learns.
+ */
+const secretsMatch = (candidate: string, secret: string) => {
+  const candidateBytes = Buffer.from(candidate);
+  const secretBytes = Buffer.from(secret);
+
+  if (candidateBytes.length !== secretBytes.length) return false;
+
+  return timingSafeEqual(candidateBytes, secretBytes);
+};
+
+/**
+ * Is this request a genuine Vercel Cron invocation?
+ *
+ * Vercel sends `Authorization: Bearer ${CRON_SECRET}` on every scheduled hit
+ * (https://vercel.com/docs/cron-jobs/manage-cron-jobs#securing-cron-jobs), so
+ * that header is the whole check. An unset `CRON_SECRET` denies everything
+ * rather than falling open, because the route behind this enqueues pushes to
+ * real devices.
+ *
+ * Lives in `@pegada/api` rather than next to the route so it can be tested by
+ * the jest suite that already has a runner; the route is a thin wrapper.
+ */
+export const isAuthorizedCronRequest = (
+  authorizationHeader: string | null | undefined,
+): boolean => {
+  const secret = config.CRON_SECRET;
+  if (!secret) return false;
+
+  if (!authorizationHeader?.startsWith("Bearer ")) return false;
+
+  return secretsMatch(authorizationHeader.slice("Bearer ".length), secret);
+};

--- a/packages/database/migrations/20260901120000_add_new_dogs_alert_requested_at/migration.sql
+++ b/packages/database/migrations/20260901120000_add_new_dogs_alert_requested_at/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "newDogsAlertRequestedAt" TIMESTAMP(3);

--- a/packages/database/migrations/20260901130000_add_notification_log/migration.sql
+++ b/packages/database/migrations/20260901130000_add_notification_log/migration.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "NotificationLog" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "kind" TEXT NOT NULL,
+  "dedupeKey" TEXT NOT NULL,
+  "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "NotificationLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "NotificationLog_dedupeKey_key"
+ON "NotificationLog"("dedupeKey");
+
+CREATE INDEX "NotificationLog_userId_sentAt_idx"
+ON "NotificationLog"("userId", "sentAt");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -66,6 +66,7 @@ model User {
 
   // Push notifications
   pushToken String?
+  newDogsAlertRequestedAt DateTime?
 
   // Metadata
   createdAt DateTime  @default(now())
@@ -320,4 +321,21 @@ model Message {
   @@index([receiverId], map: "message_receiverid_idx")
   @@index([senderId], map: "message_senderid_idx")
   @@index([matchId], map: "message_matchid_idx")
+}
+
+/// One row per re-engagement push the cron enqueued.
+///
+/// `dedupeKey` is the whole point: the cron runs every hour and re-selects the
+/// same candidates until they act, so the unique index is what turns "this user
+/// is eligible" into "this user has not been told yet". `userId` is a plain
+/// column rather than a relation on purpose, so the table can be read and
+/// pruned without widening `User`.
+model NotificationLog {
+  id        String   @id @default(cuid())
+  userId    String
+  kind      String
+  dedupeKey String   @unique
+  sentAt    DateTime @default(now())
+
+  @@index([userId, sentAt])
 }

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -43,6 +43,7 @@ export const ANALYTICS_EVENTS = {
   PAYWALL_VIEWED: "Paywall Viewed",
   PROFILE_PHOTO_ADDED: "Profile Photo Added",
   PUSH_NOTIFICATION_OPENED: "Push Notification Opened",
+  REENGAGEMENT_PUSH_SENT: "Reengagement Push Sent",
   PUSH_PERMISSION: "Push Permission",
   RESTORE_PURCHASES: "RestorePurchases",
   RESTORE_PURCHASES_SUCCESS: "Restore Purchases Success",
@@ -76,6 +77,19 @@ export type PaywallTrigger =
 
 /** An OS permission answer, collapsed to the two states that matter. */
 export type PermissionStatus = "denied" | "granted";
+
+/**
+ * Which scheduled nudge the re-engagement cron sent.
+ *
+ * Restated here rather than imported from `REENGAGEMENT_KINDS` in the API for
+ * the same reason the RevenueCat unions below are: `@pegada/shared` is a
+ * dependency of `@pegada/api`, so the import would be a cycle. The API's own
+ * constant is checked against this union where it is declared.
+ */
+export type ReengagementPushKind =
+  | "likes_waiting"
+  | "new_dogs_nearby"
+  | "unanswered_match";
 
 /**
  * Event name to property shape, for events sent from the app.
@@ -123,7 +137,12 @@ export type MobileEventProperties = {
   [ANALYTICS_EVENTS.OTP_VERIFIED]: { success: boolean };
   [ANALYTICS_EVENTS.PAYWALL_VIEWED]: { trigger: PaywallTrigger };
   [ANALYTICS_EVENTS.PROFILE_PHOTO_ADDED]: { position: number };
-  [ANALYTICS_EVENTS.PUSH_NOTIFICATION_OPENED]: { url?: string };
+  /**
+   * `kind` is only set on the scheduled re-engagement pushes, and it is what
+   * pairs an open with the "Reengagement Push Sent" that caused it, so the open
+   * rate can be read per nudge. Reactive pushes carry the url alone.
+   */
+  [ANALYTICS_EVENTS.PUSH_NOTIFICATION_OPENED]: { kind?: string; url?: string };
   [ANALYTICS_EVENTS.PUSH_PERMISSION]: { status: PermissionStatus };
   [ANALYTICS_EVENTS.RESTORE_PURCHASES]: undefined;
   [ANALYTICS_EVENTS.RESTORE_PURCHASES_SUCCESS]: undefined;
@@ -221,6 +240,15 @@ export type ServerEventProperties = {
     match_id: string;
     message_type: "text";
   };
+  /**
+   * One row per re-engagement push handed to Expo. `dedupe_key` is the same key
+   * the send claimed in `NotificationLog`, so a send and the open it produced
+   * can be lined up without trusting timestamps.
+   */
+  [ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT]: {
+    dedupe_key: string;
+    kind: ReengagementPushKind;
+  };
   [ANALYTICS_EVENTS.SUBSCRIPTION_EVENT]: {
     cancel_reason?: SubscriptionCancelReason | null;
     currency?: string | null;
@@ -314,6 +342,7 @@ export const MOBILE_EVENT_NAMES = [
 export const SERVER_EVENT_NAMES = [
   ANALYTICS_EVENTS.MATCH_CREATED,
   ANALYTICS_EVENTS.MESSAGE_SENT,
+  ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT,
   ANALYTICS_EVENTS.SUBSCRIPTION_EVENT,
 ] as const;
 

--- a/packages/shared/i18n/locales/en/server.json
+++ b/packages/shared/i18n/locales/en/server.json
@@ -16,6 +16,20 @@
     "like": {
       "title": "🐶 {{name}} received a like! 🩷",
       "body": "Search for the misterious admirer 🕵️‍♂️"
+    },
+    "reengagement": {
+      "unansweredMatch": {
+        "title": "🐶 {{name}} is still waiting",
+        "body": "You two matched and nobody has said anything yet"
+      },
+      "newDogsNearby": {
+        "title": "🐶 {{amount}} new dogs near you",
+        "body": "Come see who just arrived 👀"
+      },
+      "likesWaiting": {
+        "title": "🐶 {{name}} has likes waiting 🩷",
+        "body": "Someone is hoping you like them back"
+      }
     }
   }
 }

--- a/packages/shared/i18n/locales/pt-BR/server.json
+++ b/packages/shared/i18n/locales/pt-BR/server.json
@@ -16,6 +16,20 @@
     "like": {
       "title": "🐶 {{name}} recebeu um like! 🩷",
       "body": "Vem procurar o pretendente misterioso 🕵️‍♂️"
+    },
+    "reengagement": {
+      "unansweredMatch": {
+        "title": "🐶 {{name}} ainda está esperando",
+        "body": "Você e {{name}} deram match e ninguém falou ainda"
+      },
+      "newDogsNearby": {
+        "title": "🐶 {{amount}} dogs novos perto de você",
+        "body": "Vem ver quem acabou de chegar 👀"
+      },
+      "likesWaiting": {
+        "title": "🐶 {{name}} tem likes esperando 🩷",
+        "body": "Alguém está torcendo pra você curtir de volta"
+      }
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/reengagement",
+      "schedule": "0 * * * *"
+    }
+  ],
   "functions": {
     "src/app/api/queues/cleanup-upload/route.ts": {
       "experimentalTriggers": [


### PR DESCRIPTION
## Summary

An hourly job picks out people who went quiet after a match nobody spoke on, an empty deck, or likes they never answered, and sends each of them one notification. Every send and every open is tracked, which is the first read we have on scheduled notifications at all.

Closes #190

## Details

- Hypothesis: people who go quiet still have intent and only lack a trigger. Three nudges (silent match at 24h and 72h, new dogs near you, likes waiting) should move D7 retention of users who got one by at least 3 points over eligible users the daily cap held back, and raise the share of matches that get a first message inside 72h.
- Baseline: none exists. There is no scheduled notification today and nothing tracked sends or opens, so the instrumentation here is what creates the baseline. Reference points while we wait: dating apps retain about 26 percent on D1 and 12 percent on D7 (Adjust, State of Dating Apps 2026), and iOS direct open rate for social apps runs 2 to 5 percent (Airship 2025 benchmarks). The existing signal analysis against the seeded database is posted on issue #190.
- Readout: PostHog, through the shared event catalogue. Server event `Reengagement Push Sent` with properties `kind` and `dedupe_key`. The tap is the catalogue's existing `Push Notification Opened`, which now also carries `kind` alongside `url`, so the open rate per nudge is a breakdown of an event that already has history rather than a second name for the same tap. Two funnels broken down by kind: sent to session started within 1 hour, and sent to positive swipe within 24 hours. Each kind stays only if its open rate is at or above 5 percent after two weeks, otherwise it gets paused and the copy or timing revisited.
- Gabriel has to set `CRON_SECRET` on Vercel for all environments before this does anything. Without it the route answers 401 to everything, which is deliberate: something that sends notifications to real devices should not fall open because a variable is missing.
- Idempotency is a `NotificationLog` row with a unique dedupe key, claimed before the notification is enqueued so a crash costs a send instead of a duplicate. On top of that, one re-engagement notification per user per rolling day.
- Claimed keys are filtered out before the per user pick rather than only at send time. Someone whose best nudge was already spent falls through to the next kind they qualify for instead of losing the day to a key that can never fire again.
- Each selector infers "went quiet" from a proxy (no positive swipe, a match nobody spoke on, a like nobody answered) and every one of those proxies misses somebody who is in the app right now doing something else, so the last active timestamp added by #217 is read as a second guard: anybody seen in the last 24 hours is left alone. A user who has no timestamp yet is unknown rather than active, so their proxy still decides. The one exception is the person who explicitly asked to be told when a new dog shows up, since that is consent rather than a guess.
- Nothing is sent between 21:00 and 09:00 in the user's own local time. Local time comes from longitude divided by 15 rather than a real timezone lookup, which would mean shipping a coordinate to zone dataset into a serverless bundle to decide between 18:00 and 19:00. Users with no coordinates are treated as America/Sao_Paulo and get an early evening slot covering two hours, because the scheduler is best effort and a single missed run should not drop that whole group for the day.
- People who have never swiped positively have no anchor that moves, so their key carries a 30 day period. Without it they would be a one time audience forever. Everyone else is paced by their own last positive swipe.
- The alert request flag (`newDogsAlertRequestedAt`, added by the empty deck work) is cleared once its notification goes out, and the already sent filter is keyed on the same anchor so clearing it cannot re-qualify the user the next day.
- The column is `newDogsAlertRequestedAt DateTime?` placed directly after `pushToken` on the user model, with migration folder `20260901120000_add_new_dogs_alert_requested_at` holding one statement: `ALTER TABLE "User" ADD COLUMN "newDogsAlertRequestedAt" TIMESTAMP(3);`. The empty deck PR #222 is open and ships that same file byte identical under the same folder name, so whichever of the two lands first the other has nothing left to apply there. The migrations already on main share the `20260901120000` and `20260901130000` prefixes but sit in their own folders and add different columns, and Prisma applies same prefix folders in folder name order and accepts a later one arriving first, which is what the local run against a database already holding this branch's two folders confirmed.
- Two things the schema forced. `Interest` has no seen flag, so "unseen likes" is read as "not yet reciprocated", which is the actionable set anyway. And `User` has no language column, so the copy goes out in pt-BR for now.
- The count of new dogs mirrors the deck's hard filters, including reading a zero preferred distance as no preference the same way the deck does.
- The app side is limited to what the readout needs: the kind the server sent is carried into the open event the handler already fires, and the notification handler learns to open the swipe deck, which the two deck facing nudges point at.

## Testing steps

1. The daily job is protected by a secret that has to be added in the hosting dashboard first. Until it is there the job refuses every request and nothing goes out.
2. Match two test accounts and leave the conversation empty. A day later, during daytime hours, both people get a notification saying the other one is still waiting. Tapping it opens that conversation.
3. Stop swiping on a test account for three days while other dogs sign up nearby. The next notification says how many new dogs are waiting, and tapping it opens the deck.
4. Like a test account from another account and leave that like unanswered for a day. The owner gets a notification that likes are waiting, and tapping it opens the deck.
5. Check that somebody who has been using the app in the last day is left alone even when one of the three situations applies to them.
6. Check that none of these arrive late at night or early in the morning.
7. Check that someone who already got one of these today does not get a second one, and that the same notification never arrives twice.

## Screenshots

Server side change. The only part a person sees is the notification itself and the screen it opens, which needs a real device token and the deployed job to produce, so there is nothing to capture from a simulator here.

What is covered instead, in `apps/mobile/src/services/linking/handlers/notification.test.ts`: the open event carries the kind the server sent, a notification that carries no kind still reports its open, and the deck facing nudge lands on the deck. On the server side the send is asserted to report itself under the catalogue name with the dedupe key that pairs it with the open, and the last active guard is covered on both the silent match and new dogs paths.
