### PR TITLE
feat(api): track last activity per user

### DIFF
--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -21,8 +21,15 @@ export const userRouter = createTRPCRouter({
     .input(userSchema)
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-      const updatedDog = await UserService.updateUserById(userId, input);
-      return updatedDog;
+      const updatedUser = await UserService.updateUserById(userId, input);
+
+      // `lastActiveAt` is written by the authenticated middleware for
+      // retention reporting and has no meaning in the app, so it stops here
+      // rather than riding along in the one procedure that returns a whole
+      // user row. Prisma 5.17 has no top-level `omit`, hence the destructure.
+      const { lastActiveAt: _lastActiveAt, ...user } = updatedUser;
+
+      return user;
     }),
 
   /**

--- a/packages/api/src/services/user-service.ts
+++ b/packages/api/src/services/user-service.ts
@@ -105,6 +105,13 @@ export class UserService {
     });
   }
 
+  /**
+   * Returns the Prisma promise rather than awaiting it, because
+   * `payment-service` hands the result straight to `$transaction`, which only
+   * accepts `PrismaPromise`. The row it resolves to is the whole user record,
+   * so anything returning it to a client has to narrow it first. See
+   * `userRouter.update`.
+   */
   static updateUserById(
     id: string,
     data: Partial<Omit<User, "email" | "id" | "createdAt">>,

--- a/packages/api/src/shared/last-active.test.ts
+++ b/packages/api/src/shared/last-active.test.ts
@@ -37,8 +37,8 @@ jest.mock("superjson", () => ({
   },
 }));
 
-const updateMany = jest.fn(async () => ({ count: 1 }));
-const db = { user: { updateMany } } as unknown as PrismaClient;
+const executeRaw = jest.fn();
+const db = { $executeRaw: executeRaw } as unknown as PrismaClient;
 
 const router = createTRPCRouter({
   authed: authenticatedProcedure.query(() => "pong"),
@@ -54,8 +54,24 @@ const callerFor = (userId?: string) =>
   });
 
 /**
+ * `$executeRaw` is a tagged template, so a call arrives as the literal's
+ * fragments followed by its interpolated values. Rejoining them with `?` gives
+ * back a readable statement with the parameters marked, which is what these
+ * assertions are about: the statement must name one column and carry its own
+ * freshness guard.
+ */
+const writeAt = (index: number) => {
+  const [fragments, ...values] = executeRaw.mock.calls[index] as [
+    string[],
+    ...unknown[],
+  ];
+
+  return { sql: fragments.join("?").replaceAll(/\s+/gu, " ").trim(), values };
+};
+
+/**
  * The write is fire and forget, so the procedure resolves before it does.
- * A macrotask hop is enough for the `updateMany` promise and its `.catch`.
+ * A macrotask hop is enough for the query promise and its `.catch`.
  */
 const flushPendingWrite = () =>
   new Promise((resolve) => {
@@ -69,7 +85,7 @@ let clock = START;
 beforeEach(() => {
   clock = START;
   jest.spyOn(Date, "now").mockImplementation(() => clock);
-  updateMany.mockImplementation(async () => ({ count: 1 }));
+  executeRaw.mockImplementation(async () => 1);
 });
 
 afterEach(() => {
@@ -80,20 +96,22 @@ it("records activity on the first authenticated request for a user", async () =>
   await expect(callerFor("user-first-request").authed()).resolves.toBe("pong");
   await flushPendingWrite();
 
-  // The row is only written when it is actually stale. Two instances can both
-  // believe it needs a write; the database decides, and the loser writes
-  // nothing rather than overwriting a fresher value.
-  expect(updateMany).toHaveBeenCalledTimes(1);
-  expect(updateMany).toHaveBeenCalledWith({
-    where: {
-      id: "user-first-request",
-      OR: [
-        { lastActiveAt: null },
-        { lastActiveAt: { lt: new Date(START - LAST_ACTIVE_THROTTLE_MS) } },
-      ],
-    },
-    data: { lastActiveAt: new Date(START) },
-  });
+  expect(executeRaw).toHaveBeenCalledTimes(1);
+
+  const { sql, values } = writeAt(0);
+
+  // One column, so `updatedAt` keeps meaning "the profile was edited", and a
+  // guard the database evaluates, so a second instance racing on the same row
+  // updates nothing rather than overwriting a fresher value. Deleted accounts
+  // hold a valid token until it expires and must not count as active.
+  expect(sql).toBe(
+    'UPDATE "User" SET "lastActiveAt" = ? WHERE "id" = ? AND "deletedAt" IS NULL AND ("lastActiveAt" IS NULL OR "lastActiveAt" < ?)',
+  );
+  expect(values).toEqual([
+    new Date(START),
+    "user-first-request",
+    new Date(START - LAST_ACTIVE_THROTTLE_MS),
+  ]);
 });
 
 it("does not write again for a second request inside the throttle window", async () => {
@@ -101,14 +119,14 @@ it("does not write again for a second request inside the throttle window", async
 
   await caller.authed();
   await flushPendingWrite();
-  expect(updateMany).toHaveBeenCalledTimes(1);
+  expect(executeRaw).toHaveBeenCalledTimes(1);
 
   clock = START + LAST_ACTIVE_THROTTLE_MS - 1;
 
   await caller.authed();
   await flushPendingWrite();
 
-  expect(updateMany).toHaveBeenCalledTimes(1);
+  expect(executeRaw).toHaveBeenCalledTimes(1);
 });
 
 it("writes again once the throttle window has passed", async () => {
@@ -122,10 +140,12 @@ it("writes again once the throttle window has passed", async () => {
   await caller.authed();
   await flushPendingWrite();
 
-  expect(updateMany).toHaveBeenCalledTimes(2);
-  expect(updateMany).toHaveBeenLastCalledWith(
-    expect.objectContaining({ data: { lastActiveAt: new Date(clock) } }),
-  );
+  expect(executeRaw).toHaveBeenCalledTimes(2);
+  expect(writeAt(1).values).toEqual([
+    new Date(clock),
+    "user-past-window",
+    new Date(clock - LAST_ACTIVE_THROTTLE_MS),
+  ]);
 });
 
 it("records nothing for a request without a session", async () => {
@@ -135,18 +155,33 @@ it("records nothing for a request without a session", async () => {
   await expect(callerFor().open()).resolves.toBe("pong");
   await flushPendingWrite();
 
-  expect(updateMany).not.toHaveBeenCalled();
+  expect(executeRaw).not.toHaveBeenCalled();
 });
 
-it("reports a failed write instead of failing the request", async () => {
+it("reports a rejected write instead of failing the request", async () => {
   const failure = new Error("connection reset");
-  updateMany.mockRejectedValueOnce(failure);
+  executeRaw.mockRejectedValueOnce(failure);
 
-  await expect(callerFor("user-write-fails").authed()).resolves.toBe("pong");
+  await expect(callerFor("user-write-rejects").authed()).resolves.toBe("pong");
   await flushPendingWrite();
 
   expect(sendError).toHaveBeenCalledWith(
     failure,
-    expect.objectContaining({ userId: "user-write-fails" }),
+    expect.objectContaining({ userId: "user-write-rejects" }),
+  );
+});
+
+it("reports a write that throws before it returns a promise", async () => {
+  const failure = new Error("pool exhausted");
+  executeRaw.mockImplementationOnce(() => {
+    throw failure;
+  });
+
+  await expect(callerFor("user-write-throws").authed()).resolves.toBe("pong");
+  await flushPendingWrite();
+
+  expect(sendError).toHaveBeenCalledWith(
+    failure,
+    expect.objectContaining({ userId: "user-write-throws" }),
   );
 });

--- a/packages/api/src/shared/last-active.test.ts
+++ b/packages/api/src/shared/last-active.test.ts
@@ -1,0 +1,152 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { sendError } from "../errors/errors";
+import {
+  authenticatedProcedure,
+  createInnerTRPCContext,
+  createTRPCRouter,
+  publicProcedure,
+} from "../trpc";
+import { LAST_ACTIVE_THROTTLE_MS } from "./last-active";
+
+/**
+ * `User.lastActiveAt` is the column every retention and dormancy report reads,
+ * and it is written from the middleware every authenticated request passes
+ * through. Two things have to hold at once and they pull against each other:
+ * the value has to be recorded, and recording it must not turn one row into
+ * the hottest write in the API.
+ *
+ * So these drive the real tRPC middleware with a fake database rather than
+ * calling the helper directly. What is being asserted is which requests
+ * produce a write, and that is a property of the middleware chain.
+ */
+jest.mock("@pegada/database", () => ({ prisma: {} }));
+
+jest.mock("../errors/errors", () => ({
+  sendError: jest.fn(),
+  logDebug: jest.fn(),
+  errorDebug: jest.fn(),
+}));
+
+/** Ships ESM only, which this suite's CommonJS transform cannot load. */
+jest.mock("superjson", () => ({
+  __esModule: true,
+  default: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value,
+  },
+}));
+
+const updateMany = jest.fn(async () => ({ count: 1 }));
+const db = { user: { updateMany } } as unknown as PrismaClient;
+
+const router = createTRPCRouter({
+  authed: authenticatedProcedure.query(() => "pong"),
+  open: publicProcedure.query(() => "pong"),
+});
+
+const callerFor = (userId?: string) =>
+  router.createCaller({
+    ...createInnerTRPCContext({
+      session: userId ? { user: { id: userId } } : null,
+    }),
+    db,
+  });
+
+/**
+ * The write is fire and forget, so the procedure resolves before it does.
+ * A macrotask hop is enough for the `updateMany` promise and its `.catch`.
+ */
+const flushPendingWrite = () =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+
+const START = Date.parse("2026-09-01T12:00:00.000Z");
+
+let clock = START;
+
+beforeEach(() => {
+  clock = START;
+  jest.spyOn(Date, "now").mockImplementation(() => clock);
+  updateMany.mockImplementation(async () => ({ count: 1 }));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it("records activity on the first authenticated request for a user", async () => {
+  await expect(callerFor("user-first-request").authed()).resolves.toBe("pong");
+  await flushPendingWrite();
+
+  // The row is only written when it is actually stale. Two instances can both
+  // believe it needs a write; the database decides, and the loser writes
+  // nothing rather than overwriting a fresher value.
+  expect(updateMany).toHaveBeenCalledTimes(1);
+  expect(updateMany).toHaveBeenCalledWith({
+    where: {
+      id: "user-first-request",
+      OR: [
+        { lastActiveAt: null },
+        { lastActiveAt: { lt: new Date(START - LAST_ACTIVE_THROTTLE_MS) } },
+      ],
+    },
+    data: { lastActiveAt: new Date(START) },
+  });
+});
+
+it("does not write again for a second request inside the throttle window", async () => {
+  const caller = callerFor("user-inside-window");
+
+  await caller.authed();
+  await flushPendingWrite();
+  expect(updateMany).toHaveBeenCalledTimes(1);
+
+  clock = START + LAST_ACTIVE_THROTTLE_MS - 1;
+
+  await caller.authed();
+  await flushPendingWrite();
+
+  expect(updateMany).toHaveBeenCalledTimes(1);
+});
+
+it("writes again once the throttle window has passed", async () => {
+  const caller = callerFor("user-past-window");
+
+  await caller.authed();
+  await flushPendingWrite();
+
+  clock = START + LAST_ACTIVE_THROTTLE_MS;
+
+  await caller.authed();
+  await flushPendingWrite();
+
+  expect(updateMany).toHaveBeenCalledTimes(2);
+  expect(updateMany).toHaveBeenLastCalledWith(
+    expect.objectContaining({ data: { lastActiveAt: new Date(clock) } }),
+  );
+});
+
+it("records nothing for a request without a session", async () => {
+  await expect(callerFor().authed()).rejects.toMatchObject({
+    code: "UNAUTHORIZED",
+  });
+  await expect(callerFor().open()).resolves.toBe("pong");
+  await flushPendingWrite();
+
+  expect(updateMany).not.toHaveBeenCalled();
+});
+
+it("reports a failed write instead of failing the request", async () => {
+  const failure = new Error("connection reset");
+  updateMany.mockRejectedValueOnce(failure);
+
+  await expect(callerFor("user-write-fails").authed()).resolves.toBe("pong");
+  await flushPendingWrite();
+
+  expect(sendError).toHaveBeenCalledWith(
+    failure,
+    expect.objectContaining({ userId: "user-write-fails" }),
+  );
+});

--- a/packages/api/src/shared/last-active.ts
+++ b/packages/api/src/shared/last-active.ts
@@ -29,23 +29,36 @@ const lastWriteByUserId = new Map<string, number>();
 /**
  * Instances are recycled, but a busy one can stay warm for hours, and a map
  * keyed by user id would otherwise grow with every distinct visitor for the
- * life of the process. Entries older than the throttle window can never
- * suppress a write, so they are dead weight: drop them once the map is large
- * enough for the sweep to be worth its own cost.
+ * life of the process.
  */
 const MAX_TRACKED_USERS = 10_000;
 
-const pruneExpired = (now: number) => {
-  if (lastWriteByUserId.size < MAX_TRACKED_USERS) return;
+/**
+ * Keeps {@link lastWriteByUserId} bounded by {@link MAX_TRACKED_USERS}.
+ *
+ * Expired entries go first: they can never suppress a write, so they are pure
+ * dead weight. If that is not enough, the oldest insertions are evicted until
+ * the map fits. A `Map` iterates in insertion order and every entry is
+ * inserted at write time, so the head of the iteration is the least recently
+ * written user. Evicting one only costs a redundant `UPDATE` on that user's
+ * next request, which the WHERE clause turns into zero rows changed.
+ */
+const enforceMapBudget = (now: number) => {
+  if (lastWriteByUserId.size <= MAX_TRACKED_USERS) return;
 
   for (const [userId, writtenAt] of lastWriteByUserId) {
     if (now - writtenAt >= LAST_ACTIVE_THROTTLE_MS) {
       lastWriteByUserId.delete(userId);
     }
   }
+
+  for (const userId of lastWriteByUserId.keys()) {
+    if (lastWriteByUserId.size <= MAX_TRACKED_USERS) break;
+    lastWriteByUserId.delete(userId);
+  }
 };
 
-type LastActiveDatabase = Pick<PrismaClient, "user">;
+type LastActiveDatabase = Pick<PrismaClient, "$executeRaw">;
 
 /**
  * Records that an authenticated request arrived for `userId`, at most once per
@@ -53,7 +66,7 @@ type LastActiveDatabase = Pick<PrismaClient, "user">;
  *
  * Fire and forget on purpose: analytics must never be able to slow down or
  * fail a request that would otherwise have succeeded, so the promise is not
- * awaited and a rejection is reported rather than thrown.
+ * awaited, and neither a rejection nor a synchronous throw escapes.
  */
 export const touchLastActiveAt = (
   db: LastActiveDatabase,
@@ -69,26 +82,38 @@ export const touchLastActiveAt = (
   // Recorded before the write resolves, so a burst of concurrent requests on
   // this instance issues one query rather than one per request.
   lastWriteByUserId.set(userId, now);
-  pruneExpired(now);
+  enforceMapBudget(now);
 
+  const activeAt = new Date(now);
   const staleBefore = new Date(now - LAST_ACTIVE_THROTTLE_MS);
 
-  // `updateMany` with the freshness condition in the WHERE clause rather than
-  // `update`: two instances that both believe the row is stale then race on a
-  // condition the database evaluates, and the loser writes nothing instead of
-  // overwriting a value that was already current.
-  void db.user
-    .updateMany({
-      where: {
-        id: userId,
-        OR: [{ lastActiveAt: null }, { lastActiveAt: { lt: staleBefore } }],
+  try {
+    // Raw SQL rather than `updateMany`, for one reason: `User.updatedAt` is
+    // `@updatedAt`, so any Prisma write to the row rewrites it. Routing
+    // activity through Prisma would move `updatedAt` every 10 minutes for
+    // every active user and quietly destroy the only signal for "this profile
+    // was last edited". This statement touches one column.
+    //
+    // The freshness condition lives in the WHERE clause rather than in a read
+    // followed by a write: two instances that both believe the row is stale
+    // race on a condition the database evaluates, and the loser updates zero
+    // rows instead of overwriting a value that was already current.
+    //
+    // `deletedAt IS NULL` because this runs in `enforceUserIsAuthed`, ahead of
+    // the `enforceUserIsActive` check that a protected procedure would make.
+    // A deleted account still holds a valid token until it expires, and
+    // counting it as active would inflate every retention number here.
+    void db.$executeRaw`UPDATE "User" SET "lastActiveAt" = ${activeAt} WHERE "id" = ${userId} AND "deletedAt" IS NULL AND ("lastActiveAt" IS NULL OR "lastActiveAt" < ${staleBefore})`.catch(
+      (error: unknown) => {
+        // A failed write means one lost data point in a report, so it is
+        // reported and dropped. Clearing the map entry would retry on the next
+        // request, which is exactly the hammering this exists to prevent.
+        sendError(error, { context: "touchLastActiveAt", userId });
       },
-      data: { lastActiveAt: new Date(now) },
-    })
-    .catch((error: unknown) => {
-      // A failed write means one lost data point in a report, so it is
-      // reported and dropped. Clearing the map entry would retry on the next
-      // request, which is exactly the hammering this exists to prevent.
-      sendError(error, { context: "touchLastActiveAt", userId });
-    });
+    );
+  } catch (error) {
+    // A driver can throw before it ever returns a promise (no connection in
+    // the pool, a client shutting down). Same handling: report and carry on.
+    sendError(error, { context: "touchLastActiveAt", userId });
+  }
 };

--- a/packages/api/src/shared/last-active.ts
+++ b/packages/api/src/shared/last-active.ts
@@ -1,0 +1,94 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { sendError } from "../errors/errors";
+
+/**
+ * How stale `User.lastActiveAt` is allowed to get before another write is
+ * worth making. Retention reporting buckets by day, so 10 minutes of drift
+ * costs nothing and turns a per-request write into roughly one write per user
+ * per session.
+ */
+export const LAST_ACTIVE_THROTTLE_MS = 10 * 60 * 1000;
+
+/**
+ * Per-instance record of "we already issued a write for this user recently".
+ *
+ * The session comes from a JWT, so no user row is loaded on the authenticated
+ * path and there is no `lastActiveAt` to compare against without an extra
+ * read. This map is the cheap half of the throttle: it stops repeat writes
+ * from the same warm instance without touching the database at all.
+ *
+ * It is deliberately not the whole answer. Every serverless instance starts
+ * with an empty map, and a user with the app open hits several of them, so the
+ * write itself carries the same 10 minute condition in SQL
+ * ({@link touchLastActiveAt}). The map saves round trips; the WHERE clause is
+ * what actually bounds the writes.
+ */
+const lastWriteByUserId = new Map<string, number>();
+
+/**
+ * Instances are recycled, but a busy one can stay warm for hours, and a map
+ * keyed by user id would otherwise grow with every distinct visitor for the
+ * life of the process. Entries older than the throttle window can never
+ * suppress a write, so they are dead weight: drop them once the map is large
+ * enough for the sweep to be worth its own cost.
+ */
+const MAX_TRACKED_USERS = 10_000;
+
+const pruneExpired = (now: number) => {
+  if (lastWriteByUserId.size < MAX_TRACKED_USERS) return;
+
+  for (const [userId, writtenAt] of lastWriteByUserId) {
+    if (now - writtenAt >= LAST_ACTIVE_THROTTLE_MS) {
+      lastWriteByUserId.delete(userId);
+    }
+  }
+};
+
+type LastActiveDatabase = Pick<PrismaClient, "user">;
+
+/**
+ * Records that an authenticated request arrived for `userId`, at most once per
+ * {@link LAST_ACTIVE_THROTTLE_MS} per user.
+ *
+ * Fire and forget on purpose: analytics must never be able to slow down or
+ * fail a request that would otherwise have succeeded, so the promise is not
+ * awaited and a rejection is reported rather than thrown.
+ */
+export const touchLastActiveAt = (
+  db: LastActiveDatabase,
+  userId: string,
+): void => {
+  const now = Date.now();
+  const lastWrite = lastWriteByUserId.get(userId);
+
+  if (lastWrite !== undefined && now - lastWrite < LAST_ACTIVE_THROTTLE_MS) {
+    return;
+  }
+
+  // Recorded before the write resolves, so a burst of concurrent requests on
+  // this instance issues one query rather than one per request.
+  lastWriteByUserId.set(userId, now);
+  pruneExpired(now);
+
+  const staleBefore = new Date(now - LAST_ACTIVE_THROTTLE_MS);
+
+  // `updateMany` with the freshness condition in the WHERE clause rather than
+  // `update`: two instances that both believe the row is stale then race on a
+  // condition the database evaluates, and the loser writes nothing instead of
+  // overwriting a value that was already current.
+  void db.user
+    .updateMany({
+      where: {
+        id: userId,
+        OR: [{ lastActiveAt: null }, { lastActiveAt: { lt: staleBefore } }],
+      },
+      data: { lastActiveAt: new Date(now) },
+    })
+    .catch((error: unknown) => {
+      // A failed write means one lost data point in a report, so it is
+      // reported and dropped. Clearing the map entry would retry on the next
+      // request, which is exactly the hammering this exists to prevent.
+      sendError(error, { context: "touchLastActiveAt", userId });
+    });
+};

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -21,6 +21,7 @@ import { ZodError } from "zod";
 
 import { logDebug, sendError } from "./errors/errors";
 import { signAccessToken, type Session } from "./shared/auth-token";
+import { touchLastActiveAt } from "./shared/last-active";
 
 export { getSession, type Session } from "./shared/auth-token";
 
@@ -147,6 +148,11 @@ const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
   if (!ctx.session?.user) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
+
+  // Every authenticated request passes through here, which makes it the one
+  // place that sees "this account is in use" without a router knowing about
+  // it. Not awaited: see touchLastActiveAt.
+  touchLastActiveAt(ctx.db, ctx.session.user.id);
 
   return next({
     ctx: {

--- a/packages/database/migrations/20260901130000_add_user_last_active_at/migration.sql
+++ b/packages/database/migrations/20260901130000_add_user_last_active_at/migration.sql
@@ -1,0 +1,17 @@
+-- Records the last time an authenticated request arrived for a user, written
+-- at most once per 10 minutes per user by the tRPC authenticated middleware
+-- (packages/api/src/trpc.ts). It is the column DAU/WAU, D7/D30 retention and
+-- dormant-subscriber reporting read; nothing is exposed to the client.
+--
+-- Additive and nullable, so existing rows keep working and no backfill runs:
+-- every user starts as NULL and gets a value on their next authenticated
+-- request. Reports should read NULL as "not seen since this shipped".
+ALTER TABLE "User" ADD COLUMN "lastActiveAt" TIMESTAMP(3);
+
+-- Every reporting query filters on this column and nothing else
+-- (`lastActiveAt >= now() - interval '7 days'`, `lastActiveAt < now() -
+-- interval '14 days'`), so a single-column btree is what those scans need.
+-- Plain, not CONCURRENTLY: `prisma migrate` wraps the file in a transaction
+-- and Postgres rejects CREATE INDEX CONCURRENTLY there. The column is new, so
+-- every value is NULL and the build is near-instant regardless of table size.
+CREATE INDEX "User_lastActiveAt_idx" ON "User"("lastActiveAt");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -72,11 +72,17 @@ model User {
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?
 
+  /// Server-side only: last time an authenticated request arrived for this
+  /// user, throttled to one write per 10 minutes. Retention and dormancy
+  /// reporting read it; it is never returned to the client.
+  lastActiveAt DateTime?
+
   // Plan
   plan PlanType @default(FREE)
 
   @@index([latitude])
   @@index([longitude])
+  @@index([lastActiveAt])
 }
 
 model Dog {


### PR DESCRIPTION
## Summary

Adds a server side `lastActiveAt` column on `User`, written from the tRPC authenticated middleware at most once per 10 minutes per user. Nothing in the API records that an account is in use today, so questions about retention and dormant subscribers cannot be answered at all.

Closes #189

## Details

- Hypothesis: over 20 percent of active subscribers have not opened the app in 14 days and could be re-engaged before their renewal fails.
- Baseline: none exists. No activity column has ever been stored, so this PR is the instrumentation that establishes the baseline. The first useful read is 14 days after it ships, since every row starts null and fills in on the user's next authenticated request.
- Readout: SQL over the `User` table. DAU and WAU are the count of users whose `lastActiveAt` falls in the last 1 and 7 days. Dormant subscribers are users on a non free plan whose `lastActiveAt` is null or older than 14 days, over the count of users on a non free plan. D7 and D30 retention compare `createdAt` against `lastActiveAt` for each signup cohort. All four filter on `lastActiveAt` alone, which is why the migration indexes it.
- The write is throttled twice. An in memory map keyed by user id skips repeat writes from the same warm instance for 10 minutes, and the query itself carries the same condition in its WHERE clause, so several serverless instances that each believe the row is stale still produce one write and the losers write nothing.
- The update is a raw statement that sets only the activity column, so the row's general modified timestamp keeps meaning "profile last changed" and deleted accounts are never touched.
- The in memory map is capped. Expired entries go first, then the oldest, so a busy instance cannot grow it without bound.
- The write is fire and forget. It is never awaited, so it cannot slow a request, and a failure, whether it rejects or throws outright, is reported through the existing error funnel and dropped rather than turning a successful request into a failed one.
- Nothing new reaches the client. The one procedure that returned a whole user row, `user.update`, strips the field before responding. Every other user query in the API already uses an explicit select.
- The migration is additive and nullable with no backfill, so it is safe to apply ahead of the deploy.

## Testing steps

1. Sign in to the app and use it normally for a minute.
2. Ask the database when that account was last active. It should show the current time.
3. Keep using the app for another couple of minutes and check again. The value should not have moved yet, because it is only refreshed every ten minutes.
4. Wait more than ten minutes, use the app again, and check once more. The value should now be up to date.
5. Change your location or profile in the app and confirm nothing in the app looks different. This field is never sent to the app.

## Screenshots

No visible UI changes.
