### PR TITLE
feat(api): persist subscription lifecycle for churn measurement

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
     "./*": "./src/*.ts"
   },
   "scripts": {
+    "metrics:subscriptions": "tsx src/scripts/subscription-metrics.ts",
     "test": "jest --runInBand --detectOpenHandles",
     "pretest": "pnpm -F @pegada/database test:db:setup",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"

--- a/packages/api/src/scripts/subscription-metrics.ts
+++ b/packages/api/src/scripts/subscription-metrics.ts
@@ -1,0 +1,86 @@
+import prisma from "@pegada/database";
+
+import { getSubscriptionMetrics } from "../services/subscription-metrics-service";
+
+/**
+ * The monthly churn readout.
+ *
+ *   pnpm api metrics:subscriptions
+ *   pnpm api metrics:subscriptions --from 2026-09-01 --to 2026-09-30
+ *
+ * Prints the counts as JSON and exits. Sandbox events are left out unless
+ * `--include-sandbox` is passed.
+ */
+
+const DAYS = 30;
+const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
+
+const readFlag = (argv: string[], flag: string) => {
+  const index = argv.indexOf(`--${flag}`);
+
+  return index === -1 ? undefined : argv[index + 1];
+};
+
+const parseDate = (value: string | undefined, flag: string, fallback: Date) => {
+  if (!value) return fallback;
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new TypeError(`--${flag} is not a date: ${value}`);
+  }
+
+  return parsed;
+};
+
+/**
+ * `--to 2026-09-30` reads as the whole of the 30th. A bare date parses to
+ * midnight, which would silently drop that day's events from a month report.
+ */
+const endOfDay = (value: string | undefined, parsed: Date) => {
+  const isBareDate = value !== undefined && /^\d{4}-\d{2}-\d{2}$/.test(value);
+
+  return isBareDate
+    ? new Date(parsed.getTime() + MILLISECONDS_IN_A_DAY - 1)
+    : parsed;
+};
+
+const report = async () => {
+  const argv = process.argv.slice(2);
+  const now = new Date();
+
+  const from = parseDate(
+    readFlag(argv, "from"),
+    "from",
+    new Date(now.getTime() - DAYS * MILLISECONDS_IN_A_DAY),
+  );
+  const toFlag = readFlag(argv, "to");
+  const to = endOfDay(toFlag, parseDate(toFlag, "to", now));
+
+  const metrics = await getSubscriptionMetrics({
+    from,
+    to,
+    includeSandbox: argv.includes("--include-sandbox"),
+  });
+
+  console.log(
+    JSON.stringify(
+      { from: from.toISOString(), to: to.toISOString(), ...metrics },
+      null,
+      2,
+    ),
+  );
+};
+
+const main = async () => {
+  try {
+    await report();
+  } finally {
+    await prisma.$disconnect();
+  }
+};
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/api/src/services/__fixtures__/revenuecat-events.ts
+++ b/packages/api/src/services/__fixtures__/revenuecat-events.ts
@@ -27,6 +27,8 @@ import type {
 export const PRODUCT_ID = "pegada_premium_monthly";
 export const PURCHASED_AT_MS = 1_772_000_000_000;
 export const EXPIRATION_AT_MS = 1_774_592_000_000;
+export const PRICE_IN_CURRENCY = 19.9;
+export const PRICE_USD = 3.99;
 
 const base = {
   app_id: "appc1a2b3c4d5",
@@ -48,9 +50,11 @@ const subscription = (appUserId: string) => {
     presented_offering_id: "default",
     purchased_at_ms: PURCHASED_AT_MS,
     expiration_at_ms: EXPIRATION_AT_MS,
-    price: 19.9,
+    // `price` is USD and `price_in_purchased_currency` is what the subscriber
+    // actually paid, so they have to differ for the mapping to be testable.
+    price: PRICE_USD,
     currency: "BRL",
-    price_in_purchased_currency: 19.9,
+    price_in_purchased_currency: PRICE_IN_CURRENCY,
     tax_percentage: 0,
     commission_percentage: 0.15,
     takehome_percentage: 0.85,
@@ -78,7 +82,11 @@ export const trialStart = (
   id: string,
   appUserId: string,
 ): EventInitialPurchase =>
-  initialPurchase(id, appUserId, { period_type: "TRIAL", price: 0 });
+  initialPurchase(id, appUserId, {
+    period_type: "TRIAL",
+    price: 0,
+    price_in_purchased_currency: 0,
+  });
 
 export const renewal = (
   id: string,
@@ -89,7 +97,6 @@ export const renewal = (
   type: "RENEWAL",
   id,
   is_trial_conversion: false,
-  grace_period_expiration_at_ms: EXPIRATION_AT_MS,
   ...overrides,
 });
 

--- a/packages/api/src/services/__fixtures__/revenuecat-events.ts
+++ b/packages/api/src/services/__fixtures__/revenuecat-events.ts
@@ -1,0 +1,193 @@
+import type {
+  Environment,
+  Event,
+  EventBillingIssue,
+  EventCancellation,
+  EventExpiration,
+  EventInitialPurchase,
+  EventNonRenewingPurchase,
+  EventProductChange,
+  EventRenewal,
+  EventSubscriptionPaused,
+  EventTest,
+  EventTransfer,
+  EventUnancellation,
+  PeriodType,
+  StoreKind,
+  WebhookPayload,
+} from "../../types/revenuecat";
+
+/**
+ * Webhook payloads shaped after RevenueCat's documented event fields, so the
+ * subscription log is tested against what the store actually posts rather than
+ * against our own types.
+ * https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields
+ */
+
+export const PRODUCT_ID = "pegada_premium_monthly";
+export const PURCHASED_AT_MS = 1_772_000_000_000;
+export const EXPIRATION_AT_MS = 1_774_592_000_000;
+
+const base = {
+  app_id: "appc1a2b3c4d5",
+  event_timestamp_ms: PURCHASED_AT_MS,
+  store: "APP_STORE" as StoreKind,
+  environment: "PRODUCTION" as Environment,
+};
+
+const subscription = (appUserId: string) => {
+  return {
+    ...base,
+    app_user_id: appUserId,
+    original_app_user_id: appUserId,
+    aliases: [appUserId],
+    product_id: PRODUCT_ID,
+    entitlement_ids: ["premium"],
+    entitlement_id: "premium",
+    period_type: "NORMAL" as PeriodType,
+    presented_offering_id: "default",
+    purchased_at_ms: PURCHASED_AT_MS,
+    expiration_at_ms: EXPIRATION_AT_MS,
+    price: 19.9,
+    currency: "BRL",
+    price_in_purchased_currency: 19.9,
+    tax_percentage: 0,
+    commission_percentage: 0.15,
+    takehome_percentage: 0.85,
+    subscriber_attributes: {},
+    transaction_id: "2000000512345678",
+    original_transaction_id: "2000000512345678",
+    is_family_share: false,
+    country_code: "BR",
+    offer_code: null,
+  };
+};
+
+export const initialPurchase = (
+  id: string,
+  appUserId: string,
+  overrides: Partial<EventInitialPurchase> = {},
+): EventInitialPurchase => ({
+  ...subscription(appUserId),
+  type: "INITIAL_PURCHASE",
+  id,
+  ...overrides,
+});
+
+export const trialStart = (
+  id: string,
+  appUserId: string,
+): EventInitialPurchase =>
+  initialPurchase(id, appUserId, { period_type: "TRIAL", price: 0 });
+
+export const renewal = (
+  id: string,
+  appUserId: string,
+  overrides: Partial<EventRenewal> = {},
+): EventRenewal => ({
+  ...subscription(appUserId),
+  type: "RENEWAL",
+  id,
+  is_trial_conversion: false,
+  grace_period_expiration_at_ms: EXPIRATION_AT_MS,
+  ...overrides,
+});
+
+/** A trial that started paying, flagged by RevenueCat's own signal. */
+export const trialConversion = (id: string, appUserId: string): EventRenewal =>
+  renewal(id, appUserId, { is_trial_conversion: true });
+
+export const cancellation = (
+  id: string,
+  appUserId: string,
+  overrides: Partial<EventCancellation> = {},
+): EventCancellation => ({
+  ...subscription(appUserId),
+  type: "CANCELLATION",
+  id,
+  cancel_reason: "UNSUBSCRIBE",
+  ...overrides,
+});
+
+/** The one cancel reason RevenueCat documents as a refund. */
+export const refund = (id: string, appUserId: string): EventCancellation =>
+  cancellation(id, appUserId, { cancel_reason: "CUSTOMER_SUPPORT" });
+
+export const uncancellation = (
+  id: string,
+  appUserId: string,
+): EventUnancellation => ({
+  ...subscription(appUserId),
+  type: "UNCANCELLATION",
+  id,
+});
+
+export const expiration = (id: string, appUserId: string): EventExpiration => ({
+  ...subscription(appUserId),
+  type: "EXPIRATION",
+  id,
+  expiration_reason: "UNSUBSCRIBE",
+});
+
+export const productChange = (
+  id: string,
+  appUserId: string,
+): EventProductChange => ({
+  ...subscription(appUserId),
+  type: "PRODUCT_CHANGE",
+  id,
+  new_product_id: "pegada_premium_yearly",
+});
+
+export const billingIssue = (
+  id: string,
+  appUserId: string,
+): EventBillingIssue => ({
+  ...subscription(appUserId),
+  type: "BILLING_ISSUE",
+  id,
+  grace_period_expiration_at_ms: EXPIRATION_AT_MS,
+});
+
+export const subscriptionPaused = (
+  id: string,
+  appUserId: string,
+): EventSubscriptionPaused => ({
+  ...subscription(appUserId),
+  type: "SUBSCRIPTION_PAUSED",
+  id,
+});
+
+export const nonRenewingPurchase = (
+  id: string,
+  appUserId: string,
+): EventNonRenewingPurchase => ({
+  ...subscription(appUserId),
+  type: "NON_RENEWING_PURCHASE",
+  id,
+  expiration_at_ms: null,
+});
+
+export const transfer = (
+  id: string,
+  transferredFrom: string[],
+  transferredTo: string[],
+): EventTransfer => ({
+  ...base,
+  type: "TRANSFER",
+  id,
+  transferred_from: transferredFrom,
+  transferred_to: transferredTo,
+});
+
+/** RevenueCat's dashboard "send test event" button, and no user attached. */
+export const testEvent = (id: string): EventTest => ({
+  ...base,
+  type: "TEST",
+  id,
+});
+
+export const webhookPayload = (event: Event): WebhookPayload => ({
+  api_version: "1.0",
+  event,
+});

--- a/packages/api/src/services/payment-service.test.ts
+++ b/packages/api/src/services/payment-service.test.ts
@@ -6,6 +6,15 @@ jest.mock("../shared/analytics", () => ({
   captureEvent: (...args: unknown[]) => mockCaptureEvent(...args),
 }));
 
+// `subscription-event-service.ts` reaches `errors.ts` -> `observability.ts` ->
+// the ESM-only `magic-observability/node`, which jest can't parse. Same mock
+// the other service suites use.
+jest.mock("../errors/errors", () => ({
+  sendError: jest.fn(),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
 jest.mock("@pegada/database", () => ({
   __esModule: true,
   default: { $transaction: (...args: unknown[]) => mockTransaction(...args) },
@@ -95,11 +104,13 @@ beforeEach(() => {
 });
 
 describe("PaymentService.handleRevenueCatEvent", () => {
-  it("captures a Subscription Event for every type RevenueCat can send", () => {
+  it("captures a Subscription Event for every type RevenueCat can send", async () => {
     // Most of these change no plan at all, and those are exactly the ones that
     // answer "why did they leave" — so the capture sits before the switch.
     for (const type of EVERY_EVENT_TYPE) {
-      void service.handleRevenueCatEvent({ event: buildEvent({ type }) });
+      // The assertion below reads the order the captures arrived in.
+      // oxlint-disable-next-line no-await-in-loop -- so these run one at a time.
+      await service.handleRevenueCatEvent({ event: buildEvent({ type }) });
     }
 
     expect(mockCaptureEvent).toHaveBeenCalledTimes(EVERY_EVENT_TYPE.length);
@@ -110,8 +121,8 @@ describe("PaymentService.handleRevenueCatEvent", () => {
     expect(capturedTypes).toEqual(EVERY_EVENT_TYPE);
   });
 
-  it("sends the billing detail the revenue questions are asked in", () => {
-    service.handleRevenueCatEvent({
+  it("sends the billing detail the revenue questions are asked in", async () => {
+    await service.handleRevenueCatEvent({
       event: buildEvent({ type: "INITIAL_PURCHASE" }),
     });
 
@@ -132,14 +143,14 @@ describe("PaymentService.handleRevenueCatEvent", () => {
     );
   });
 
-  it("reads a cancellation's reason and an expiration's under one key", () => {
-    service.handleRevenueCatEvent({
+  it("reads a cancellation's reason and an expiration's under one key", async () => {
+    await service.handleRevenueCatEvent({
       event: buildEvent({
         type: "CANCELLATION",
         cancel_reason: "UNSUBSCRIBE",
       }),
     });
-    service.handleRevenueCatEvent({
+    await service.handleRevenueCatEvent({
       event: buildEvent({
         type: "EXPIRATION",
         expiration_reason: "BILLING_ERROR",
@@ -152,8 +163,8 @@ describe("PaymentService.handleRevenueCatEvent", () => {
     expect(reasons).toEqual(["UNSUBSCRIBE", "BILLING_ERROR"]);
   });
 
-  it("leaves an event with no billing detail with nulls rather than undefined", () => {
-    service.handleRevenueCatEvent({
+  it("leaves an event with no billing detail with nulls rather than undefined", async () => {
+    await service.handleRevenueCatEvent({
       event: {
         type: "TEST",
         id: "event-1",
@@ -181,18 +192,18 @@ describe("PaymentService.handleRevenueCatEvent", () => {
   });
 
   describe("plan mutations, which this change must not touch", () => {
-    it("does not downgrade on CANCELLATION", () => {
+    it("does not downgrade on CANCELLATION", async () => {
       // A cancellation is a promise to leave at the end of the period. The
       // entitlement is still paid for until EXPIRATION says otherwise.
-      service.handleRevenueCatEvent({
+      await service.handleRevenueCatEvent({
         event: buildEvent({ type: "CANCELLATION" }),
       });
 
       expect(mockUpdateUserById).not.toHaveBeenCalled();
     });
 
-    it("downgrades on EXPIRATION", () => {
-      service.handleRevenueCatEvent({
+    it("downgrades on EXPIRATION", async () => {
+      await service.handleRevenueCatEvent({
         event: buildEvent({ type: "EXPIRATION" }),
       });
 
@@ -201,8 +212,8 @@ describe("PaymentService.handleRevenueCatEvent", () => {
       });
     });
 
-    it("upgrades on INITIAL_PURCHASE with the premium entitlement", () => {
-      service.handleRevenueCatEvent({
+    it("upgrades on INITIAL_PURCHASE with the premium entitlement", async () => {
+      await service.handleRevenueCatEvent({
         event: buildEvent({
           type: "INITIAL_PURCHASE",
           entitlement_ids: ["premium"],
@@ -214,8 +225,8 @@ describe("PaymentService.handleRevenueCatEvent", () => {
       });
     });
 
-    it("ignores anonymous purchasers", () => {
-      service.handleRevenueCatEvent({
+    it("ignores anonymous purchasers", async () => {
+      await service.handleRevenueCatEvent({
         event: buildEvent({
           type: "INITIAL_PURCHASE",
           app_user_id: "$RCAnonymousID:abc",

--- a/packages/api/src/services/payment-service.ts
+++ b/packages/api/src/services/payment-service.ts
@@ -22,6 +22,11 @@ import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { PlanType } from "@prisma/client";
 
 import { captureEvent } from "../shared/analytics";
+import {
+  findNonAnonymousUserIds,
+  isAnonymous,
+  SubscriptionEventService,
+} from "./subscription-event-service";
 import { UserService } from "./user-service";
 
 enum RevenueCatEntitlement {
@@ -30,11 +35,6 @@ enum RevenueCatEntitlement {
 
 type RevenueCatEvent = {
   event: Event;
-};
-
-const isAnonymous = (alias: string) => alias.startsWith("$RCAnonymousID:");
-const findNonAnonymousUserIds = (aliases: string[]): string[] => {
-  return aliases.filter((alias) => !isAnonymous(alias));
 };
 
 const getPlanByEntitlements = (entitlements: string[] | null) => {
@@ -105,7 +105,11 @@ const readSubscriptionFields = (event: Event) => {
 };
 
 class PaymentService {
-  handleRevenueCatEvent({ event }: RevenueCatEvent) {
+  async handleRevenueCatEvent({ event }: RevenueCatEvent) {
+    // Reporting only, and it swallows its own failures, so a broken
+    // subscription log can never cost a subscriber their entitlement.
+    await SubscriptionEventService.record({ event });
+
     const { app_user_id: userID, type } = event;
 
     // Every type, before the switch, including the nine this service ignores.

--- a/packages/api/src/services/subscription-event-service.test.ts
+++ b/packages/api/src/services/subscription-event-service.test.ts
@@ -105,6 +105,25 @@ describe("SubscriptionEventService log", () => {
     });
   });
 
+  it("keeps the subscriber's email out of the stored payload", async () => {
+    const subscriber = await seedSubscriber("attributes@pegada.app");
+
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.initialPurchase("evt_attributes", subscriber.id, {
+        subscriber_attributes: {
+          $email: { value: "attributes@pegada.app", updated_at_ms: 1 },
+        },
+      }),
+    });
+
+    const { raw } = await prisma.subscriptionEvent.findUniqueOrThrow({
+      where: { eventId: "evt_attributes" },
+    });
+
+    expect(raw).not.toHaveProperty("subscriber_attributes");
+    expect(raw).toMatchObject({ product_id: revenuecat.PRODUCT_ID });
+  });
+
   it("stores the cancel reason of a cancellation", async () => {
     const subscriber = await seedSubscriber("reason@pegada.app");
 

--- a/packages/api/src/services/subscription-event-service.test.ts
+++ b/packages/api/src/services/subscription-event-service.test.ts
@@ -1,0 +1,242 @@
+import type { Event } from "../types/revenuecat";
+
+import prisma from "@pegada/database";
+import { PlanType } from "@prisma/client";
+
+import { sendError } from "../errors/errors";
+import * as revenuecat from "./__fixtures__/revenuecat-events";
+import PaymentService from "./payment-service";
+
+// `errors.ts` pulls in `observability.ts` -> the ESM-only
+// `magic-observability/node`, which jest can't parse. Same mock the other
+// service suites use.
+jest.mock("../errors/errors", () => ({
+  sendError: jest.fn(),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
+const reportedError = jest.mocked(sendError);
+const paymentService = new PaymentService();
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.subscriptionEvent.deleteMany();
+  await prisma.uploadGrant.deleteMany();
+  await prisma.message.deleteMany();
+  await prisma.match.deleteMany();
+  await prisma.interest.deleteMany();
+  await prisma.image.deleteMany();
+  await prisma.dog.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+const seedSubscriber = (email: string, plan: PlanType = PlanType.PREMIUM) =>
+  prisma.user.create({ data: { email, plan } });
+
+/** One recorded payload per type the webhook can receive. */
+const everyEventType = (subscriberId: string, previousOwnerId: string) => [
+  revenuecat.trialStart("evt_trial_start", subscriberId),
+  revenuecat.initialPurchase("evt_initial_purchase", subscriberId),
+  revenuecat.renewal("evt_renewal", subscriberId),
+  revenuecat.trialConversion("evt_trial_conversion", subscriberId),
+  revenuecat.cancellation("evt_cancellation", subscriberId),
+  revenuecat.refund("evt_refund", subscriberId),
+  revenuecat.uncancellation("evt_uncancellation", subscriberId),
+  revenuecat.expiration("evt_expiration", subscriberId),
+  revenuecat.productChange("evt_product_change", subscriberId),
+  revenuecat.billingIssue("evt_billing_issue", subscriberId),
+  revenuecat.subscriptionPaused("evt_subscription_paused", subscriberId),
+  revenuecat.nonRenewingPurchase("evt_non_renewing", subscriberId),
+  revenuecat.transfer("evt_transfer", [previousOwnerId], [subscriberId]),
+  revenuecat.testEvent("evt_test"),
+];
+
+describe("SubscriptionEventService log", () => {
+  it("records exactly one row for every event type RevenueCat sends", async () => {
+    const [subscriber, previousOwner] = await Promise.all([
+      seedSubscriber("every-type@pegada.app"),
+      seedSubscriber("every-type-previous@pegada.app"),
+    ]);
+    const events = everyEventType(subscriber.id, previousOwner.id);
+
+    for (const event of events) {
+      // oxlint-disable-next-line no-await-in-loop -- The webhook delivers one event at a time, and a TRANSFER has to land after the purchase it moves.
+      await paymentService.handleRevenueCatEvent(
+        revenuecat.webhookPayload(event),
+      );
+    }
+
+    const recorded = await prisma.subscriptionEvent.findMany();
+
+    expect(recorded).toHaveLength(events.length);
+    expect(recorded.map((row) => row.eventId).sort()).toEqual(
+      events.map((event) => event.id).sort(),
+    );
+    expect(reportedError).not.toHaveBeenCalled();
+  });
+
+  it("stores the documented fields of a purchase and attributes it to the user", async () => {
+    const subscriber = await seedSubscriber("fields@pegada.app");
+
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.initialPurchase("evt_fields", subscriber.id),
+    });
+
+    await expect(
+      prisma.subscriptionEvent.findUniqueOrThrow({
+        where: { eventId: "evt_fields" },
+      }),
+    ).resolves.toMatchObject({
+      type: "INITIAL_PURCHASE",
+      userId: subscriber.id,
+      productId: revenuecat.PRODUCT_ID,
+      periodType: "NORMAL",
+      store: "APP_STORE",
+      environment: "PRODUCTION",
+      price: 19.9,
+      currency: "BRL",
+      purchasedAt: new Date(revenuecat.PURCHASED_AT_MS),
+      expirationAt: new Date(revenuecat.EXPIRATION_AT_MS),
+      raw: expect.objectContaining({ id: "evt_fields" }),
+    });
+  });
+
+  it("stores the cancel reason of a cancellation", async () => {
+    const subscriber = await seedSubscriber("reason@pegada.app");
+
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.refund("evt_reason", subscriber.id),
+    });
+
+    await expect(
+      prisma.subscriptionEvent.findUniqueOrThrow({
+        where: { eventId: "evt_reason" },
+      }),
+    ).resolves.toMatchObject({ cancelReason: "CUSTOMER_SUPPORT" });
+  });
+
+  it("does not write twice when RevenueCat retries the same event", async () => {
+    const subscriber = await seedSubscriber("retry@pegada.app");
+    const event = revenuecat.renewal("evt_retried", subscriber.id);
+
+    await paymentService.handleRevenueCatEvent({ event });
+    await expect(
+      paymentService.handleRevenueCatEvent({ event }),
+    ).resolves.not.toThrow();
+
+    await expect(
+      prisma.subscriptionEvent.count({ where: { eventId: "evt_retried" } }),
+    ).resolves.toBe(1);
+    expect(reportedError).not.toHaveBeenCalled();
+  });
+
+  it("leaves the row unattributed when the subscriber is anonymous", async () => {
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.trialStart(
+        "evt_anonymous",
+        "$RCAnonymousID:8f9a0b1c2d3e4f50",
+      ),
+    });
+
+    await expect(
+      prisma.subscriptionEvent.findUniqueOrThrow({
+        where: { eventId: "evt_anonymous" },
+      }),
+    ).resolves.toMatchObject({ userId: null, periodType: "TRIAL" });
+  });
+
+  it("still applies the plan change when the log write fails", async () => {
+    const subscriber = await seedSubscriber("log-down@pegada.app");
+    const upsert = jest
+      .spyOn(prisma.subscriptionEvent, "upsert")
+      .mockRejectedValue(new Error("subscription log unavailable"));
+
+    try {
+      await paymentService.handleRevenueCatEvent({
+        event: revenuecat.expiration("evt_log_down", subscriber.id),
+      });
+    } finally {
+      upsert.mockRestore();
+    }
+
+    await expect(
+      prisma.user.findUniqueOrThrow({ where: { id: subscriber.id } }),
+    ).resolves.toMatchObject({ plan: PlanType.FREE });
+    expect(reportedError).toHaveBeenCalled();
+  });
+});
+
+describe("SubscriptionEventService alongside the plan changes", () => {
+  it("keeps a cancelled subscriber on premium until the period ends", async () => {
+    const subscriber = await seedSubscriber("cancels@pegada.app");
+
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.cancellation("evt_cancels", subscriber.id),
+    });
+
+    await expect(
+      prisma.user.findUniqueOrThrow({ where: { id: subscriber.id } }),
+    ).resolves.toMatchObject({ plan: PlanType.PREMIUM });
+  });
+
+  it("downgrades to free once the subscription expires", async () => {
+    const subscriber = await seedSubscriber("expires@pegada.app");
+
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.expiration("evt_expires", subscriber.id),
+    });
+
+    await expect(
+      prisma.user.findUniqueOrThrow({ where: { id: subscriber.id } }),
+    ).resolves.toMatchObject({ plan: PlanType.FREE });
+  });
+});
+
+type EventBuilder = (id: string, appUserId: string) => Event;
+
+const paidThroughCases: [string, EventBuilder][] = [
+  ["purchase", revenuecat.initialPurchase],
+  ["renewal", revenuecat.renewal],
+  ["product-change", revenuecat.productChange],
+  ["uncancellation", revenuecat.uncancellation],
+];
+
+describe("SubscriptionEventService paid-through date", () => {
+  it.each(paidThroughCases)(
+    "records how long the subscriber is paid for after a %s",
+    async (label, buildEvent) => {
+      const subscriber = await seedSubscriber(
+        `paid-through-${label}@pegada.app`,
+        PlanType.FREE,
+      );
+
+      await paymentService.handleRevenueCatEvent({
+        event: buildEvent("evt_paid_through", subscriber.id),
+      });
+
+      await expect(
+        prisma.user.findUniqueOrThrow({ where: { id: subscriber.id } }),
+      ).resolves.toMatchObject({
+        premiumUntil: new Date(revenuecat.EXPIRATION_AT_MS),
+      });
+    },
+  );
+
+  it("leaves the paid-through date alone when the store sends no expiry", async () => {
+    const subscriber = await seedSubscriber("no-expiry@pegada.app");
+
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.renewal("evt_no_expiry", subscriber.id, {
+        expiration_at_ms: null,
+      }),
+    });
+
+    await expect(
+      prisma.user.findUniqueOrThrow({ where: { id: subscriber.id } }),
+    ).resolves.toMatchObject({ premiumUntil: null });
+  });
+});

--- a/packages/api/src/services/subscription-event-service.test.ts
+++ b/packages/api/src/services/subscription-event-service.test.ts
@@ -16,6 +16,13 @@ jest.mock("../errors/errors", () => ({
   errorDebug: () => undefined,
 }));
 
+// `payment-service.ts` also reports every webhook to product analytics, and
+// that module reaches `observability.ts` -> the ESM-only
+// `magic-observability/node` the same way `errors.ts` does.
+jest.mock("../shared/analytics", () => ({
+  captureEvent: jest.fn(),
+}));
+
 const reportedError = jest.mocked(sendError);
 const paymentService = new PaymentService();
 
@@ -97,8 +104,11 @@ describe("SubscriptionEventService log", () => {
       periodType: "NORMAL",
       store: "APP_STORE",
       environment: "PRODUCTION",
-      price: 19.9,
+      // What the subscriber paid, in their own currency, with RevenueCat's
+      // USD conversion kept in its own column.
+      price: revenuecat.PRICE_IN_CURRENCY,
       currency: "BRL",
+      priceUsd: revenuecat.PRICE_USD,
       purchasedAt: new Date(revenuecat.PURCHASED_AT_MS),
       expirationAt: new Date(revenuecat.EXPIRATION_AT_MS),
       raw: expect.objectContaining({ id: "evt_fields" }),
@@ -122,6 +132,20 @@ describe("SubscriptionEventService log", () => {
 
     expect(raw).not.toHaveProperty("subscriber_attributes");
     expect(raw).toMatchObject({ product_id: revenuecat.PRODUCT_ID });
+  });
+
+  it("stores the amount paid in the subscriber's currency, not the USD one", async () => {
+    const subscriber = await seedSubscriber("currency@pegada.app");
+
+    await paymentService.handleRevenueCatEvent({
+      event: revenuecat.initialPurchase("evt_currency", subscriber.id),
+    });
+
+    await expect(
+      prisma.subscriptionEvent.findUniqueOrThrow({
+        where: { eventId: "evt_currency" },
+      }),
+    ).resolves.toMatchObject({ price: 19.9, currency: "BRL", priceUsd: 3.99 });
   });
 
   it("stores the cancel reason of a cancellation", async () => {

--- a/packages/api/src/services/subscription-event-service.ts
+++ b/packages/api/src/services/subscription-event-service.ts
@@ -45,6 +45,19 @@ const toDate = (milliseconds: number | null | undefined) =>
   milliseconds ? new Date(milliseconds) : null;
 
 /**
+ * The whole event minus `subscriber_attributes`, which carries the email the
+ * app pushes to RevenueCat through `setEmail`. We already hold that address on
+ * `User`, and none of the churn numbers read it, so copying it into a second
+ * table would only spread the same personal data over more rows.
+ */
+const toStoredPayload = (event: Event): Prisma.InputJsonValue => {
+  const { subscriber_attributes: _attributes, ...rest } = event as Event &
+    LoggableEvent;
+
+  return rest as unknown as Prisma.InputJsonValue;
+};
+
+/**
  * The reporting half of the RevenueCat webhook. Nothing in here decides
  * whether a subscriber has premium, so nothing in here is allowed to throw:
  * `record` catches everything and reports it, leaving the plan mutation in
@@ -88,7 +101,7 @@ export class SubscriptionEventService {
           cancelReason:
             fields.cancel_reason ?? fields.expiration_reason ?? null,
           environment: event.environment,
-          raw: event as unknown as Prisma.InputJsonValue,
+          raw: toStoredPayload(event),
         },
       });
     } catch (error) {

--- a/packages/api/src/services/subscription-event-service.ts
+++ b/packages/api/src/services/subscription-event-service.ts
@@ -1,0 +1,145 @@
+import type {
+  Event,
+  EventCancellation,
+  EventExpiration,
+  SubscriptionLifecycleEvent,
+} from "../types/revenuecat";
+import type { Prisma } from "@prisma/client";
+
+import prisma from "@pegada/database";
+
+import { sendError } from "../errors/errors";
+import { UserService } from "./user-service";
+
+export const isAnonymous = (alias: string) =>
+  alias.startsWith("$RCAnonymousID:");
+
+export const findNonAnonymousUserIds = (aliases: string[]): string[] => {
+  return aliases.filter((alias) => !isAnonymous(alias));
+};
+
+/**
+ * Event types after which the store has told us how long the subscriber is
+ * paid through. `plan` stays the entitlement source of truth; `premiumUntil`
+ * only records the date, so churn reporting can see a renewal coming.
+ */
+const PAID_THROUGH_EVENT_TYPES = new Set([
+  "INITIAL_PURCHASE",
+  "RENEWAL",
+  "PRODUCT_CHANGE",
+  "UNCANCELLATION",
+]);
+
+/**
+ * TEST and TRANSFER events carry none of the subscription fields, and
+ * `cancel_reason` and `expiration_reason` each live on one type only, so the
+ * union has to be widened before the log can read whatever happens to be
+ * there. Every field is optional on purpose: a type RevenueCat adds later is
+ * recorded with whatever it sends instead of crashing the webhook.
+ */
+type LoggableEvent = Partial<SubscriptionLifecycleEvent> &
+  Partial<Pick<EventCancellation, "cancel_reason">> &
+  Partial<Pick<EventExpiration, "expiration_reason">>;
+
+const toDate = (milliseconds: number | null | undefined) =>
+  milliseconds ? new Date(milliseconds) : null;
+
+/**
+ * The reporting half of the RevenueCat webhook. Nothing in here decides
+ * whether a subscriber has premium, so nothing in here is allowed to throw:
+ * `record` catches everything and reports it, leaving the plan mutation in
+ * `PaymentService` to run either way.
+ */
+export class SubscriptionEventService {
+  static async record({ event }: { event: Event }) {
+    await SubscriptionEventService.append(event);
+    await SubscriptionEventService.syncPaidThrough(event);
+  }
+
+  /**
+   * Appends every webhook event, including the ones that change nothing, so
+   * trial conversion, churn and refunds can be counted against our own users.
+   * Keyed on the RevenueCat event id, so the retries RevenueCat sends after a
+   * timeout land on the same row instead of inflating the counts.
+   */
+  private static async append(event: Event) {
+    try {
+      const fields = event as LoggableEvent;
+
+      await prisma.subscriptionEvent.upsert({
+        where: { eventId: event.id },
+        // Already recorded: the first delivery won, nothing to change.
+        update: {},
+        create: {
+          eventId: event.id,
+          type: event.type,
+          userId: await SubscriptionEventService.resolveUserId(event),
+          productId: fields.product_id ?? null,
+          periodType: fields.period_type ?? null,
+          store: event.store,
+          // `price` is null on stores that do not report it, and RevenueCat
+          // documents `price_in_purchased_currency` as the fallback.
+          price: fields.price ?? fields.price_in_purchased_currency ?? null,
+          currency: fields.currency ?? null,
+          purchasedAt: toDate(fields.purchased_at_ms),
+          expirationAt: toDate(fields.expiration_at_ms),
+          // CANCELLATION carries `cancel_reason`, EXPIRATION carries
+          // `expiration_reason`; both answer the same question.
+          cancelReason:
+            fields.cancel_reason ?? fields.expiration_reason ?? null,
+          environment: event.environment,
+          raw: event as unknown as Prisma.InputJsonValue,
+        },
+      });
+    } catch (error) {
+      sendError(error, {
+        scope: "subscription-event-service.append",
+        revenueCatEventId: event.id,
+        revenueCatEventType: event.type,
+      });
+    }
+  }
+
+  /**
+   * The webhook identifies subscribers by our own user id, so the mapping is
+   * an existence check. Anonymous and unknown ids still get a row, just an
+   * unattributed one, because the aggregate counts still matter.
+   */
+  private static async resolveUserId(event: Event) {
+    // A TRANSFER names no `app_user_id`; the account that ends up holding the
+    // subscription is the one the event belongs to.
+    const candidate =
+      event.type === "TRANSFER"
+        ? findNonAnonymousUserIds(event.transferred_to)[0]
+        : event.app_user_id;
+
+    if (!candidate || isAnonymous(candidate)) return null;
+
+    const user = await prisma.user.findUnique({
+      where: { id: candidate },
+      select: { id: true },
+    });
+
+    return user?.id ?? null;
+  }
+
+  private static async syncPaidThrough(event: Event) {
+    try {
+      if (!PAID_THROUGH_EVENT_TYPES.has(event.type)) return;
+
+      const { expiration_at_ms: expirationAtMs } = event as LoggableEvent;
+      const paidThrough = toDate(expirationAtMs);
+      const userID = event.app_user_id;
+
+      if (!paidThrough || !userID || isAnonymous(userID)) return;
+
+      await UserService.updateUserById(userID, { premiumUntil: paidThrough });
+    } catch (error) {
+      sendError(error, {
+        scope: "subscription-event-service.syncPaidThrough",
+        revenueCatEventId: event.id,
+        revenueCatEventType: event.type,
+      });
+    }
+  }
+}

--- a/packages/api/src/services/subscription-event-service.ts
+++ b/packages/api/src/services/subscription-event-service.ts
@@ -90,10 +90,13 @@ export class SubscriptionEventService {
           productId: fields.product_id ?? null,
           periodType: fields.period_type ?? null,
           store: event.store,
-          // `price` is null on stores that do not report it, and RevenueCat
-          // documents `price_in_purchased_currency` as the fallback.
-          price: fields.price ?? fields.price_in_purchased_currency ?? null,
+          // RevenueCat's `price` is always USD; `price_in_purchased_currency`
+          // is the amount in `currency`. Storing the USD number next to a BRL
+          // currency code would make every revenue query wrong by the
+          // exchange rate.
+          price: fields.price_in_purchased_currency ?? null,
           currency: fields.currency ?? null,
+          priceUsd: fields.price ?? null,
           purchasedAt: toDate(fields.purchased_at_ms),
           expirationAt: toDate(fields.expiration_at_ms),
           // CANCELLATION carries `cancel_reason`, EXPIRATION carries

--- a/packages/api/src/services/subscription-metrics-service.test.ts
+++ b/packages/api/src/services/subscription-metrics-service.test.ts
@@ -116,6 +116,21 @@ describe("getSubscriptionMetrics", () => {
     ).resolves.toMatchObject({ trialStarts: 2 });
   });
 
+  it("still counts an event that arrived without an environment", async () => {
+    await prisma.subscriptionEvent.create({
+      data: {
+        eventId: "evt_no_environment",
+        type: "EXPIRATION",
+        environment: null,
+        raw: {},
+      },
+    });
+
+    await expect(getSubscriptionMetrics(wholeWindow)).resolves.toMatchObject({
+      expirations: 1,
+    });
+  });
+
   it("returns zeroes when nothing happened", async () => {
     await expect(getSubscriptionMetrics(wholeWindow)).resolves.toEqual({
       trialStarts: 0,

--- a/packages/api/src/services/subscription-metrics-service.test.ts
+++ b/packages/api/src/services/subscription-metrics-service.test.ts
@@ -1,0 +1,129 @@
+import type { Event } from "../types/revenuecat";
+
+import prisma from "@pegada/database";
+import { PlanType } from "@prisma/client";
+
+import * as revenuecat from "./__fixtures__/revenuecat-events";
+import PaymentService from "./payment-service";
+import { getSubscriptionMetrics } from "./subscription-metrics-service";
+
+jest.mock("../errors/errors", () => ({
+  sendError: jest.fn(),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
+const paymentService = new PaymentService();
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.subscriptionEvent.deleteMany();
+  await prisma.uploadGrant.deleteMany();
+  await prisma.message.deleteMany();
+  await prisma.match.deleteMany();
+  await prisma.interest.deleteMany();
+  await prisma.image.deleteMany();
+  await prisma.dog.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+const ingest = async (events: Event[]) => {
+  for (const event of events) {
+    // oxlint-disable-next-line no-await-in-loop -- The webhook delivers one event at a time, and the counts depend on that order.
+    await paymentService.handleRevenueCatEvent({ event });
+  }
+};
+
+/** Wide enough that everything the suite ingests falls inside it. */
+const wholeWindow = {
+  from: new Date(Date.now() - 60 * 60 * 1000),
+  to: new Date(Date.now() + 60 * 60 * 1000),
+};
+
+describe("getSubscriptionMetrics", () => {
+  it("counts the lifecycle of a mixed month", async () => {
+    const subscriber = await prisma.user.create({
+      data: { email: "metrics@pegada.app", plan: PlanType.PREMIUM },
+    });
+
+    await ingest([
+      revenuecat.trialStart("evt_trial_1", subscriber.id),
+      revenuecat.trialStart("evt_trial_2", subscriber.id),
+      revenuecat.trialStart("evt_trial_3", subscriber.id),
+      revenuecat.trialConversion("evt_conversion_1", subscriber.id),
+      revenuecat.trialConversion("evt_conversion_2", subscriber.id),
+      revenuecat.renewal("evt_renewal_1", subscriber.id),
+      revenuecat.cancellation("evt_cancellation_1", subscriber.id),
+      revenuecat.cancellation("evt_cancellation_2", subscriber.id),
+      revenuecat.refund("evt_refund_1", subscriber.id),
+      revenuecat.expiration("evt_expiration_1", subscriber.id),
+      // Neither of these belongs in any of the six counts.
+      revenuecat.billingIssue("evt_billing_1", subscriber.id),
+      revenuecat.testEvent("evt_test_1"),
+    ]);
+
+    await expect(getSubscriptionMetrics(wholeWindow)).resolves.toEqual({
+      trialStarts: 3,
+      // The two conversions are NORMAL renewals too, so they are counted in
+      // `renewals` as well as here.
+      trialConversions: 2,
+      renewals: 3,
+      cancellations: 2,
+      expirations: 1,
+      refunds: 1,
+    });
+  });
+
+  it("leaves out events from outside the window", async () => {
+    const subscriber = await prisma.user.create({
+      data: { email: "window@pegada.app" },
+    });
+
+    await ingest([revenuecat.trialStart("evt_outside", subscriber.id)]);
+
+    const lastMonth = {
+      from: new Date("2026-07-01T00:00:00.000Z"),
+      to: new Date("2026-07-31T23:59:59.999Z"),
+    };
+
+    await expect(getSubscriptionMetrics(lastMonth)).resolves.toMatchObject({
+      trialStarts: 0,
+      renewals: 0,
+    });
+  });
+
+  it("leaves out sandbox events unless they are asked for", async () => {
+    const subscriber = await prisma.user.create({
+      data: { email: "sandbox@pegada.app" },
+    });
+
+    await ingest([
+      revenuecat.initialPurchase("evt_sandbox", subscriber.id, {
+        period_type: "TRIAL",
+        environment: "SANDBOX",
+      }),
+      revenuecat.trialStart("evt_production", subscriber.id),
+    ]);
+
+    await expect(getSubscriptionMetrics(wholeWindow)).resolves.toMatchObject({
+      trialStarts: 1,
+    });
+    await expect(
+      getSubscriptionMetrics({ ...wholeWindow, includeSandbox: true }),
+    ).resolves.toMatchObject({ trialStarts: 2 });
+  });
+
+  it("returns zeroes when nothing happened", async () => {
+    await expect(getSubscriptionMetrics(wholeWindow)).resolves.toEqual({
+      trialStarts: 0,
+      trialConversions: 0,
+      renewals: 0,
+      cancellations: 0,
+      expirations: 0,
+      refunds: 0,
+    });
+  });
+});

--- a/packages/api/src/services/subscription-metrics-service.test.ts
+++ b/packages/api/src/services/subscription-metrics-service.test.ts
@@ -13,6 +13,13 @@ jest.mock("../errors/errors", () => ({
   errorDebug: () => undefined,
 }));
 
+// `payment-service.ts` also reports every webhook to product analytics, and
+// that module reaches `observability.ts` -> the ESM-only
+// `magic-observability/node` the same way `errors.ts` does.
+jest.mock("../shared/analytics", () => ({
+  captureEvent: jest.fn(),
+}));
+
 const paymentService = new PaymentService();
 
 afterAll(async () => {
@@ -56,6 +63,14 @@ describe("getSubscriptionMetrics", () => {
       revenuecat.trialConversion("evt_conversion_1", subscriber.id),
       revenuecat.trialConversion("evt_conversion_2", subscriber.id),
       revenuecat.renewal("evt_renewal_1", subscriber.id),
+      // An intro price is still a paying renewal.
+      revenuecat.renewal("evt_renewal_intro", subscriber.id, {
+        period_type: "INTRO",
+      }),
+      // A renewal into another trial period is not.
+      revenuecat.renewal("evt_renewal_trial", subscriber.id, {
+        period_type: "TRIAL",
+      }),
       revenuecat.cancellation("evt_cancellation_1", subscriber.id),
       revenuecat.cancellation("evt_cancellation_2", subscriber.id),
       revenuecat.refund("evt_refund_1", subscriber.id),
@@ -67,10 +82,12 @@ describe("getSubscriptionMetrics", () => {
 
     await expect(getSubscriptionMetrics(wholeWindow)).resolves.toEqual({
       trialStarts: 3,
-      // The two conversions are NORMAL renewals too, so they are counted in
+      // The two conversions bill the subscriber, so they are counted in
       // `renewals` as well as here.
       trialConversions: 2,
-      renewals: 3,
+      // Two conversions, one normal renewal and one intro renewal. The
+      // renewal into another trial period is not money in.
+      renewals: 4,
       cancellations: 2,
       expirations: 1,
       refunds: 1,

--- a/packages/api/src/services/subscription-metrics-service.ts
+++ b/packages/api/src/services/subscription-metrics-service.ts
@@ -46,14 +46,20 @@ export const getSubscriptionMetrics = async ({
   // `purchasedAt`. A CANCELLATION carries the *original* purchase date, so
   // filtering on it would file this month's cancellation under the month the
   // subscriber first paid.
-  const window = { createdAt: { gte: from, lte: to } };
-  // `not` on a nullable column drops the null rows in SQL, and the column is
-  // nullable so an event type RevenueCat invents later still gets recorded.
-  // Spelling the null case out keeps those rows in the production counts.
-  const environment = includeSandbox
-    ? {}
-    : { OR: [{ environment: { not: "SANDBOX" } }, { environment: null }] };
-  const scope = { ...window, ...environment };
+  // `not` on a nullable column drops the null rows in SQL, and both columns
+  // are nullable so an event type RevenueCat invents later still gets
+  // recorded. Spelling the null case out keeps those rows in the counts.
+  const notSandbox = {
+    OR: [{ environment: { not: "SANDBOX" } }, { environment: null }],
+  };
+  const outsideATrial = {
+    OR: [{ periodType: { not: "TRIAL" } }, { periodType: null }],
+  };
+
+  const scope = {
+    createdAt: { gte: from, lte: to },
+    AND: includeSandbox ? [] : [notSandbox],
+  };
 
   const [
     trialStarts,
@@ -78,7 +84,9 @@ export const getSubscriptionMetrics = async ({
       },
     }),
     prisma.subscriptionEvent.count({
-      where: { ...scope, type: "RENEWAL", periodType: "NORMAL" },
+      // Every renewal that is not another free trial period is money in:
+      // INTRO, PROMOTIONAL and PREPAID all bill the subscriber.
+      where: { ...scope, type: "RENEWAL", ...outsideATrial },
     }),
     prisma.subscriptionEvent.count({
       where: { ...scope, type: "EXPIRATION" },
@@ -97,7 +105,7 @@ export const getSubscriptionMetrics = async ({
 
   return {
     trialStarts,
-    // A subset of `renewals`: a converting renewal is also a NORMAL renewal.
+    // A subset of `renewals`: a converting renewal bills the subscriber too.
     trialConversions,
     renewals,
     cancellations: allCancellations - refunds,

--- a/packages/api/src/services/subscription-metrics-service.ts
+++ b/packages/api/src/services/subscription-metrics-service.ts
@@ -47,7 +47,12 @@ export const getSubscriptionMetrics = async ({
   // filtering on it would file this month's cancellation under the month the
   // subscriber first paid.
   const window = { createdAt: { gte: from, lte: to } };
-  const environment = includeSandbox ? {} : { NOT: { environment: "SANDBOX" } };
+  // `not` on a nullable column drops the null rows in SQL, and the column is
+  // nullable so an event type RevenueCat invents later still gets recorded.
+  // Spelling the null case out keeps those rows in the production counts.
+  const environment = includeSandbox
+    ? {}
+    : { OR: [{ environment: { not: "SANDBOX" } }, { environment: null }] };
   const scope = { ...window, ...environment };
 
   const [

--- a/packages/api/src/services/subscription-metrics-service.ts
+++ b/packages/api/src/services/subscription-metrics-service.ts
@@ -1,0 +1,102 @@
+import prisma from "@pegada/database";
+
+/**
+ * The only `cancel_reason` RevenueCat documents as money going back: "Customer
+ * received a refund from Apple support, a Google Play subscription was
+ * refunded through RevenueCat, an Amazon subscription was refunded through
+ * Amazon support, or a web subscription was refunded." Every other reason,
+ * `UNSUBSCRIBE` above all, is a subscriber turning auto renew off and keeping
+ * access until the period ends, which is a cancellation and not a refund.
+ * https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields
+ */
+const REFUND_CANCEL_REASONS = ["CUSTOMER_SUPPORT"];
+
+export type SubscriptionMetrics = {
+  trialStarts: number;
+  trialConversions: number;
+  renewals: number;
+  cancellations: number;
+  expirations: number;
+  refunds: number;
+};
+
+export type SubscriptionMetricsOptions = {
+  from: Date;
+  to: Date;
+  /**
+   * Sandbox events come from our own devices and from store review, so they
+   * are out of the numbers unless someone is deliberately checking the
+   * pipeline works end to end.
+   */
+  includeSandbox?: boolean;
+};
+
+/**
+ * Counts the subscription lifecycle for a window, from the events the
+ * RevenueCat webhook has been appending. Answers the M2 questions the
+ * RevenueCat dashboard cannot: how many trials we start, how many of them pay,
+ * and how the paid ones end.
+ */
+export const getSubscriptionMetrics = async ({
+  from,
+  to,
+  includeSandbox = false,
+}: SubscriptionMetricsOptions): Promise<SubscriptionMetrics> => {
+  // The window is on `createdAt`, the moment the webhook reached us, not on
+  // `purchasedAt`. A CANCELLATION carries the *original* purchase date, so
+  // filtering on it would file this month's cancellation under the month the
+  // subscriber first paid.
+  const window = { createdAt: { gte: from, lte: to } };
+  const environment = includeSandbox ? {} : { NOT: { environment: "SANDBOX" } };
+  const scope = { ...window, ...environment };
+
+  const [
+    trialStarts,
+    trialConversions,
+    renewals,
+    expirations,
+    refunds,
+    allCancellations,
+  ] = await Promise.all([
+    prisma.subscriptionEvent.count({
+      where: { ...scope, type: "INITIAL_PURCHASE", periodType: "TRIAL" },
+    }),
+    prisma.subscriptionEvent.count({
+      where: {
+        ...scope,
+        type: "RENEWAL",
+        // RevenueCat's documented conversion signal: `is_trial_conversion` is
+        // "whether the previous period was a free trial", and it is sent on
+        // RENEWAL only. Comparing period types across a user's own history
+        // would miss the subscribers who trialled before we started logging.
+        raw: { path: ["is_trial_conversion"], equals: true },
+      },
+    }),
+    prisma.subscriptionEvent.count({
+      where: { ...scope, type: "RENEWAL", periodType: "NORMAL" },
+    }),
+    prisma.subscriptionEvent.count({
+      where: { ...scope, type: "EXPIRATION" },
+    }),
+    prisma.subscriptionEvent.count({
+      where: {
+        ...scope,
+        type: "CANCELLATION",
+        cancelReason: { in: REFUND_CANCEL_REASONS },
+      },
+    }),
+    prisma.subscriptionEvent.count({
+      where: { ...scope, type: "CANCELLATION" },
+    }),
+  ]);
+
+  return {
+    trialStarts,
+    // A subset of `renewals`: a converting renewal is also a NORMAL renewal.
+    trialConversions,
+    renewals,
+    cancellations: allCancellations - refunds,
+    expirations,
+    refunds,
+  };
+};

--- a/packages/api/src/types/revenuecat.ts
+++ b/packages/api/src/types/revenuecat.ts
@@ -85,7 +85,6 @@ export type EventInitialPurchase = {
 export type EventRenewal = {
   type: "RENEWAL";
   is_trial_conversion: boolean;
-  grace_period_expiration_at_ms: number;
 } & SubscriptionLifecycleEvent;
 
 export type EventCancellation = {

--- a/packages/database/migrations/20260901120000_add_subscription_events/migration.sql
+++ b/packages/database/migrations/20260901120000_add_subscription_events/migration.sql
@@ -10,6 +10,7 @@ CREATE TABLE "SubscriptionEvent" (
   "store" TEXT,
   "price" DOUBLE PRECISION,
   "currency" TEXT,
+  "priceUsd" DOUBLE PRECISION,
   "purchasedAt" TIMESTAMP(3),
   "expirationAt" TIMESTAMP(3),
   "cancelReason" TEXT,

--- a/packages/database/migrations/20260901120000_add_subscription_events/migration.sql
+++ b/packages/database/migrations/20260901120000_add_subscription_events/migration.sql
@@ -1,0 +1,33 @@
+ALTER TABLE "User" ADD COLUMN "premiumUntil" TIMESTAMP(3);
+
+CREATE TABLE "SubscriptionEvent" (
+  "id" TEXT NOT NULL,
+  "eventId" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "userId" TEXT,
+  "productId" TEXT,
+  "periodType" TEXT,
+  "store" TEXT,
+  "price" DOUBLE PRECISION,
+  "currency" TEXT,
+  "purchasedAt" TIMESTAMP(3),
+  "expirationAt" TIMESTAMP(3),
+  "cancelReason" TEXT,
+  "environment" TEXT,
+  "raw" JSONB NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "SubscriptionEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "SubscriptionEvent_eventId_key"
+ON "SubscriptionEvent"("eventId");
+
+CREATE INDEX "SubscriptionEvent_userId_idx"
+ON "SubscriptionEvent"("userId");
+
+CREATE INDEX "SubscriptionEvent_type_purchasedAt_idx"
+ON "SubscriptionEvent"("type", "purchasedAt");
+
+CREATE INDEX "SubscriptionEvent_purchasedAt_idx"
+ON "SubscriptionEvent"("purchasedAt");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -112,8 +112,15 @@ model SubscriptionEvent {
   periodType String?
   store      String?
 
+  /// What the subscriber actually paid, in `currency`. RevenueCat sends this
+  /// as `price_in_purchased_currency`.
   price    Float?
+  /// The currency `price` is denominated in.
   currency String?
+  /// The same transaction converted to USD, which is what RevenueCat's own
+  /// `price` field holds. Kept apart so revenue can be summed across
+  /// currencies without a conversion table.
+  priceUsd Float?
 
   purchasedAt  DateTime?
   expirationAt DateTime?
@@ -123,8 +130,9 @@ model SubscriptionEvent {
   /// SANDBOX or PRODUCTION.
   environment  String?
 
-  /// The untouched event object, so a metric we did not think of can still be
-  /// recomputed from history.
+  /// The event object with `subscriber_attributes` stripped, so a metric we
+  /// did not think of can still be recomputed from history without copying
+  /// subscriber emails into a second table.
   raw Json
 
   createdAt DateTime @default(now())

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -79,10 +79,59 @@ model User {
 
   // Plan
   plan PlanType @default(FREE)
+  // Latest paid-through date reported by the store. `plan` stays the
+  // entitlement source of truth; this is only for churn reporting.
+  premiumUntil DateTime?
+
+  subscriptionEvents SubscriptionEvent[]
 
   @@index([latitude])
   @@index([longitude])
   @@index([lastActiveAt])
+}
+
+/// Append-only log of every RevenueCat webhook event, so trial conversion,
+/// churn and refunds can be measured against our own users instead of the
+/// RevenueCat dashboard, which cannot be joined to this database.
+model SubscriptionEvent {
+  id String @id @default(cuid())
+
+  /// RevenueCat `event.id`. Unique so webhook retries are idempotent.
+  eventId String @unique
+
+  /// The RevenueCat event type, kept as a string so a new type RevenueCat
+  /// starts sending is recorded instead of rejected.
+  type String
+
+  user   User?   @relation(fields: [userId], references: [id])
+  /// Null when the event carries an anonymous or unknown `app_user_id`.
+  userId String?
+
+  productId  String?
+  /// TRIAL, INTRO, NORMAL, PROMOTIONAL or PREPAID.
+  periodType String?
+  store      String?
+
+  price    Float?
+  currency String?
+
+  purchasedAt  DateTime?
+  expirationAt DateTime?
+
+  /// `cancel_reason` on CANCELLATION, `expiration_reason` on EXPIRATION.
+  cancelReason String?
+  /// SANDBOX or PRODUCTION.
+  environment  String?
+
+  /// The untouched event object, so a metric we did not think of can still be
+  /// recomputed from history.
+  raw Json
+
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@index([type, purchasedAt])
+  @@index([purchasedAt])
 }
 
 model Dog {


### PR DESCRIPTION
## Summary

Records every RevenueCat webhook event in our own database, so trial conversion, churn and refunds can be measured against our users instead of read off a dashboard we cannot join to anything. Closes #194.

## Details

- New `SubscriptionEvent` table keyed on the RevenueCat event id, so the retries RevenueCat sends after a timeout land on the same row instead of inflating the counts. Migration included.
- The webhook now logs every event type it receives, including the ones that change nothing today, and keeps the payload in a `raw` column so a metric we did not think of can still be recomputed from history. `subscriber_attributes` is stripped from it, because the app pushes the subscriber's email to RevenueCat and we already hold that address on the user record.
- `User.premiumUntil` records the paid through date the store reports on a purchase, a renewal, a product change and an uncancellation.
- Entitlements are untouched. `User.plan` still moves on exactly the same events as before, a cancellation still leaves a subscriber on premium, and only an expiration downgrades.
- Logging can never cost a subscriber their entitlement. A failed write is reported and the plan change runs anyway, which is covered by a test.
- `getSubscriptionMetrics({ from, to })` counts trial starts, trial conversions, renewals, cancellations, expirations and refunds for a window, leaving sandbox events out unless they are asked for. Renewals count every period that bills the subscriber, so an intro or promotional price is money in and a renewal into another trial period is not.
- `pnpm api metrics:subscriptions --from 2026-09-01 --to 2026-09-30` prints those counts as JSON. Without the flags it reports the last 30 days.
- The amount the subscriber paid is stored in their own currency, with RevenueCat's USD conversion kept in a separate column, so revenue can be summed across currencies without reading a BRL total as dollars.
- Trial conversion uses RevenueCat's documented `is_trial_conversion` flag, and refunds use `CUSTOMER_SUPPORT`, the one cancel reason RevenueCat documents as money going back. Both are cited in the code.
- Complements #213, which sends the same events to PostHog; this PR is the durable, idempotent record in our database that the churn and trial conversion readout is computed from.

- Removing the free trial from the stores is a dashboard change that has to be made by hand, and this PR does not do it. In App Store Connect, open the premium subscription and remove the introductory offer on the product.
- In Google Play Console, open the subscription, edit the base plan offer and delete the free trial phase. Deactivate the offer if the trial is the only phase it carries.
- In RevenueCat, point the offering package at the product or base plan without the trial, and confirm the current offering serves it before the next release.
- Until all three are done the stores can still return an intro price. The app does not advertise a trial either way, and the `periodType` recorded here keeps the trial and paid counts correct while both states exist.

## Metric

- Hypothesis: this is instrumentation. It does not move a number on its own, it establishes the baseline every M2 pricing decision depends on: trial to paid conversion, 30 day churn and the lag between a cancellation and the expiration that follows it.
- Baseline: none in our database. The only source today is the RevenueCat dashboard, which cannot be joined to our users or to PostHog. The first 30 days of webhook events after release become the baseline.
- Readout: `pnpm api metrics:subscriptions --from <first day> --to <last day>` run monthly, which calls `getSubscriptionMetrics({ from, to })` and prints the counts as JSON. SQL fallback is a count of `SubscriptionEvent` grouped by `type` and `periodType` for the window, plus `cancelReason` for cancellations and refunds. Trial conversion is the renewals flagged as trial conversions divided by the trial starts.

## Testing steps

1. Nothing changes for anyone using the app. Subscribing, renewing, cancelling and letting a subscription lapse behave exactly as they did before.
2. Cancel a subscription and confirm premium is still there. It should only go away when the paid period actually ends.
3. Resubscribe and confirm premium comes back immediately.
4. After a month of live traffic, run the monthly subscription metrics report for that month (command in the Metric section above) and compare the trial, renewal, cancellation and refund counts against the RevenueCat dashboard for the same period.

## Screenshots

Not applicable, server only.


