### PR TITLE
feat(web): enable PostHog on the marketing site

### DIFF
--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 
 import { Namespace } from "@pegada/shared/i18n/types/types";
 
+import { DownloadCta } from "@/components/download-cta";
 import { getSafeLocale } from "@/lib/get-safe-locale";
 import { t } from "@/lib/translate";
 import { cn } from "@/lib/utils";
@@ -182,13 +183,17 @@ const DogProfile = async ({ params }: DogProfileProps) => {
           </h2>
           <p className="text-lg font-light text-subtitle">{nextStep}</p>
           <div className="mt-2 flex flex-col items-start gap-3">
-            {/* oxlint-disable-next-line next/no-html-link-for-pages -- /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to. */}
-            <a
+            {/* /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to, which is why `store` is reported as "auto" rather than a named store. */}
+            <DownloadCta
               href="/store"
+              page="dog_share"
+              placement="desktop_copy"
+              store="auto"
+              dogId={id}
               className="rounded-full bg-primary px-8 py-4 font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
             >
               {ctaButton}
-            </a>
+            </DownloadCta>
             <p className="text-sm font-light text-subtitle/80">
               {t("dog.cta.reassurance")}
             </p>
@@ -201,13 +206,16 @@ const DogProfile = async ({ params }: DogProfileProps) => {
         <p className="flex-1 truncate text-sm font-medium text-text">
           {mobileContext}
         </p>
-        {/* oxlint-disable-next-line next/no-html-link-for-pages -- /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to. */}
-        <a
+        <DownloadCta
           href="/store"
+          page="dog_share"
+          placement="mobile_sticky_bar"
+          store="auto"
+          dogId={id}
           className="shrink-0 rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
         >
           {ctaButton}
-        </a>
+        </DownloadCta>
       </div>
     </div>
   );

--- a/apps/nextjs/src/components/cta.tsx
+++ b/apps/nextjs/src/components/cta.tsx
@@ -16,6 +16,9 @@ export const Cta = () => {
         <StoreButton
           href="https://apps.apple.com/br/app/pegada/id6450865592"
           target="_blank"
+          page="landing"
+          placement="hero"
+          store="app_store"
         >
           <StoreButton.Icon
             width={20}
@@ -28,6 +31,9 @@ export const Cta = () => {
         <StoreButton
           href="https://play.google.com/store/apps/details?id=app.pegada"
           target="_blank"
+          page="landing"
+          placement="hero"
+          store="play_store"
         >
           <StoreButton.Icon
             width={24}

--- a/apps/nextjs/src/components/download-cta.tsx
+++ b/apps/nextjs/src/components/download-cta.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import type { DownloadCtaClick } from "@/services/analytics";
+
+import type { ComponentProps } from "react";
+
+import { useCallback } from "react";
+
+import { trackDownloadCtaClicked } from "@/services/analytics";
+
+/**
+ * Every "get the app" link on the site, so all of them report the same event
+ * with the same properties.
+ *
+ * It is a client component only because an `onClick` cannot cross the server
+ * boundary. The describing props are flat scalars rather than one object, so
+ * the pages using it stay server components and pass nothing that has to be
+ * serialised structurally.
+ *
+ * The capture is fire-and-forget and the anchor keeps its normal navigation:
+ * PostHog batches over `sendBeacon`, which survives the unload that follows.
+ */
+export const DownloadCta = ({
+  href,
+  page,
+  placement,
+  store,
+  dogId,
+  onClick,
+  ...props
+}: ComponentProps<"a"> & DownloadCtaClick) => {
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      trackDownloadCtaClicked({ page, placement, store, dogId });
+      onClick?.(event);
+    },
+    [page, placement, store, dogId, onClick],
+  );
+
+  return (
+    // oxlint-disable-next-line jsx-a11y/anchor-has-content -- content provided by caller via props spread
+    <a href={href} onClick={handleClick} {...props} />
+  );
+};

--- a/apps/nextjs/src/components/download-cta.tsx
+++ b/apps/nextjs/src/components/download-cta.tsx
@@ -18,10 +18,17 @@ import { trackDownloadCtaClicked } from "@/services/analytics";
  * serialised structurally.
  *
  * The capture is fire-and-forget and the anchor keeps its normal navigation:
- * PostHog batches over `sendBeacon`, which survives the unload that follows.
+ * it goes out over `sendBeacon`, which survives the unload that follows.
+ *
+ * `rel` is defaulted rather than left to the call sites. Every link here
+ * points at a store, so every one of them is a candidate for `target="_blank"`
+ * and would otherwise hand the opened tab a `window.opener` back into the
+ * site. A caller that needs different values can still pass its own.
  */
 export const DownloadCta = ({
   href,
+  target,
+  rel,
   page,
   placement,
   store,
@@ -39,6 +46,12 @@ export const DownloadCta = ({
 
   return (
     // oxlint-disable-next-line jsx-a11y/anchor-has-content -- content provided by caller via props spread
-    <a href={href} onClick={handleClick} {...props} />
+    <a
+      href={href}
+      target={target}
+      rel={rel ?? (target === "_blank" ? "noopener noreferrer" : undefined)}
+      onClick={handleClick}
+      {...props}
+    />
   );
 };

--- a/apps/nextjs/src/components/store-button.tsx
+++ b/apps/nextjs/src/components/store-button.tsx
@@ -1,13 +1,16 @@
+import type { DownloadCtaClick } from "@/services/analytics";
+
 import type { ComponentProps } from "react";
 
 import type { ImageProps } from "next/image";
 
 import Image from "next/image";
 
-export const StoreButton = (props: ComponentProps<"a">) => {
+import { DownloadCta } from "@/components/download-cta";
+
+export const StoreButton = (props: ComponentProps<"a"> & DownloadCtaClick) => {
   return (
-    // oxlint-disable-next-line jsx-a11y/anchor-has-content -- content provided by caller via props spread
-    <a
+    <DownloadCta
       className="bg-card justify-center hover:bg-blue-700 cursor-pointer p-4 text-center rounded-xl gap-3 flex items-center hover:scale-105 transition-all duration-200 ease-in-out"
       {...props}
     />

--- a/apps/nextjs/src/services/analytics.ts
+++ b/apps/nextjs/src/services/analytics.ts
@@ -1,11 +1,10 @@
-import { capture } from "magic-observability/web";
+import { getPostHog, getWebClient } from "magic-observability/web";
 
 /**
  * Product analytics for the marketing site.
  *
- * `capture` is `magic-observability`'s browser shorthand. Without
- * `NEXT_PUBLIC_POSTHOG_KEY` the client behind it is the no-op one, so a call
- * here is a function call and nothing else: no network, no queue, nothing
+ * Without `NEXT_PUBLIC_POSTHOG_KEY` the shared client is the no-op one, so a
+ * call here is a function call and nothing else: no network, no queue, nothing
  * written to the console. Setting that variable on Vercel is the only step
  * needed to start receiving these events.
  *
@@ -47,6 +46,24 @@ export const downloadCtaProperties = (click: DownloadCtaClick) => ({
   ...(click.dogId === undefined ? {} : { dog_id: click.dogId }),
 });
 
+/**
+ * A download click is usually the last thing that happens on the page. On iOS
+ * `/store` redirects to the App Store, the store app takes over and the tab is
+ * backgrounded within the same tick — early enough that `posthog-js`'s batch
+ * timer has not fired and late enough that its `pagehide` flush can be skipped
+ * altogether. That window is exactly the click we are here to count.
+ *
+ * So the event skips the queue and goes out over `sendBeacon`, which the
+ * browser is obliged to deliver even after the page is gone. The shared facade
+ * takes no per-event options, hence the raw handle, and it is only reached for
+ * once the facade reports a live client: `posthog-js` warns when it is called
+ * before `init`, which is every click until the key is set.
+ */
 export const trackDownloadCtaClicked = (click: DownloadCtaClick) => {
-  capture(DOWNLOAD_CTA_CLICKED, downloadCtaProperties(click));
+  if (!getWebClient().enabled) return;
+
+  getPostHog().capture(DOWNLOAD_CTA_CLICKED, downloadCtaProperties(click), {
+    transport: "sendBeacon",
+    send_instantly: true,
+  });
 };

--- a/apps/nextjs/src/services/analytics.ts
+++ b/apps/nextjs/src/services/analytics.ts
@@ -1,0 +1,52 @@
+import { capture } from "magic-observability/web";
+
+/**
+ * Product analytics for the marketing site.
+ *
+ * `capture` is `magic-observability`'s browser shorthand. Without
+ * `NEXT_PUBLIC_POSTHOG_KEY` the client behind it is the no-op one, so a call
+ * here is a function call and nothing else: no network, no queue, nothing
+ * written to the console. Setting that variable on Vercel is the only step
+ * needed to start receiving these events.
+ *
+ * The mobile app is growing its own event catalogue under
+ * `packages/shared/analytics`. This name lives here until that lands, and
+ * should move into it then so both clients share one source of truth.
+ */
+export const DOWNLOAD_CTA_CLICKED = "Download CTA Clicked";
+
+/** Which page the button was on. */
+export type DownloadCtaPage = "landing" | "dog_share";
+
+/**
+ * Where the click sends the visitor. `auto` is the `/store` route handler,
+ * which picks a store from the user agent, so the destination is not known at
+ * click time.
+ */
+export type DownloadCtaStore = "app_store" | "play_store" | "auto";
+
+export type DownloadCtaClick = {
+  page: DownloadCtaPage;
+  /** Where on the page the button sits, e.g. `hero`, `mobile_sticky_bar`. */
+  placement: string;
+  store: DownloadCtaStore;
+  /** Only on `dog_share`: whose profile the visitor arrived through. */
+  dogId?: string;
+};
+
+/**
+ * The property bag, split out from the capture so it can be asserted on
+ * without a PostHog client. `dog_id` is omitted rather than sent as `null`
+ * on the landing page: PostHog stores an explicit null and it would show up
+ * as a real value in a breakdown.
+ */
+export const downloadCtaProperties = (click: DownloadCtaClick) => ({
+  page: click.page,
+  placement: click.placement,
+  store: click.store,
+  ...(click.dogId === undefined ? {} : { dog_id: click.dogId }),
+});
+
+export const trackDownloadCtaClicked = (click: DownloadCtaClick) => {
+  capture(DOWNLOAD_CTA_CLICKED, downloadCtaProperties(click));
+};

--- a/apps/nextjs/tests/download-cta-event.test.mjs
+++ b/apps/nextjs/tests/download-cta-event.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import {
+  initWebAnalytics,
+  resetWebClientForTests,
+} from "magic-observability/web";
+
 /**
  * The download CTA event is the only number that answers "does the share page
  * actually send anyone to a store". Its name and its property keys are what a
@@ -58,10 +63,25 @@ test("dog_id is absent rather than null when there is no dog", () => {
   );
 });
 
-test("capturing without a PostHog key is silent, not a crash", (t) => {
+test("a click without a PostHog key is silent, not a crash", (t) => {
   // Production has no NEXT_PUBLIC_POSTHOG_KEY yet, so this is the path every
-  // real click takes until it is set: the shared client is the no-op one and
-  // a capture has to cost nothing and say nothing.
+  // real click takes until Gabriel sets it. Init has to actually run for the
+  // assertion to mean anything: asserting silence against a client that was
+  // never built would pass with or without a key.
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+  t.after(() => {
+    resetWebClientForTests();
+    if (key !== undefined) process.env.NEXT_PUBLIC_POSTHOG_KEY = key;
+  });
+
+  resetWebClientForTests();
+  const client = initWebAnalytics();
+
+  assert.equal(client.enabled, false);
+  assert.equal(client.disabledReason, "missing-key");
+
   const error = t.mock.method(console, "error", () => {});
   const warn = t.mock.method(console, "warn", () => {});
 

--- a/apps/nextjs/tests/download-cta-event.test.mjs
+++ b/apps/nextjs/tests/download-cta-event.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+/**
+ * The download CTA event is the only number that answers "does the share page
+ * actually send anyone to a store". Its name and its property keys are what a
+ * PostHog insight is saved against, so renaming either one silently breaks a
+ * chart nobody is watching at the time.
+ *
+ * Imported straight from the TypeScript source: Node strips the types, and
+ * this module deliberately depends on nothing but `magic-observability/web`.
+ */
+const analytics = await import("../src/services/analytics.ts");
+
+test("the event name is the one the insight is saved against", () => {
+  assert.equal(analytics.DOWNLOAD_CTA_CLICKED, "Download CTA Clicked");
+});
+
+test("a landing page click reports page, placement and store", () => {
+  assert.deepEqual(
+    analytics.downloadCtaProperties({
+      page: "landing",
+      placement: "hero",
+      store: "app_store",
+    }),
+    { page: "landing", placement: "hero", store: "app_store" },
+  );
+});
+
+test("a share page click carries the dog it came from", () => {
+  assert.deepEqual(
+    analytics.downloadCtaProperties({
+      page: "dog_share",
+      placement: "mobile_sticky_bar",
+      store: "auto",
+      dogId: "dog_123",
+    }),
+    {
+      page: "dog_share",
+      placement: "mobile_sticky_bar",
+      store: "auto",
+      dog_id: "dog_123",
+    },
+  );
+});
+
+test("dog_id is absent rather than null when there is no dog", () => {
+  // An explicit null is a value PostHog stores and shows in a breakdown,
+  // which would put a "null" row next to the real dog ids.
+  assert.equal(
+    "dog_id" in
+      analytics.downloadCtaProperties({
+        page: "landing",
+        placement: "hero",
+        store: "play_store",
+      }),
+    false,
+  );
+});
+
+test("capturing without a PostHog key is silent, not a crash", (t) => {
+  // Production has no NEXT_PUBLIC_POSTHOG_KEY yet, so this is the path every
+  // real click takes until it is set: the shared client is the no-op one and
+  // a capture has to cost nothing and say nothing.
+  const error = t.mock.method(console, "error", () => {});
+  const warn = t.mock.method(console, "warn", () => {});
+
+  analytics.trackDownloadCtaClicked({
+    page: "dog_share",
+    placement: "desktop_copy",
+    store: "auto",
+    dogId: "dog_123",
+  });
+
+  assert.equal(error.mock.callCount(), 0);
+  assert.equal(warn.mock.callCount(), 0);
+});


### PR DESCRIPTION
## Summary

Every download button on the marketing site now reports a `Download CTA Clicked` event, so we can finally see how many visitors a share link actually sends to a store. Turning it on is one variable: set `NEXT_PUBLIC_POSTHOG_KEY` on Vercel (production and preview) and the events start arriving; until then everything here is a silent no-op. Closes #198.

## Details

* Hypothesis: the public dog share page converts visitors into store clicks. Over 10 percent and the viral share loop is worth investing in; under 3 percent and the page itself needs work first.
* Baseline: none. PostHog on the web app is a no-op today because the public key is unset, and Vercel Analytics only counts pageviews.
* Readout: a PostHog insight one week after release, `Download CTA Clicked` broken down by `page` (landing, dog_share) and `placement`, divided by pageviews of the same page.
* Initialisation was already env driven and is untouched. `NEXT_PUBLIC_POSTHOG_KEY` is already documented in `.env.example`, so there was nothing to fix for the key to take effect.
* Properties on the event: `page` (landing, dog_share), `placement` (hero, desktop_copy, mobile_sticky_bar), `store` (app_store, play_store, auto) and `dog_id` on the share page only.
* `store` is `auto` for the share page buttons because they point at `/store`, the route handler that picks a store from the user agent. The destination is not known at click time.
* `dog_id` is omitted rather than sent as null on the landing page, so a breakdown does not grow a null row alongside the real ids.
* One new client component carries the click handler; the pages using it stay server components.
* Without a key the shared client is the no-op one, so a click is a function call and nothing else: no network, no queue, nothing written to the console.
* The event name lives in the web analytics wrapper for now. It should fold into the shared event catalogue once that lands.

## Testing steps

1. Open the site and click both store buttons on the front page. Each one should still open the right store, exactly as before.
2. Open a dog share link on a phone and tap the button in the bar at the bottom of the screen. It should still take you to the store for your device.
3. Open the same link on a desktop and click the button next to the photo. It should behave the same way.
4. Nothing on either page should look or move differently, and no error should appear.

## Screenshots

No visible UI changes.
