### PR TITLE
feat(mobile): paywall without free trial, yearly first

### DIFF
--- a/apps/mobile/src/components/LikeLimitReached/index.tsx
+++ b/apps/mobile/src/components/LikeLimitReached/index.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/components/LikeLimitReached/use-countdown";
 import { CloseIcon, styles as pickerStyles } from "@/components/Picker/styles";
 import { Text } from "@/components/text";
-import { useEligibleForTrial } from "@/hooks/use-payments";
 import { analytics } from "@/services/analytics";
 import { SceneName } from "@/types/scene-name";
 
@@ -34,8 +33,6 @@ const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
   const { t } = useTranslation();
   const router = useRouter();
   const { hide } = useMagicModal();
-
-  const isEligibleForTrial = useEligibleForTrial();
 
   useEffect(() => {
     // Hide the modal when the time is up
@@ -74,9 +71,7 @@ const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
           }, 150);
         }}
       >
-        {isEligibleForTrial
-          ? t("likeLimit.winFreeTrial")
-          : t("likeLimit.getPremium")}
+        {t("likeLimit.getPremium")}
       </OkButton>
       <PinnedCloseButton
         onPress={() => hide()}

--- a/apps/mobile/src/hooks/use-payments.tsx
+++ b/apps/mobile/src/hooks/use-payments.tsx
@@ -1,4 +1,4 @@
-import type { CustomerInfo, PurchasesPackage } from "react-native-purchases";
+import type { CustomerInfo } from "react-native-purchases";
 
 import { useEffect } from "react";
 
@@ -19,19 +19,6 @@ const usePaymentsLogin = () => {
     refetchOnWindowFocus: false,
     staleTime: Infinity,
   });
-};
-
-export const useEligibleForTrial = ({
-  offering,
-}: {
-  offering?: PurchasesPackage | null | undefined;
-} = {}) => {
-  const customerInfo = useCustomerInfo();
-
-  const hasIntroPrice = offering?.product.introPrice;
-  const hadPremium = customerInfo.data?.entitlements.all.premium;
-
-  return hasIntroPrice && !hadPremium;
 };
 
 export const useCustomerInfo = () => {

--- a/apps/mobile/src/services/linking/handlers/notification.ts
+++ b/apps/mobile/src/services/linking/handlers/notification.ts
@@ -8,6 +8,7 @@ import { SceneName } from "@/types/scene-name";
 enum NotificationUrl {
   Match = "match/",
   Chat = "chat/",
+  Like = "like",
 }
 
 export const getNotificationUrl = (
@@ -34,6 +35,14 @@ const handleChatNotification = (matchId: string, dogId: string) => {
   });
 };
 
+/**
+ * A received like has no screen of its own: the dog that liked us stays hidden
+ * until we like them back, so the tap lands on the deck where that can happen.
+ */
+const handleLikeNotification = () => {
+  return router.push(SceneName.Swipe);
+};
+
 export const customNotificationHandler = (url?: string) => {
   if (!url) return;
 
@@ -44,6 +53,10 @@ export const customNotificationHandler = (url?: string) => {
     if (!matchId || !dogId) throw new Error("Invalid notification url");
 
     return handleMatchNotification(matchId, dogId);
+  }
+
+  if (url === NotificationUrl.Like) {
+    return handleLikeNotification();
   }
 
   if (url.startsWith(NotificationUrl.Chat)) {

--- a/apps/mobile/src/services/payments/index.ts
+++ b/apps/mobile/src/services/payments/index.ts
@@ -107,7 +107,7 @@ const logIn = async () => {
 
 /**
  * Synthesizes a `PurchasesOffering` shape sufficient for the upgrade-wall UI
- * (PlanPackages + PlanCard + useEligibleForTrial). Only the fields the React
+ * (PlanPackages + PlanCard). Only the fields the React
  * tree actually reads are populated — anything else stays undefined and is
  * cast through `unknown` because the full RC type has ~40 fields most of
  * which the mobile never touches.
@@ -304,7 +304,7 @@ const maestroMockPurchase = async (pkg: PurchasesPackage) => {
   await trpc.client.payment.maestroGrantPremium.mutate();
 
   // Synthesize the minimum shape consumers (useCustomerPlan, getPlan,
-  // useEligibleForTrial, the upgrade-wall analytics) read from
+  // the upgrade-wall analytics) read from
   // CustomerInfo. The full RC type has ~30 fields; only entitlements is
   // load-bearing for the UI under test.
   const now = new Date();

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/index.tsx
@@ -15,31 +15,7 @@ import { styles as planPackagesStyles } from "@/views/UpgradeWall/components/Pla
 
 import { PlanCard } from "./plan-card";
 
-const periodToDays = (period: string | null | undefined) => {
-  if (!period) return 0;
-
-  const match = period.match(/P(\d+)(D|W|M|Y)/);
-  if (!match) return 0;
-
-  const [, num, unit] = match;
-
-  if (!num || !unit) throw new Error("Invalid period format");
-
-  const numVal = Math.trunc(Number(num));
-
-  switch (unit) {
-    case "D":
-      return numVal;
-    case "W":
-      return numVal * 7;
-    case "M":
-      return numVal * 30; // Approximation
-    case "Y":
-      return numVal * 365; // Approximation
-    default:
-      return 0;
-  }
-};
+const MONTHS_IN_A_YEAR = 12;
 
 type OfferingsProps = {
   selectedPackage: PurchasesPackage | null | undefined;
@@ -67,56 +43,63 @@ const PlanPackages: React.FC<OfferingsProps> = ({
   }, [isError, router, t]);
 
   const packageList = offeringsData
-    ? Object.values(offeringsData.availablePackages).sort(
+    ? [...offeringsData.availablePackages].sort(
         // Highest price first
         (a, b) => b.product.price - a.product.price,
       )
     : [];
 
-  const packageWithLessRelativeValue = offeringsData
-    ? Object.values(offeringsData.availablePackages).sort((a, b) => {
-        const relativeValueA =
-          a.product.price / periodToDays(a.product.subscriptionPeriod);
-        const relativeValueB =
-          b.product.price / periodToDays(b.product.subscriptionPeriod);
+  const annualPackage =
+    offeringsData?.annual ??
+    packageList.find((pkg) => pkg.packageType === "ANNUAL");
 
-        return relativeValueB - relativeValueA;
-      })[0]
-    : undefined;
+  const monthlyPackage =
+    offeringsData?.monthly ??
+    packageList.find((pkg) => pkg.packageType === "MONTHLY");
 
-  // `packageList` is rebuilt on every render, so depending on it would run
-  // this effect every render. The first package is the only part that matters.
-  const [defaultPackage] = packageList;
+  // Yearly first: preselect the annual package when the offering has one, and
+  // otherwise fall back to the most expensive package (the previous default).
+  // Both are stable references from the offerings query, so the effect below
+  // does not re-run on every render even though `packageList` is rebuilt.
+  const defaultPackage = annualPackage ?? packageList[0];
 
   useEffect(() => {
     if (defaultPackage && !selectedPackage) {
-      // Optionally set a default package, or leave it to user interaction
       setSelectedPackage(defaultPackage);
     }
   }, [defaultPackage, selectedPackage, setSelectedPackage]);
 
+  // What a year of the monthly plan would cost against the yearly price.
+  // Undefined when either plan is missing or the yearly plan is not cheaper,
+  // in which case no badge is shown.
+  const yearlySavingPercent = (() => {
+    if (!annualPackage || !monthlyPackage) return;
+
+    const twelveMonths = monthlyPackage.product.price * MONTHS_IN_A_YEAR;
+    if (twelveMonths <= 0) return;
+
+    const percent = Math.round(
+      ((twelveMonths - annualPackage.product.price) / twelveMonths) * 100,
+    );
+
+    return percent > 0 ? percent : undefined;
+  })();
+
   return (
     <View style={planPackagesStyles.container}>
-      {packageList?.map((planPackage) => {
-        // Get old price comparing with the package with less relative value / period * this package period
-        const oldPrice = packageWithLessRelativeValue
-          ? (packageWithLessRelativeValue.product.price /
-              periodToDays(
-                packageWithLessRelativeValue.product.subscriptionPeriod,
-              )) *
-            periodToDays(planPackage.product.subscriptionPeriod)
-          : undefined;
-
-        return (
-          <PlanCard
-            key={planPackage.identifier}
-            selected={selectedPackage?.identifier === planPackage.identifier}
-            onPress={() => setSelectedPackage(planPackage)}
-            planPackage={planPackage}
-            oldPrice={oldPrice}
-          />
-        );
-      })}
+      {packageList.map((planPackage) => (
+        <PlanCard
+          key={planPackage.identifier}
+          selected={selectedPackage?.identifier === planPackage.identifier}
+          onPress={() => setSelectedPackage(planPackage)}
+          planPackage={planPackage}
+          savingPercent={
+            planPackage.identifier === annualPackage?.identifier
+              ? yearlySavingPercent
+              : undefined
+          }
+        />
+      ))}
     </View>
   );
 };

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/index.tsx
@@ -14,8 +14,7 @@ import { useOfferings } from "@/hooks/use-payments";
 import { styles as planPackagesStyles } from "@/views/UpgradeWall/components/PlanPackages/styles";
 
 import { PlanCard } from "./plan-card";
-
-const MONTHS_IN_A_YEAR = 12;
+import { getYearlySavingPercent } from "./saving-percent";
 
 type OfferingsProps = {
   selectedPackage: PurchasesPackage | null | undefined;
@@ -70,20 +69,10 @@ const PlanPackages: React.FC<OfferingsProps> = ({
   }, [defaultPackage, selectedPackage, setSelectedPackage]);
 
   // What a year of the monthly plan would cost against the yearly price.
-  // Undefined when either plan is missing or the yearly plan is not cheaper,
-  // in which case no badge is shown.
-  const yearlySavingPercent = (() => {
-    if (!annualPackage || !monthlyPackage) return;
-
-    const twelveMonths = monthlyPackage.product.price * MONTHS_IN_A_YEAR;
-    if (twelveMonths <= 0) return;
-
-    const percent = Math.round(
-      ((twelveMonths - annualPackage.product.price) / twelveMonths) * 100,
-    );
-
-    return percent > 0 ? percent : undefined;
-  })();
+  const yearlySavingPercent = getYearlySavingPercent(
+    monthlyPackage?.product.price,
+    annualPackage?.product.price,
+  );
 
   return (
     <View style={planPackagesStyles.container}>

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/plan-card.tsx
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/plan-card.tsx
@@ -40,14 +40,15 @@ type PlanCardProps = {
   selected: boolean;
   onPress: () => void;
   planPackage: PurchasesPackage;
-  oldPrice?: number;
+  /** Percent saved against paying monthly. Hidden when undefined. */
+  savingPercent?: number;
 };
 
 export const PlanCard: React.FC<PlanCardProps> = ({
   selected,
   onPress,
   planPackage: pkg,
-  oldPrice,
+  savingPercent,
 }) => {
   const { t } = useTranslation();
   const { product } = pkg;
@@ -79,9 +80,8 @@ export const PlanCard: React.FC<PlanCardProps> = ({
     }
   })();
 
-  const percentSaved = oldPrice
-    ? Math.floor(((oldPrice - currentPrice) / oldPrice) * 100)
-    : undefined;
+  // A single month already reads as "X/mo", so the total would just repeat it.
+  const showTotalPrice = !(periodUnit === "M" && periodValue === 1);
 
   const translatedPlanName = (() => {
     switch (identifier) {
@@ -114,23 +114,23 @@ export const PlanCard: React.FC<PlanCardProps> = ({
             fontWeight="semibold"
             style={planPackagesStyles.price}
           >
-            {formatPrice(pricePerMonth, currencyCode)}/{t("plans.M")}{" "}
-            {percentSaved ? (
+            {`${formatPrice(pricePerMonth, currencyCode)}/${t("plans.M")}`}
+            {showTotalPrice ? (
               <Text color="subtitle" fontSize="md">
-                ({formattedCurrentPrice}/{t(`plans.${periodUnit}`)})
+                {` (${formattedCurrentPrice}/${t(`plans.${periodUnit}`)})`}
               </Text>
             ) : null}
           </Price>
         ) : null}
       </View>
-      {percentSaved ? (
+      {savingPercent ? (
         <View style={planPackagesStyles.percentContainer}>
           <PercentText
             fontSize="sm"
             fontWeight="semibold"
             style={planPackagesStyles.percentText}
           >
-            {t("plans.save", { percent: percentSaved })}
+            {t("plans.save", { percent: savingPercent })}
           </PercentText>
         </View>
       ) : null}

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/plan-card.tsx
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/plan-card.tsx
@@ -14,12 +14,6 @@ import {
   styles as planPackagesStyles,
 } from "@/views/UpgradeWall/components/PlanPackages/styles";
 
-const formatPrice = (value: number, currency: string) =>
-  new Intl.NumberFormat("default", {
-    style: "currency",
-    currency,
-  }).format(value);
-
 const getPeriodDetails = (
   period: string,
 ): {
@@ -53,32 +47,27 @@ export const PlanCard: React.FC<PlanCardProps> = ({
   const { t } = useTranslation();
   const { product } = pkg;
 
+  // Both amounts come from the store's own formatter (`priceString` and
+  // `pricePerMonthString`), the same source as the price line under the plan
+  // list, so the card and that line always show one currency symbol and one
+  // decimal format. Reformatting `product.price` locally would follow the
+  // device locale instead of the storefront and the two would disagree.
   const {
-    price: currentPrice,
-    currencyCode,
+    priceString,
+    pricePerMonthString,
     subscriptionPeriod: period,
     identifier,
   } = product;
 
-  const formattedCurrentPrice = formatPrice(currentPrice, currencyCode);
-
   const { periodUnit, periodValue } = getPeriodDetails(period || "");
 
-  const pricePerMonth = (() => {
-    if (!periodUnit || !periodValue) return;
-    switch (periodUnit) {
-      case "D":
-        return currentPrice / periodValue;
-      case "W":
-        return currentPrice / (periodValue * 4); // Approximation
-      case "M":
-        return currentPrice / periodValue;
-      case "Y":
-        return currentPrice / (periodValue * 12); // Approximation
-      default:
-        return 0;
-    }
-  })();
+  const totalPriceLabel = `${priceString}/${t(`plans.${periodUnit}`)}`;
+
+  // `pricePerMonthString` is null for one-off products, where the total is the
+  // only amount we can show.
+  const pricePerMonthLabel = pricePerMonthString
+    ? `${pricePerMonthString}/${t("plans.M")}`
+    : null;
 
   // A single month already reads as "X/mo", so the total would just repeat it.
   const showTotalPrice = !(periodUnit === "M" && periodValue === 1);
@@ -107,21 +96,19 @@ export const PlanCard: React.FC<PlanCardProps> = ({
         <Text fontSize="sm" fontWeight="semibold">
           {translatedPlanName}
         </Text>
-        {pricePerMonth ? (
-          <Price
-            color="subtitle"
-            fontSize="md"
-            fontWeight="semibold"
-            style={planPackagesStyles.price}
-          >
-            {`${formatPrice(pricePerMonth, currencyCode)}/${t("plans.M")}`}
-            {showTotalPrice ? (
-              <Text color="subtitle" fontSize="md">
-                {` (${formattedCurrentPrice}/${t(`plans.${periodUnit}`)})`}
-              </Text>
-            ) : null}
-          </Price>
-        ) : null}
+        <Price
+          color="subtitle"
+          fontSize="md"
+          fontWeight="semibold"
+          style={planPackagesStyles.price}
+        >
+          {pricePerMonthLabel ?? totalPriceLabel}
+          {pricePerMonthLabel && showTotalPrice ? (
+            <Text color="subtitle" fontSize="md">
+              {` (${totalPriceLabel})`}
+            </Text>
+          ) : null}
+        </Price>
       </View>
       {savingPercent ? (
         <View style={planPackagesStyles.percentContainer}>

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.test.ts
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.test.ts
@@ -1,0 +1,17 @@
+import { getYearlySavingPercent } from "./saving-percent";
+
+test("rounds the yearly saving down so the badge never overstates", () => {
+  // 9.99 x 12 = 119.88, saving 58.31% against 49.99.
+  expect(getYearlySavingPercent(9.99, 49.99)).toBe(58);
+  // 10 x 12 = 120, saving 58.33% against 50.
+  expect(getYearlySavingPercent(10, 50)).toBe(58);
+  expect(getYearlySavingPercent(10, 60)).toBe(50);
+});
+
+test("hides the badge when there is nothing to save", () => {
+  expect(getYearlySavingPercent(10, 120)).toBeUndefined();
+  expect(getYearlySavingPercent(10, 130)).toBeUndefined();
+  expect(getYearlySavingPercent(0, 50)).toBeUndefined();
+  expect(getYearlySavingPercent(undefined, 50)).toBeUndefined();
+  expect(getYearlySavingPercent(10, undefined)).toBeUndefined();
+});

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.ts
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.ts
@@ -1,0 +1,23 @@
+const MONTHS_IN_A_YEAR = 12;
+
+/**
+ * Percent saved by paying a year up front instead of twelve monthly charges.
+ * Rounded down so the badge never promises more than the plans deliver.
+ * Returns undefined when either price is missing or the yearly plan is not
+ * actually cheaper, in which case no badge should be shown.
+ */
+export const getYearlySavingPercent = (
+  monthlyPrice: number | undefined,
+  yearlyPrice: number | undefined,
+) => {
+  if (monthlyPrice === undefined || yearlyPrice === undefined) return;
+
+  const twelveMonths = monthlyPrice * MONTHS_IN_A_YEAR;
+  if (twelveMonths <= 0) return;
+
+  const percent = Math.floor(
+    ((twelveMonths - yearlyPrice) / twelveMonths) * 100,
+  );
+
+  return percent > 0 ? percent : undefined;
+};

--- a/apps/mobile/src/views/UpgradeWall/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/index.tsx
@@ -14,7 +14,6 @@ import { useUnistyles } from "react-native-unistyles";
 
 import { BottomAction, useBottomActionStyle } from "@/components/BottomAction";
 import { Button } from "@/components/Button";
-import { useEligibleForTrial } from "@/hooks/use-payments";
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
 import { haptics } from "@/services/haptics";
@@ -24,6 +23,7 @@ import PlanPackages from "@/views/UpgradeWall/components/PlanPackages";
 import RestorePurchases from "@/views/UpgradeWall/components/RestorePurchases";
 
 import {
+  CancelAnytime,
   CloseButton,
   CloseIcon,
   GradientEffect,
@@ -34,35 +34,26 @@ import {
   Title,
 } from "./styles";
 
-const useTranslatedTrialDuration = (
-  offering: PurchasesPackage | null | undefined,
-) => {
+/**
+ * The store price of the selected plan, spelled out with its billing period so
+ * the amount next to the CTA is the amount that will actually be charged.
+ * Uses RevenueCat's `priceString`, which is already formatted and localised by
+ * the store, rather than reformatting the raw number ourselves.
+ */
+const usePriceLine = (offering: PurchasesPackage | null | undefined) => {
   const { t } = useTranslation();
 
-  const introPrice = offering?.product.introPrice;
-  if (!introPrice) return;
+  if (!offering) return;
 
-  const quantity = introPrice.periodNumberOfUnits;
+  const price = offering.product.priceString;
 
-  const props = { replace: { unit: quantity } };
-
-  switch (introPrice.periodUnit) {
-    case "DAY":
-      return quantity === 1
-        ? t("dateFormatting.day", props)
-        : t("dateFormatting.days", props);
-    case "WEEK":
-      return quantity === 1
-        ? t("dateFormatting.week", props)
-        : t("dateFormatting.weeks", props);
-    case "MONTH":
-      return quantity === 1
-        ? t("dateFormatting.month", props)
-        : t("dateFormatting.months", props);
-    case "YEAR":
-      return quantity === 1
-        ? t("dateFormatting.year", props)
-        : t("dateFormatting.years", props);
+  switch (offering.packageType) {
+    case "ANNUAL":
+      return t("plans.upgradeWall.priceYearly", { price });
+    case "MONTHLY":
+      return t("plans.upgradeWall.priceMonthly", { price });
+    default:
+      return t("plans.upgradeWall.price", { price });
   }
 };
 
@@ -76,7 +67,7 @@ const UpgradeWall: React.FC = () => {
     PurchasesPackage | null | undefined
   >();
 
-  const freeTrialDuration = useTranslatedTrialDuration(selectedOffering);
+  const priceLine = usePriceLine(selectedOffering);
 
   const purchasePackage = useMutation({
     mutationFn: payments.purchasePackage,
@@ -85,7 +76,6 @@ const UpgradeWall: React.FC = () => {
         event_type: "Upgrade",
         event_properties: {
           package: selectedOffering?.product.identifier,
-          trial: isEligibleForTrial,
           type: "start",
         },
       });
@@ -97,7 +87,6 @@ const UpgradeWall: React.FC = () => {
         event_type: "Upgrade",
         event_properties: {
           package: selectedOffering?.product.identifier,
-          trial: isEligibleForTrial,
           type: "success",
         },
       });
@@ -109,7 +98,6 @@ const UpgradeWall: React.FC = () => {
           event_type: "Upgrade",
           event_properties: {
             package: selectedOffering?.product.identifier,
-            trial: isEligibleForTrial,
             type: "cancel",
           },
         });
@@ -126,7 +114,6 @@ const UpgradeWall: React.FC = () => {
         event_type: "Upgrade",
         event_properties: {
           package: selectedOffering?.product.identifier,
-          trial: isEligibleForTrial,
           type: "error",
         },
       });
@@ -136,26 +123,6 @@ const UpgradeWall: React.FC = () => {
   });
 
   const bottomActionStyle = useBottomActionStyle();
-
-  const isEligibleForTrial = useEligibleForTrial({
-    offering: selectedOffering,
-  });
-
-  const title = t(
-    isEligibleForTrial
-      ? "plans.upgradeWall.earnedFreeTrial"
-      : "plans.upgradeWall.getPremium",
-  );
-
-  const trialSubtitle = isEligibleForTrial
-    ? t("plans.upgradeWall.tryPremiumFree", { duration: freeTrialDuration })
-    : t("plans.upgradeWall.enjoyFullAccess");
-
-  const buttonText = t(
-    isEligibleForTrial
-      ? "plans.upgradeWall.startFreeTrial"
-      : "plans.upgradeWall.getPremium",
-  );
 
   const paddingTop =
     Platform.OS === "ios" ? theme.spacing[2] : insets.top + theme.spacing[2];
@@ -186,17 +153,28 @@ const UpgradeWall: React.FC = () => {
         <View style={{ gap: theme.spacing[7] }}>
           <View>
             <Title style={styles.title} fontSize="xl" fontWeight="bold">
-              {title}
+              {t("plans.upgradeWall.getPremium")}
             </Title>
             <Subtitle style={styles.subtitle} fontWeight="semibold">
-              {trialSubtitle}
+              {t("plans.upgradeWall.enjoyFullAccess")}
             </Subtitle>
           </View>
 
-          <PlanPackages
-            selectedPackage={selectedOffering}
-            setSelectedPackage={setSelectedOffering}
-          />
+          <View style={{ gap: theme.spacing[3] }}>
+            <PlanPackages
+              selectedPackage={selectedOffering}
+              setSelectedPackage={setSelectedOffering}
+            />
+            {priceLine ? (
+              <CancelAnytime
+                style={styles.cancelAnytime}
+                color="subtitle"
+                fontSize="sm"
+              >
+                {priceLine}
+              </CancelAnytime>
+            ) : null}
+          </View>
         </View>
 
         <Benefits />
@@ -241,7 +219,7 @@ const UpgradeWall: React.FC = () => {
           disabled={!selectedOffering}
           loading={purchasePackage.isPending || !selectedOffering}
         >
-          {buttonText}
+          {t("plans.upgradeWall.subscribe")}
         </Button>
       </BottomAction.Container>
     </View>

--- a/packages/api/src/services/swipe-service.ts
+++ b/packages/api/src/services/swipe-service.ts
@@ -61,6 +61,9 @@ export class SwipeService {
         body: TranslationService.translate("server:notification.like.body", {
           lng: this.language,
         }),
+        // Gives the like push the same shape as the match and chat pushes so a
+        // tap resolves to a known destination instead of an unknown link.
+        data: { url: "like" },
       });
     } catch (error) {
       sendError(error);

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -4,8 +4,7 @@
     "description": "You have liked <b>{{count}} dogs</b> in the last <b>24 hours</b>. Wait or become <b>premium</b> to keep swiping.",
     "remaining": "remaining",
     "timeHours": "{{time}}h",
-    "winFreeTrial": "Win a Free Trial",
-    "getPremium": "Discover Premium"
+    "getPremium": "Get Premium"
   },
   "liveStatus": {
     "title": "Likes recharging",
@@ -261,11 +260,12 @@
       "fetchingOfferings": "An error occurred while fetching the offerings."
     },
     "upgradeWall": {
-      "earnedFreeTrial": "You Earned a Free Trial",
       "getPremium": "Get Premium",
-      "tryPremiumFree": "Try Premium Free for {{duration}}",
       "enjoyFullAccess": "Enjoy full access to all features and supercharge your doggie",
-      "startFreeTrial": "Start Free Trial"
+      "subscribe": "Get Premium",
+      "price": "{{price}}, cancel anytime",
+      "priceMonthly": "{{price}} per month, cancel anytime",
+      "priceYearly": "{{price}} per year, cancel anytime"
     }
   },
   "links": {

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -93,11 +93,7 @@
     "month": "{{unit}} month",
     "months": "{{unit}} months",
     "year": "{{unit}} year",
-    "years": "{{unit}} years",
-    "day": "{{unit}} day",
-    "days": "{{unit}} days",
-    "week": "{{unit}} week",
-    "weeks": "{{unit}} weeks"
+    "years": "{{unit}} years"
   },
   "dogProfile": {
     "profileInfoError": "⚠️ Loading Error. Try again later.",
@@ -260,7 +256,7 @@
       "fetchingOfferings": "An error occurred while fetching the offerings."
     },
     "upgradeWall": {
-      "getPremium": "Get Premium",
+      "getPremium": "Unlock Premium",
       "enjoyFullAccess": "Enjoy full access to all features and supercharge your doggie",
       "subscribe": "Get Premium",
       "price": "{{price}}, cancel anytime",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -4,8 +4,7 @@
     "description": "Você curtiu <b>{{count}} cachorros</b> em <b>24h</b>. Espere ou vire <b>premium</b> para continuar deslizando.",
     "remaining": "restantes",
     "timeHours": "{{time}}h",
-    "winFreeTrial": "Ganhe um Teste Gratuito",
-    "getPremium": "Descubra o Premium"
+    "getPremium": "Assinar Premium"
   },
   "liveStatus": {
     "title": "Curtidas recarregando",
@@ -296,11 +295,12 @@
       "fetchingOfferings": "Ocorreu um erro ao buscar as ofertas."
     },
     "upgradeWall": {
-      "earnedFreeTrial": "Inicie o Teste Gratuito",
       "getPremium": "Obtenha o Premium",
-      "tryPremiumFree": "Experimente o Premium grátis por {{duration}}",
       "enjoyFullAccess": "Aproveite o acesso total a todos os recursos e turbine o seu doguinho",
-      "startFreeTrial": "Inicie o Teste Gratuito"
+      "subscribe": "Assinar Premium",
+      "price": "{{price}}, cancele quando quiser",
+      "priceMonthly": "{{price}} por mês, cancele quando quiser",
+      "priceYearly": "{{price}} por ano, cancele quando quiser"
     }
   },
   "networkBoundary": {

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -93,11 +93,7 @@
     "month": "{{unit}} mês",
     "months": "{{unit}} meses",
     "year": "{{unit}} ano",
-    "years": "{{unit}} anos",
-    "day": "{{unit}} dia",
-    "days": "{{unit}} dias",
-    "week": "{{unit}} semana",
-    "weeks": "{{unit}} semanas"
+    "years": "{{unit}} anos"
   },
   "dogProfile": {
     "profileInfoError": "⚠️ Oops. Tente novamente mais tarde.",
@@ -295,7 +291,7 @@
       "fetchingOfferings": "Ocorreu um erro ao buscar as ofertas."
     },
     "upgradeWall": {
-      "getPremium": "Obtenha o Premium",
+      "getPremium": "Desbloqueie o Premium",
       "enjoyFullAccess": "Aproveite o acesso total a todos os recursos e turbine o seu doguinho",
       "subscribe": "Assinar Premium",
       "price": "{{price}}, cancele quando quiser",


### PR DESCRIPTION
## Summary
Takes the free trial out of the paywall and the like limit modal, makes the yearly plan the default and says what it saves, and gives the like push a link type so an opened like can be followed into the funnel. Closes #193.

## Details
- The paywall no longer branches on trial eligibility. Title, subtitle and CTA are fixed premium copy, and the intro price is never shown even when the store still returns one. The title reads Unlock Premium and the button reads Get Premium, so the screen no longer repeats the same words twice.
- `useEligibleForTrial` and the trial duration helper are gone, along with the trial strings in English and Portuguese.
- The yearly plan is preselected by package type rather than by being the most expensive row, with the old highest price rule kept as a fallback for offerings that have no annual package.
- The saving badge on the yearly row is now twelve months of the monthly price against the yearly price, taken from the store. It rounds down so it never promises more than the plans deliver, and it is hidden when either plan is missing or the yearly plan is not cheaper.
- New line under the plans spells out the store price and the billing period, plus cancel anytime, in both languages.
- Both amounts on a plan row now come from the store's own formatter, the same source as that line, so the currency symbol and the decimal separator always agree. Before this they could disagree when the device language and the storefront country differed.
- The like limit modal CTA sells premium instead of a trial.
- The `Upgrade` event loses its `trial` property. Nothing replaces it here: the `trigger` property lands with #213.
- The like push now carries a link type, and a tap on it opens the deck instead of being reported as an unknown notification. That is the measurement for #195, no new copy.

## Metric
- Hypothesis: removing the trial and defaulting to yearly raises paid revenue per paywall view. Target is yearly above 50 percent of new purchases, with no drop in view to paid larger than the refund and cancel loss the trial was causing.
- Baseline: no paywall view event exists yet, only `Upgrade` with `type` and `package`. Purchases by plan come from RevenueCat Charts for the 30 days before release.
- Readout: PostHog funnel `Paywall Viewed` (with the `trigger` property from #213) to `Upgrade` where type is success, split by `package`. RevenueCat Charts for the yearly share of new subscriptions. For the like push, `Push Notification Opened` where the link is a like, followed by `Paywall Viewed` in the same session. This PR only makes the like push carry a link so that event can see it.

## Testing steps
1. Open the app as a free account and tap the plan row on the profile tab.
2. The paywall opens with the yearly plan already chosen, a badge showing what it saves against paying monthly, the price and billing period spelled out under the plans, and a button that says Get Premium. Nothing anywhere offers a free trial.
3. Tap the monthly plan. The price line changes to the monthly price and the badge stays on the yearly row.
4. Like ten dogs in a day, then like one more. The daily limit card appears and its button offers premium rather than a trial.

## Screenshots
| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/paywall-no-trial/shots/before-paywall.png" width="320"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/paywall-no-trial/shots/after-paywall.png" width="320"> |
|  | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/paywall-no-trial/shots/after-paywall-monthly.png" width="320"> |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/paywall-no-trial/shots/before-like-limit.png" width="320"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/paywall-no-trial/shots/after-like-limit.png" width="320"> |

