### PR TITLE
feat: attribute installs and signups to the dog that was shared

### DIFF
--- a/apps/mobile/src/app/+not-found.tsx
+++ b/apps/mobile/src/app/+not-found.tsx
@@ -1,0 +1,19 @@
+import { Redirect } from "expo-router";
+
+/**
+ * Expo Router mounts nothing at all when a deep link names a path this app has
+ * no route for — not even the root layout — so the native splash never hides
+ * and the app sits on the logo forever.
+ *
+ * That is the normal case for a share link, not an edge case: the dog card
+ * lives on the website (`/dog/<id>`), the app has no screen at that path, and
+ * the referral is read in the root layout's effect. Without this file, every
+ * shared dog link that reaches an installed app both hangs it and loses the
+ * attribution it was carrying.
+ *
+ * Redirecting to the root sends the user through the normal auth gate, which
+ * is where a link with no matching screen should land them anyway.
+ */
+const NotFound = () => <Redirect href="/" />;
+
+export default NotFound;

--- a/apps/mobile/src/app/+not-found.tsx
+++ b/apps/mobile/src/app/+not-found.tsx
@@ -2,7 +2,7 @@ import { Redirect } from "expo-router";
 
 /**
  * Expo Router mounts nothing at all when a deep link names a path this app has
- * no route for — not even the root layout — so the native splash never hides
+ * no route for, not even the root layout, so the native splash never hides
  * and the app sits on the logo forever.
  *
  * That is the normal case for a share link, not an edge case: the dog card

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -24,6 +24,7 @@ import { sendError } from "@/services/error-tracking";
 import { useGetInitialNotifications } from "@/services/linking";
 import { getExpoPostHog } from "@/services/observability";
 import { useQuickActions } from "@/services/quick-actions";
+import { useCaptureReferral } from "@/services/referral";
 import { store } from "@/store";
 import { SceneName } from "@/types/scene-name";
 
@@ -75,6 +76,10 @@ const App = () => {
 
   useTrackScreens();
   useGetInitialNotifications();
+  // Ahead of the auth gate on purpose: the link that carries a referral is
+  // usually opened by someone with no account, and the referral has to be on
+  // disk before they reach the sign in screen.
+  useCaptureReferral();
   // Wait for authentication and onboarding before following a shortcut.
   useQuickActions(initialRouteName === SceneName.Swipe);
 

--- a/apps/mobile/src/services/referral/index.ts
+++ b/apps/mobile/src/services/referral/index.ts
@@ -1,0 +1,13 @@
+export {
+  parseReferralFromUrl,
+  withReferral,
+  type Referral,
+} from "./parse-referral-from-url";
+export {
+  clearPendingReferral,
+  getPendingReferral,
+  savePendingReferral,
+} from "./pending-referral";
+export { useCaptureReferral } from "./use-capture-referral";
+export { usePendingReferral } from "./use-pending-referral";
+export { LOGIN_PLATFORM } from "./login-platform";

--- a/apps/mobile/src/services/referral/login-platform.ts
+++ b/apps/mobile/src/services/referral/login-platform.ts
@@ -1,0 +1,9 @@
+import { Platform } from "react-native";
+
+/**
+ * Sent with the login so the readout splits by store without a second event.
+ * Anything that is not one of the two shipped platforms is left off rather
+ * than guessed at, and the server defaults it to "unknown".
+ */
+export const LOGIN_PLATFORM =
+  Platform.OS === "ios" || Platform.OS === "android" ? Platform.OS : undefined;

--- a/apps/mobile/src/services/referral/parse-referral-from-url.test.ts
+++ b/apps/mobile/src/services/referral/parse-referral-from-url.test.ts
@@ -1,0 +1,130 @@
+import { parseReferralFromUrl, withReferral } from "./parse-referral-from-url";
+
+/**
+ * The device has no usable `URL`.
+ *
+ * React Native ships its own (Libraries/Blob/URL.js): `hostname` is a regex
+ * that only matches `^https?://`, and `searchParams` is a stub. A parser
+ * written against the global passes every test in here, where jest supplies
+ * node's real one, and returns `undefined` for every deep link on a phone.
+ * Removing both globals for the whole suite is what makes these tests run
+ * against the same thing the app runs against.
+ */
+const globals = globalThis as { URL?: unknown; URLSearchParams?: unknown };
+const realUrl = globals.URL;
+const realSearchParams = globals.URLSearchParams;
+
+beforeAll(() => {
+  delete globals.URL;
+  delete globals.URLSearchParams;
+});
+
+afterAll(() => {
+  globals.URL = realUrl;
+  globals.URLSearchParams = realSearchParams;
+});
+
+const SHARER = "cms9es4dr0001wbmv1a2b3c4d";
+const DOG = "cms9es4ht0005wbmvmjg1okvo";
+
+describe("parseReferralFromUrl", () => {
+  it.each([
+    `https://www.pegada.app/dog/${DOG}?ref=${SHARER}`,
+    `https://pegada.app/dog/${DOG}?ref=${SHARER}`,
+    `https://www.pegada.app/dog/${DOG}/?ref=${SHARER}`,
+    `pegada://dog/${DOG}?ref=${SHARER}`,
+    `pegada:///dog/${DOG}?ref=${SHARER}`,
+    // Real links come back from chat apps with their own tracking on them.
+    `https://www.pegada.app/dog/${DOG}?utm_source=whatsapp&ref=${SHARER}`,
+  ])("reads the sharer and the dog out of %s", (url) => {
+    expect(parseReferralFromUrl(url)).toStrictEqual({
+      ref: SHARER,
+      referredDogId: DOG,
+    });
+  });
+
+  it.each([
+    // The Instagram bio link, and the rest of the site carrying the same token.
+    "https://www.pegada.app/store?ref=ig",
+    "https://www.pegada.app/?ref=ig",
+    "https://pegada.app?ref=ig",
+    "pegada://dog/mangled?ref=ig",
+  ])("reads a channel token with no dog out of %s", (url) => {
+    expect(parseReferralFromUrl(url)).toStrictEqual({ ref: "ig" });
+  });
+
+  it.each([
+    ["nothing was opened", undefined],
+    ["the link is empty", ""],
+    ["the link is not a URL", `dog/${DOG}?ref=${SHARER}`],
+    // The whole point of the host check: any page anywhere can put `?ref=` on
+    // a `/dog/` path, and an attributed signup has to mean something.
+    [
+      "the host is not ours",
+      `https://pegada.app.evil.com/dog/${DOG}?ref=${SHARER}`,
+    ],
+    [
+      "the scheme is not ours",
+      `http://www.pegada.app/dog/${DOG}?ref=${SHARER}`,
+    ],
+    ["there is no ref", `https://www.pegada.app/dog/${DOG}`],
+    ["the ref is empty", `https://www.pegada.app/dog/${DOG}?ref=`],
+    ["the ref is a single character", "https://www.pegada.app/?ref=a"],
+    [
+      "the ref is too long",
+      `https://www.pegada.app/dog/${DOG}?ref=${"a".repeat(33)}`,
+    ],
+    [
+      "the ref carries a path traversal",
+      `https://www.pegada.app/dog/${DOG}?ref=../../admin`,
+    ],
+    ["the ref carries a space", "https://www.pegada.app/?ref=some%20thing"],
+  ])("returns nothing when %s", (_reason, url) => {
+    expect(parseReferralFromUrl(url)).toBeUndefined();
+  });
+
+  it("keeps the sharer when the dog id is unreadable", () => {
+    // Who shared it is the number; which dog is the detail. A link mangled in
+    // the middle should still be attributed.
+    expect(
+      parseReferralFromUrl(
+        `https://www.pegada.app/dog/NOT-AN-ID?ref=${SHARER}`,
+      ),
+    ).toStrictEqual({ ref: SHARER });
+  });
+});
+
+describe("withReferral", () => {
+  it("appends the sharer to a share link", () => {
+    expect(withReferral(`https://www.pegada.app/dog/${DOG}`, SHARER)).toBe(
+      `https://www.pegada.app/dog/${DOG}?ref=${SHARER}`,
+    );
+  });
+
+  it("round-trips through the parser", () => {
+    expect(
+      parseReferralFromUrl(
+        withReferral(`https://www.pegada.app/dog/${DOG}`, SHARER),
+      ),
+    ).toStrictEqual({ ref: SHARER, referredDogId: DOG });
+  });
+
+  it("replaces a ref that is already there instead of adding a second", () => {
+    const link = withReferral(
+      `https://www.pegada.app/dog/${DOG}?ref=${DOG}`,
+      SHARER,
+    );
+
+    expect(link).toBe(`https://www.pegada.app/dog/${DOG}?ref=${SHARER}`);
+  });
+
+  it("hands back the link untouched when there is no usable sharer", () => {
+    const link = `https://www.pegada.app/dog/${DOG}`;
+
+    // A channel token is not a sharer: the app only ever puts a real user id
+    // on a link it generates.
+    expect(withReferral(link, "")).toBe(link);
+    expect(withReferral(link, "ig")).toBe(link);
+    expect(withReferral(link, "not-an-id")).toBe(link);
+  });
+});

--- a/apps/mobile/src/services/referral/parse-referral-from-url.ts
+++ b/apps/mobile/src/services/referral/parse-referral-from-url.ts
@@ -33,8 +33,8 @@ type UrlParts = {
  * React Native ships its own `URL` (Libraries/Blob/URL.js) and it is not the
  * web one: `hostname` is a regex that only matches `^https?://`, so it returns
  * "" for `pegada://`, and `searchParams` is a stub. Written against the global,
- * this function passed every test in jest — where `URL` is node's real one —
- * and silently returned `undefined` for every deep link on the device. The
+ * this function passed every test in jest, where `URL` is node's real one, and
+ * silently returned `undefined` for every deep link on the device. The
  * whole feature reads as "referrals just do not work" and nothing logs.
  *
  * `pegada://dog/<id>` puts "dog" in the authority and the id in the path;
@@ -123,10 +123,11 @@ export const parseReferralFromUrl = (
 /**
  * Put a sharer on a share link.
  *
- * Exported for the share link builder (`DogShareOptions/share-actions.ts`),
- * which calls it so every link this app hands out can be attributed. Built by
- * hand for the same reason as {@link splitUrl}: `URLSearchParams` is a stub in
- * React Native.
+ * Exported for the share link builder coming with the profile share feature,
+ * which should wrap its URL with this once both land, so every link this app
+ * hands out can be attributed. Nothing calls it yet. Built by hand for the
+ * same reason as {@link splitUrl}: `URLSearchParams` is a stub in React
+ * Native.
  */
 export const withReferral = (
   shareUrl: string,

--- a/apps/mobile/src/services/referral/parse-referral-from-url.ts
+++ b/apps/mobile/src/services/referral/parse-referral-from-url.ts
@@ -1,0 +1,155 @@
+import { isReferralId, isReferralRef } from "@pegada/shared/utils/referral";
+
+/**
+ * What a link carries. `ref` is a user id when the app generated the link and
+ * a channel token (`ig`) when a human wrote it into a profile bio; the server
+ * resolves which. `referredDogId` is only present on a dog card link.
+ */
+export type Referral = {
+  ref: string;
+  referredDogId?: string;
+};
+
+/**
+ * The hosts a Pegada link can legitimately arrive on. Anything else is some
+ * other site's URL that happens to have a `ref` on it, and attributing a
+ * signup to it would put noise straight into the metric.
+ */
+const ALLOWED_HOSTS = new Set(["www.pegada.app", "pegada.app"]);
+
+/** The custom scheme, registered in app.config.ts. */
+const APP_SCHEME = "pegada";
+
+type UrlParts = {
+  scheme: string;
+  authority: string;
+  path: string;
+  query: string;
+};
+
+/**
+ * Split a URL by hand rather than with `new URL()`.
+ *
+ * React Native ships its own `URL` (Libraries/Blob/URL.js) and it is not the
+ * web one: `hostname` is a regex that only matches `^https?://`, so it returns
+ * "" for `pegada://`, and `searchParams` is a stub. Written against the global,
+ * this function passed every test in jest — where `URL` is node's real one —
+ * and silently returned `undefined` for every deep link on the device. The
+ * whole feature reads as "referrals just do not work" and nothing logs.
+ *
+ * `pegada://dog/<id>` puts "dog" in the authority and the id in the path;
+ * `pegada:///dog/<id>` puts both in the path. Both are normalised below.
+ */
+const splitUrl = (url: string): UrlParts | undefined => {
+  const match = /^([a-z][\d+.a-z-]*):\/\/([^#/?]*)([^#?]*)(?:\?([^#]*))?/i.exec(
+    url,
+  );
+
+  if (!match) return undefined;
+
+  const [, scheme, authority, path, query] = match;
+
+  return {
+    scheme: (scheme ?? "").toLowerCase(),
+    authority: (authority ?? "").toLowerCase(),
+    path: path ?? "",
+    query: query ?? "",
+  };
+};
+
+/** One query parameter, or undefined. Percent escapes are decoded once. */
+const queryValue = (query: string, name: string): string | undefined => {
+  const pair = query
+    .split("&")
+    .find((candidate) => candidate.split("=")[0] === name);
+
+  if (pair === undefined) return undefined;
+
+  const separator = pair.indexOf("=");
+  if (separator === -1) return "";
+
+  try {
+    return decodeURIComponent(pair.slice(separator + 1).replaceAll("+", " "));
+  } catch {
+    // A lone `%` from a link a chat app cut in half.
+    return undefined;
+  }
+};
+
+const dogIdFromPath = (path: string): string | undefined => {
+  // Leading and trailing slashes vary by platform and by whether the link came
+  // out of a share sheet or a browser address bar.
+  const segments = path.split("/").filter(Boolean);
+  const [first, second] = segments;
+
+  if (first !== "dog") return undefined;
+  return isReferralId(second) ? second : undefined;
+};
+
+/**
+ * Pull the attribution out of a link the user just opened.
+ *
+ * Accepts anything on our own hosts or our own scheme that carries a `ref`:
+ * the dog card the app shares, the store link in the Instagram bio, the plain
+ * site link. The dog is optional because only one of those is a dog link, and
+ * the number this feeds is "who sent them", not "what they looked at first".
+ *
+ * Returns `undefined` for everything else, including one of our links with no
+ * `ref` on it: there is nothing to attribute, and storing a partial referral
+ * would mean the next real one loses the race.
+ */
+export const parseReferralFromUrl = (
+  url: string | null | undefined,
+): Referral | undefined => {
+  if (!url) return undefined;
+
+  const parts = splitUrl(url);
+  if (!parts) return undefined;
+
+  const isAppScheme = parts.scheme === APP_SCHEME;
+
+  if (!isAppScheme && parts.scheme !== "https") return undefined;
+  if (!isAppScheme && !ALLOWED_HOSTS.has(parts.authority)) return undefined;
+
+  const ref = queryValue(parts.query, "ref");
+  if (!isReferralRef(ref)) return undefined;
+
+  const path = isAppScheme ? `/${parts.authority}${parts.path}` : parts.path;
+  const referredDogId = dogIdFromPath(path);
+
+  return { ref, ...(referredDogId ? { referredDogId } : {}) };
+};
+
+/**
+ * Put a sharer on a share link.
+ *
+ * Exported for the share link builder (`DogShareOptions/share-actions.ts`),
+ * which calls it so every link this app hands out can be attributed. Built by
+ * hand for the same reason as {@link splitUrl}: `URLSearchParams` is a stub in
+ * React Native.
+ */
+export const withReferral = (
+  shareUrl: string,
+  sharerUserId: string,
+): string => {
+  if (!isReferralId(sharerUserId)) return shareUrl;
+  if (!splitUrl(shareUrl)) return shareUrl;
+
+  const [beforeHash = "", ...hash] = shareUrl.split("#");
+  const [base = "", query = ""] = splitOnce(beforeHash, "?");
+
+  const kept = query
+    .split("&")
+    .filter((pair) => pair !== "" && !pair.startsWith("ref="));
+
+  kept.push(`ref=${sharerUserId}`);
+
+  const rebuilt = `${base}?${kept.join("&")}`;
+  return hash.length > 0 ? `${rebuilt}#${hash.join("#")}` : rebuilt;
+};
+
+const splitOnce = (value: string, separator: string): [string, string] => {
+  const index = value.indexOf(separator);
+  if (index === -1) return [value, ""];
+  return [value.slice(0, index), value.slice(index + separator.length)];
+};

--- a/apps/mobile/src/services/referral/pending-referral.test.ts
+++ b/apps/mobile/src/services/referral/pending-referral.test.ts
@@ -1,0 +1,117 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import { StorageKeys } from "@/services/storage";
+
+import {
+  clearPendingReferral,
+  getPendingReferral,
+  savePendingReferral,
+} from "./pending-referral";
+
+jest.mock<
+  Partial<typeof import("@react-native-async-storage/async-storage").default>
+>("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock<Partial<typeof import("expo-secure-store")>>(
+  "expo-secure-store",
+  () => ({
+    getItemAsync: jest.fn(),
+    setItemAsync: jest.fn(),
+    deleteItemAsync: jest.fn(),
+  }),
+);
+
+jest.mock<Partial<typeof import("@/services/error-tracking")>>(
+  "@/services/error-tracking",
+  () => ({ sendError: jest.fn() }),
+);
+
+const asyncStorage = jest.mocked(AsyncStorage);
+
+const SHARER = "cms9es4dr0001wbmv1a2b3c4d";
+const DOG = "cms9es4ht0005wbmvmjg1okvo";
+
+const REFERRAL = { ref: SHARER, referredDogId: DOG };
+
+test("stores a referral opened before there is an account", async () => {
+  asyncStorage.getItem.mockResolvedValueOnce(null);
+
+  await expect(savePendingReferral(REFERRAL)).resolves.toBe(REFERRAL);
+
+  expect(asyncStorage.setItem).toHaveBeenCalledWith(
+    StorageKeys.PendingReferral,
+    JSON.stringify(REFERRAL),
+  );
+});
+
+test("keeps the first referral when a second link is opened", async () => {
+  // The link that got someone to install is the one that earned the signup.
+  // Overwriting would also make the number move for users who take days to
+  // sign up, which is exactly the cohort this measures.
+  asyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(REFERRAL));
+
+  await expect(savePendingReferral({ ref: "ig" })).resolves.toStrictEqual(
+    REFERRAL,
+  );
+
+  expect(asyncStorage.setItem).not.toHaveBeenCalled();
+});
+
+test("reads a stored referral back", async () => {
+  asyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(REFERRAL));
+
+  await expect(getPendingReferral()).resolves.toStrictEqual(REFERRAL);
+});
+
+test("returns nothing when there is no referral stored", async () => {
+  asyncStorage.getItem.mockResolvedValueOnce(null);
+
+  await expect(getPendingReferral()).resolves.toBeUndefined();
+});
+
+test.each([
+  ["the value is not JSON", "{"],
+  ["the value is not an object", '"cms9es4dr0001wbmv1a2b3c4d"'],
+  ["the ref is missing", JSON.stringify({ referredDogId: DOG })],
+  ["the ref could not have come from a link", JSON.stringify({ ref: "a b" })],
+])("returns nothing when %s", async (_reason, stored) => {
+  // Written by an older build, or edited on a rooted device. Sending it would
+  // cost a round trip the server drops on the floor anyway.
+  asyncStorage.getItem.mockResolvedValueOnce(stored);
+
+  await expect(getPendingReferral()).resolves.toBeUndefined();
+});
+
+test("drops a stored dog id that is not an id, and keeps the ref", async () => {
+  asyncStorage.getItem.mockResolvedValueOnce(
+    JSON.stringify({ ref: SHARER, referredDogId: 7 }),
+  );
+
+  await expect(getPendingReferral()).resolves.toStrictEqual({ ref: SHARER });
+});
+
+test("stores a channel token from the bio link", async () => {
+  asyncStorage.getItem.mockResolvedValueOnce(null);
+
+  await expect(savePendingReferral({ ref: "ig" })).resolves.toStrictEqual({
+    ref: "ig",
+  });
+});
+
+test("clears the referral once a login has carried it", async () => {
+  await clearPendingReferral();
+
+  expect(asyncStorage.removeItem).toHaveBeenCalledWith(
+    StorageKeys.PendingReferral,
+  );
+});
+
+test("survives a storage failure instead of taking the launch with it", async () => {
+  asyncStorage.getItem.mockRejectedValueOnce(new Error("disk full"));
+
+  await expect(getPendingReferral()).resolves.toBeUndefined();
+});

--- a/apps/mobile/src/services/referral/pending-referral.ts
+++ b/apps/mobile/src/services/referral/pending-referral.ts
@@ -1,0 +1,76 @@
+import type { Referral } from "./parse-referral-from-url";
+
+import { isReferralId, isReferralRef } from "@pegada/shared/utils/referral";
+
+import { sendError } from "@/services/error-tracking";
+import {
+  deleteData,
+  getData,
+  StorageKeys,
+  storeData,
+} from "@/services/storage";
+
+/**
+ * The gap this bridges: a link is opened before there is an account to attach
+ * it to. The user lands on a dog profile, browses, maybe closes the app, and
+ * signs up later. Attribution has to survive all of that, so it is written to
+ * disk the moment the link is read and only removed once a login has carried
+ * it to the server.
+ *
+ * Storage failures are reported and swallowed. Losing an attribution is a hole
+ * in a metric; a throw here would be a hole in the launch path, since this runs
+ * from the root layout's effect.
+ */
+
+/**
+ * First one wins. Someone who opens three friends' links before signing up is
+ * attributed to the friend whose link got them to install, not to the last one
+ * they happened to tap. Overwriting would also make the number unstable in the
+ * exact case the metric cares about: a user who takes days to sign up.
+ */
+export const savePendingReferral = async (referral: Referral) => {
+  try {
+    const existing = await getPendingReferral();
+    if (existing) return existing;
+
+    await storeData(StorageKeys.PendingReferral, JSON.stringify(referral));
+    return referral;
+  } catch (error) {
+    sendError(error);
+    return undefined;
+  }
+};
+
+export const getPendingReferral = async (): Promise<Referral | undefined> => {
+  try {
+    const stored = await getData(StorageKeys.PendingReferral);
+    if (!stored) return undefined;
+
+    const parsed: unknown = JSON.parse(stored);
+
+    // Re-validated on the way out. The value has been sitting on disk across
+    // app versions, and the server rejects a bad id anyway, so the only thing
+    // sending one would achieve is a login round trip that drops it silently.
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+
+    const { ref, referredDogId } = parsed as Record<string, unknown>;
+
+    if (!isReferralRef(ref)) return undefined;
+
+    return {
+      ref,
+      ...(isReferralId(referredDogId) ? { referredDogId } : {}),
+    };
+  } catch (error) {
+    sendError(error);
+    return undefined;
+  }
+};
+
+export const clearPendingReferral = async () => {
+  try {
+    await deleteData(StorageKeys.PendingReferral);
+  } catch (error) {
+    sendError(error);
+  }
+};

--- a/apps/mobile/src/services/referral/use-capture-referral.ts
+++ b/apps/mobile/src/services/referral/use-capture-referral.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import * as Linking from "expo-linking";
 
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { isReferralId } from "@pegada/shared/utils/referral";
 
 import { analytics } from "@/services/analytics";
@@ -32,7 +33,7 @@ const capture = async (url: string | null, cold: boolean) => {
   if (stored !== referral) return;
 
   analytics.track({
-    event_type: "Referral Captured",
+    event_type: ANALYTICS_EVENTS.REFERRAL_CAPTURED,
     event_properties: {
       ref: referral.ref,
       // Only the server can say whether this id names a real account. The app

--- a/apps/mobile/src/services/referral/use-capture-referral.ts
+++ b/apps/mobile/src/services/referral/use-capture-referral.ts
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+
+import * as Linking from "expo-linking";
+
+import { isReferralId } from "@pegada/shared/utils/referral";
+
+import { analytics } from "@/services/analytics";
+import { sendError } from "@/services/error-tracking";
+
+import { parseReferralFromUrl } from "./parse-referral-from-url";
+import { savePendingReferral } from "./pending-referral";
+
+/**
+ * Read the referral off whichever link opened the app, and put it on disk
+ * before anything else needs it.
+ *
+ * Two entry points, because a link reaches a React Native app two different
+ * ways and only one of them is an event. A cold start has already happened by
+ * the time this effect runs, so the URL is fetched; a warm link arrives while
+ * the app is alive, and is listened for. Handling only the second is the
+ * classic version of this bug: it works every time you test it with the app
+ * already open, and never for the install it was written for.
+ */
+const capture = async (url: string | null, cold: boolean) => {
+  const referral = parseReferralFromUrl(url);
+  if (!referral) return;
+
+  const stored = await savePendingReferral(referral);
+
+  // Nothing stored means either a write that failed, or an earlier referral
+  // that keeps its claim. Neither is this link's capture to report.
+  if (stored !== referral) return;
+
+  analytics.track({
+    event_type: "Referral Captured",
+    event_properties: {
+      ref: referral.ref,
+      // Only the server can say whether this id names a real account. The app
+      // reports the shape it saw, so a channel token (`ig`) and a user link
+      // are still tellable apart in the funnel before signup.
+      referredByUserId: isReferralId(referral.ref) ? referral.ref : null,
+      referredDogId: referral.referredDogId ?? null,
+      cold,
+    },
+  });
+};
+
+export const useCaptureReferral = () => {
+  useEffect(() => {
+    Linking.getInitialURL()
+      .then((url) => capture(url, true))
+      .catch(sendError);
+
+    const subscription = Linking.addEventListener("url", ({ url }) => {
+      capture(url, false).catch(sendError);
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+};

--- a/apps/mobile/src/services/referral/use-pending-referral.ts
+++ b/apps/mobile/src/services/referral/use-pending-referral.ts
@@ -1,0 +1,39 @@
+import type { Referral } from "./parse-referral-from-url";
+
+import { useEffect, useState } from "react";
+
+import { sendError } from "@/services/error-tracking";
+
+import { getPendingReferral } from "./pending-referral";
+
+/**
+ * The stored referral, read once when the screen mounts.
+ *
+ * Both halves of the login need it, because both can be the call that creates
+ * the account row: asking for a code upserts the User, and the verified login
+ * upserts it again. Reading on mount rather than at submit time keeps a disk
+ * read off the path between the user's tap and the request.
+ *
+ * `undefined` while it loads and when there is nothing stored, which the login
+ * input treats the same way: send no attribution.
+ */
+export const usePendingReferral = (): Referral | undefined => {
+  const [referral, setReferral] = useState<Referral | undefined>(undefined);
+
+  useEffect(() => {
+    let active = true;
+
+    getPendingReferral()
+      .then((pending) => {
+        if (active) setReferral(pending);
+        return undefined;
+      })
+      .catch(sendError);
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return referral;
+};

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -12,6 +12,8 @@ export enum StorageKeys {
   NewDogsAlertRequested = "newDogsAlertRequested",
   AppReviewMatchPrompted = "appReviewMatchPrompted",
   AppReviewSentMessageCount = "appReviewSentMessageCount",
+  /** JSON, written by `services/referral`. Survives the install, not the login. */
+  PendingReferral = "pendingReferral",
 }
 
 export enum Theme {
@@ -29,6 +31,7 @@ export type StorageDataTypes = {
   [StorageKeys.NewDogsAlertRequested]: "requested";
   [StorageKeys.AppReviewMatchPrompted]: "true";
   [StorageKeys.AppReviewSentMessageCount]: string;
+  [StorageKeys.PendingReferral]: string;
 };
 
 export const storeData = async <T extends StorageKeys>(

--- a/apps/mobile/src/views/(auth)/OneTimeCode/index.tsx
+++ b/apps/mobile/src/views/(auth)/OneTimeCode/index.tsx
@@ -22,6 +22,11 @@ import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
 import { getError } from "@/services/get-error";
 import { getInitialRouteName } from "@/services/get-initial-route-name";
+import {
+  clearPendingReferral,
+  LOGIN_PLATFORM,
+  usePendingReferral,
+} from "@/services/referral";
 import { StorageKeys, storeData } from "@/services/storage";
 import {
   shouldRetryTransient,
@@ -56,6 +61,10 @@ const OneTimeCode = () => {
 
   const insetTop = Math.max(15 + insets.top, 50);
 
+  // Resending a code re-runs `sendVerification`, which is one of the two calls
+  // that can create the account row, so this screen sends the referral too.
+  const referral = usePendingReferral();
+
   const loginMutation = api.authentication.login.useMutation({
     // Same policy as the email step. INVALID_OTP_CODE carries an `error_code`
     // and is never retried, so a code the server already consumed is reported
@@ -77,6 +86,12 @@ const OneTimeCode = () => {
 
         const { token } = data;
         await storeData(StorageKeys.Token, token);
+
+        // The referral has done its job: the server has either attributed the
+        // account or decided not to, and either way this device must not
+        // attribute a second one. Cleared here rather than on the server's
+        // say-so so a user who signs up twice on one phone counts once.
+        await clearPendingReferral();
 
         const initialRouteName = await getInitialRouteName();
 
@@ -121,12 +136,21 @@ const OneTimeCode = () => {
 
   const handleResendCode = () => {
     // Submitting with no code will trigger a resend
-    loginMutation.mutate({ email: email as string });
+    loginMutation.mutate({
+      email: email as string,
+      referral,
+      platform: LOGIN_PLATFORM,
+    });
   };
 
   useDidMountEffect(() => {
     if (keyboardInput.length === CODE_LENGTH) {
-      loginMutation.mutate({ email: email as string, code: keyboardInput });
+      loginMutation.mutate({
+        email: email as string,
+        code: keyboardInput,
+        referral,
+        platform: LOGIN_PLATFORM,
+      });
     }
   }, [keyboardInput]);
   styles.useVariants({ disabled: Boolean(timer) });

--- a/apps/mobile/src/views/(auth)/SignIn/index.tsx
+++ b/apps/mobile/src/views/(auth)/SignIn/index.tsx
@@ -16,6 +16,7 @@ import { useKeyboardOverlap } from "@/hooks/use-keyboard-aware-scroll";
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
 import { getError } from "@/services/get-error";
+import { LOGIN_PLATFORM, usePendingReferral } from "@/services/referral";
 import {
   shouldRetryTransient,
   transientRetryDelayMs,
@@ -63,6 +64,11 @@ const InsertEmail = () => {
   const [email, setEmail] = useState("");
   const [error, setError] = useState<string | undefined>(undefined);
 
+  // This screen's submit is what creates the account row: it asks for a code,
+  // and `sendVerification` upserts the User. The attribution columns are
+  // create-only, so if the referral is not on this request it is never written.
+  const referral = usePendingReferral();
+
   const loginMutation = api.authentication.login.useMutation({
     // The first request of a cold deployment is the one that fails, and
     // mutations do not retry by default. See services/transient-retry.ts for
@@ -106,7 +112,7 @@ const InsertEmail = () => {
     // "OTP Requested" measures the request and not a typo in the field.
     analytics.track({ event_type: "Sign In Email Submitted" });
 
-    loginMutation.mutate({ email });
+    loginMutation.mutate({ email, referral, platform: LOGIN_PLATFORM });
   };
 
   return (

--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -78,6 +78,21 @@ const nextConfig = {
   /** We already do linting and typechecking as separate tasks in CI */
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
+
+  /**
+   * `/store` is a route handler, and the middleware's matcher excludes it from
+   * next-intl, so it never gets a locale prefix. A visitor who copies
+   * `/pt-br/store` out of somewhere would otherwise get a 404 on the one link
+   * that is printed in an Instagram bio. Query strings are preserved by
+   * default, which is what keeps `?ref=` alive across the hop.
+   */
+  redirects: () => [
+    {
+      source: "/:locale(en-us|pt-br)/store",
+      destination: "/store",
+      permanent: false,
+    },
+  ],
 };
 
 const withMDX = createMDX({

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { Namespace } from "@pegada/shared/i18n/types/types";
+import { isReferralRef } from "@pegada/shared/utils/referral";
 
 import { DownloadCta } from "@/components/download-cta";
 import { getSafeLocale } from "@/lib/get-safe-locale";
@@ -27,6 +28,12 @@ type DogProfileProps = {
   params: Promise<{
     id: string;
   }>;
+  /**
+   * `ref` is the id of whoever shared this card. Read on the page and nowhere
+   * else: `generateMetadata` below never sees it, so the Open Graph card a
+   * link previewer scrapes is identical for every sharer and stays cacheable.
+   */
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
 export const generateMetadata = async ({
@@ -54,7 +61,7 @@ export const generateMetadata = async ({
   };
 };
 
-const DogProfile = async ({ params }: DogProfileProps) => {
+const DogProfile = async ({ params, searchParams }: DogProfileProps) => {
   const { id } = await params;
   const dog = await getDog(id);
   const lng = getSafeLocale();
@@ -62,6 +69,16 @@ const DogProfile = async ({ params }: DogProfileProps) => {
   if (!dog) {
     return notFound();
   }
+
+  // Same regex the app and the API use. A `ref` that does not survive it is
+  // dropped here rather than forwarded, because the next stop is an App Store
+  // campaign token and a Play install referrer.
+  const query = await searchParams;
+  const referral = isReferralRef(query?.ref) ? query.ref : undefined;
+
+  // The store route sniffs the user agent and redirects; `ref` and `dog` are
+  // what it turns into per-store attribution parameters.
+  const storeHref = referral ? `/store?ref=${referral}&dog=${id}` : "/store";
 
   const dogImage = getDogImage(dog);
   const tagline = getDogTagline(dog, lng);
@@ -185,11 +202,12 @@ const DogProfile = async ({ params }: DogProfileProps) => {
           <div className="mt-2 flex flex-col items-start gap-3">
             {/* /store is a route handler that UA-sniffs the request and redirects; it isn't a page for `Link` to prefetch or client-navigate to, which is why `store` is reported as "auto" rather than a named store. */}
             <DownloadCta
-              href="/store"
+              href={storeHref}
               page="dog_share"
               placement="desktop_copy"
               store="auto"
               dogId={id}
+              referral={referral}
               className="rounded-full bg-primary px-8 py-4 font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
             >
               {ctaButton}
@@ -207,11 +225,12 @@ const DogProfile = async ({ params }: DogProfileProps) => {
           {mobileContext}
         </p>
         <DownloadCta
-          href="/store"
+          href={storeHref}
           page="dog_share"
           placement="mobile_sticky_bar"
           store="auto"
           dogId={id}
+          referral={referral}
           className="shrink-0 rounded-full bg-primary px-5 py-3 text-sm font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
         >
           {ctaButton}

--- a/apps/nextjs/src/app/[locale]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/page.tsx
@@ -1,3 +1,4 @@
+import { readCampaign } from "@/app/store/store-urls";
 import { Cta } from "@/components/cta";
 import { HeroImage } from "@/components/hero-image";
 import { Logo } from "@/components/logo";
@@ -7,14 +8,28 @@ import { HowItWorks } from "@/components/sections/how-it-works";
 import { Screens } from "@/components/sections/screens";
 import { t } from "@/lib/translate";
 
-const App = () => {
+const App = async ({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) => {
+  // `/store` redirects desktop visitors here with whatever campaign they
+  // arrived on, so the store badges below can carry it the rest of the way.
+  const campaign = readCampaign(
+    new URLSearchParams(
+      Object.entries((await searchParams) ?? {}).flatMap(([key, value]) =>
+        typeof value === "string" ? [[key, value] as [string, string]] : [],
+      ),
+    ),
+  );
+
   return (
     <>
       <Restricter>
         <div className="flex flex-1 min-h-screen flex-wrap flex-col lg:flex-row">
           <div className="p-12 flex flex-col flex-1 gap-20 justify-between items-center lg:items-start">
             <Logo />
-            <Cta />
+            <Cta campaign={campaign} />
             <div className="gap-4 flex flex-col items-center lg:items-start">
               <a
                 href="https://www.producthunt.com/posts/pegada?embed=true&utm_source=badge-featured&utm_medium=badge&utm_souce=badge-pegada"

--- a/apps/nextjs/src/app/store/route.ts
+++ b/apps/nextjs/src/app/store/route.ts
@@ -44,6 +44,7 @@ export const GET = (request: Request) => {
   }).capture("Store Redirect", {
     store: target,
     ref: campaign.ref ?? null,
+    dogId: campaign.dog ?? null,
     utm_source: campaign.utm_source ?? null,
     utm_medium: campaign.utm_medium ?? null,
     utm_campaign: campaign.utm_campaign ?? null,

--- a/apps/nextjs/src/app/store/route.ts
+++ b/apps/nextjs/src/app/store/route.ts
@@ -1,23 +1,59 @@
 import { redirect } from "next/navigation";
 
-const WEBSITE_URL = "https://www.pegada.app/";
-const APP_STORE_URL = "https://apps.apple.com/br/app/pegada/id6450865592";
-const PLAY_STORE_URL =
-  "https://play.google.com/store/apps/details?id=app.pegada";
+import { getServerClient } from "magic-observability/next";
 
+import {
+  deployEnvironment,
+  deployRelease,
+  posthogHost,
+  posthogServerKey,
+} from "@/env";
+
+import {
+  landingPathFor,
+  readCampaign,
+  storeTargetForUserAgent,
+  storeUrlFor,
+} from "./store-urls";
+
+/**
+ * The one link that can be printed anywhere: an Instagram bio, a sticker, a
+ * reply in a comment thread. It sniffs the user agent and forwards whoever
+ * sent the visitor into the store's own campaign parameters, which is the only
+ * way an install on the other side of the App Store can be tied back to here.
+ *
+ * `https://www.pegada.app/store` is the canonical form. The old
+ * `share.pegada.app` host has no DNS record behind it (#211), so anything
+ * still pointing there is a dead link, not a slower one.
+ */
 export const GET = (request: Request) => {
   const userAgent = request.headers.get("user-agent") ?? "";
+  const target = storeTargetForUserAgent(userAgent);
+  const campaign = readCampaign(new URL(request.url).searchParams);
 
-  // Redirect to the App Store for iOS devices
-  if (/iPhone|iPad|iPod|WatchOS/i.test(userAgent)) {
-    return redirect(APP_STORE_URL);
+  // Server side because the redirect is the whole response: there is no page
+  // for a browser event to fire from, and a bot following the link should not
+  // be counted as a person either way. No key means a no-op client, and the
+  // shared facade swallows anything the SDK throws, so this cannot turn a
+  // dead bio link into a 500.
+  getServerClient({
+    key: posthogServerKey(),
+    host: posthogHost(),
+    environment: deployEnvironment(),
+    release: deployRelease(),
+  }).capture("Store Redirect", {
+    store: target,
+    ref: campaign.ref ?? null,
+    utm_source: campaign.utm_source ?? null,
+    utm_medium: campaign.utm_medium ?? null,
+    utm_campaign: campaign.utm_campaign ?? null,
+  });
+
+  // Desktop has no install to send anyone to. The landing page already shows
+  // both store badges, so it is the fallback, with the campaign still attached.
+  if (target === "web") {
+    return redirect(landingPathFor(campaign));
   }
 
-  // Redirect to Google Play Store for Android devices
-  if (/Android/i.test(userAgent)) {
-    return redirect(PLAY_STORE_URL);
-  }
-
-  // Redirect to the website or web app for all other devices
-  return redirect(WEBSITE_URL);
+  return redirect(storeUrlFor({ target, campaign }));
 };

--- a/apps/nextjs/src/app/store/store-urls.ts
+++ b/apps/nextjs/src/app/store/store-urls.ts
@@ -1,0 +1,142 @@
+import { isReferralRef } from "@pegada/shared/utils/referral";
+
+export const WEBSITE_URL = "https://www.pegada.app/";
+export const APP_STORE_URL =
+  "https://apps.apple.com/br/app/pegada/id6450865592";
+export const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=app.pegada";
+
+/** Which of the three destinations `/store` sends a request to. */
+export type StoreTarget = "ios" | "android" | "web";
+
+/** What a campaign link can carry into a store. All optional, all untrusted. */
+export type StoreCampaign = {
+  ref?: string | null;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+};
+
+/**
+ * The same sniff the route handler has always done, pulled out so the CTA can
+ * run it too. The button needs to name the store it is about to open, and
+ * asking the server would mean a round trip before a redirect.
+ */
+export const storeTargetForUserAgent = (userAgent: string): StoreTarget => {
+  if (/iPhone|iPad|iPod|WatchOS/i.test(userAgent)) return "ios";
+  if (/Android/i.test(userAgent)) return "android";
+  return "web";
+};
+
+/**
+ * Everything here is dropped unless it survives {@link isReferralRef}. These
+ * strings end up in someone else's analytics product and in a URL we hand to
+ * a browser, and every one of them arrives from a query string anyone can
+ * type. The character set is the guardrail, applied once, on the way in.
+ */
+const keep = (value: string | null | undefined) =>
+  isReferralRef(value) ? value : undefined;
+
+export const readCampaign = (params: URLSearchParams): StoreCampaign => ({
+  ref: keep(params.get("ref")),
+  utm_source: keep(params.get("utm_source")),
+  utm_medium: keep(params.get("utm_medium")),
+  utm_campaign: keep(params.get("utm_campaign")),
+});
+
+/** The campaign with every unusable value already dropped. */
+const cleanCampaign = (campaign?: StoreCampaign) => {
+  const ref = keep(campaign?.ref);
+  const source = keep(campaign?.utm_source);
+  const medium = keep(campaign?.utm_medium);
+  const name = keep(campaign?.utm_campaign);
+
+  return {
+    ref,
+    source,
+    medium,
+    name,
+    any: Boolean(ref ?? source ?? medium ?? name),
+  };
+};
+
+/**
+ * Carry the campaign across the store, which is the one hop in this funnel
+ * nobody owns.
+ *
+ * A tap on a shared dog card, or on the Instagram bio link, leaves our origin,
+ * spends a while in the App Store or Play, and comes back as a fresh install
+ * with no memory of where it came from. Both stores hand one opaque string
+ * through to the installed app, under different names and different rules:
+ *
+ *   - Apple: `ct` is the campaign token on an App Store link, readable through
+ *     App Analytics. `pt` (provider token) would let it show up per-provider;
+ *     this project has no provider id, and inventing one would just be a
+ *     parameter Apple ignores.
+ *   - Google: `referrer` is a single URL-encoded query string, handed to the
+ *     app through the Install Referrer API. It is conventionally utm_*, so the
+ *     incoming utm_* values are folded into it and the `ref` rides as
+ *     `utm_content`.
+ */
+export const storeUrlFor = ({
+  target,
+  campaign,
+}: {
+  target: StoreTarget;
+  campaign?: StoreCampaign;
+}): string => {
+  const {
+    ref,
+    source,
+    medium,
+    name,
+    any: hasCampaign,
+  } = cleanCampaign(campaign);
+
+  if (target === "ios") {
+    // Apple takes one token. The referrer is the thing worth knowing; the utm_*
+    // values have no separate field to land in.
+    if (!ref) return APP_STORE_URL;
+    const url = new URL(APP_STORE_URL);
+    url.searchParams.set("ct", ref);
+    return url.toString();
+  }
+
+  if (target === "android") {
+    if (!hasCampaign) return PLAY_STORE_URL;
+
+    const referrer = new URLSearchParams();
+    referrer.set("utm_source", source ?? "pegada");
+    referrer.set("utm_medium", medium ?? "share");
+    if (name) referrer.set("utm_campaign", name);
+    if (ref) referrer.set("utm_content", ref);
+
+    const url = new URL(PLAY_STORE_URL);
+    url.searchParams.set("referrer", referrer.toString());
+    return url.toString();
+  }
+
+  // Desktop. No install to attribute, but the campaign rides along so the
+  // landing page's own store badges can carry it to whichever phone follows.
+  if (!hasCampaign) return WEBSITE_URL;
+
+  const url = new URL(WEBSITE_URL);
+  if (ref) url.searchParams.set("ref", ref);
+  if (source) url.searchParams.set("utm_source", source);
+  if (medium) url.searchParams.set("utm_medium", medium);
+  if (name) url.searchParams.set("utm_campaign", name);
+  return url.toString();
+};
+
+/**
+ * The desktop fallback, as a path on this site rather than an absolute URL.
+ *
+ * `/store` is a route handler, so it cannot also render a page. The landing
+ * page already shows both store badges, which is exactly the fallback a
+ * desktop visitor needs, so the redirect goes there and the campaign rides
+ * along in the query for the badges to pick up.
+ */
+export const landingPathFor = (campaign?: StoreCampaign): string => {
+  const absolute = new URL(storeUrlFor({ target: "web", campaign }));
+  return `/${absolute.search}`;
+};

--- a/apps/nextjs/src/app/store/store-urls.ts
+++ b/apps/nextjs/src/app/store/store-urls.ts
@@ -1,4 +1,4 @@
-import { isReferralRef } from "@pegada/shared/utils/referral";
+import { isReferralId, isReferralRef } from "@pegada/shared/utils/referral";
 
 export const WEBSITE_URL = "https://www.pegada.app/";
 export const APP_STORE_URL =
@@ -12,6 +12,7 @@ export type StoreTarget = "ios" | "android" | "web";
 /** What a campaign link can carry into a store. All optional, all untrusted. */
 export type StoreCampaign = {
   ref?: string | null;
+  dog?: string | null;
   utm_source?: string | null;
   utm_medium?: string | null;
   utm_campaign?: string | null;
@@ -37,8 +38,17 @@ export const storeTargetForUserAgent = (userAgent: string): StoreTarget => {
 const keep = (value: string | null | undefined) =>
   isReferralRef(value) ? value : undefined;
 
+/**
+ * `dog` is narrower than `ref`. A referrer can be a hand typed channel token
+ * like `ig`, but the dog is always an id this site put on the link itself, so
+ * it is held to the id pattern.
+ */
+const keepDog = (value: string | null | undefined) =>
+  isReferralId(value) ? value : undefined;
+
 export const readCampaign = (params: URLSearchParams): StoreCampaign => ({
   ref: keep(params.get("ref")),
+  dog: keepDog(params.get("dog")),
   utm_source: keep(params.get("utm_source")),
   utm_medium: keep(params.get("utm_medium")),
   utm_campaign: keep(params.get("utm_campaign")),
@@ -47,16 +57,18 @@ export const readCampaign = (params: URLSearchParams): StoreCampaign => ({
 /** The campaign with every unusable value already dropped. */
 const cleanCampaign = (campaign?: StoreCampaign) => {
   const ref = keep(campaign?.ref);
+  const dog = keepDog(campaign?.dog);
   const source = keep(campaign?.utm_source);
   const medium = keep(campaign?.utm_medium);
   const name = keep(campaign?.utm_campaign);
 
   return {
     ref,
+    dog,
     source,
     medium,
     name,
-    any: Boolean(ref ?? source ?? medium ?? name),
+    any: Boolean(ref ?? dog ?? source ?? medium ?? name),
   };
 };
 
@@ -72,11 +84,12 @@ const cleanCampaign = (campaign?: StoreCampaign) => {
  *   - Apple: `ct` is the campaign token on an App Store link, readable through
  *     App Analytics. `pt` (provider token) would let it show up per-provider;
  *     this project has no provider id, and inventing one would just be a
- *     parameter Apple ignores.
+ *     parameter Apple ignores. One slot, so the referrer takes it and the dog
+ *     is not carried at all on iOS.
  *   - Google: `referrer` is a single URL-encoded query string, handed to the
  *     app through the Install Referrer API. It is conventionally utm_*, so the
- *     incoming utm_* values are folded into it and the `ref` rides as
- *     `utm_content`.
+ *     incoming utm_* values are folded into it, the `ref` rides as
+ *     `utm_content` and the shared dog rides as `utm_term`.
  */
 export const storeUrlFor = ({
   target,
@@ -87,6 +100,7 @@ export const storeUrlFor = ({
 }): string => {
   const {
     ref,
+    dog,
     source,
     medium,
     name,
@@ -110,6 +124,7 @@ export const storeUrlFor = ({
     referrer.set("utm_medium", medium ?? "share");
     if (name) referrer.set("utm_campaign", name);
     if (ref) referrer.set("utm_content", ref);
+    if (dog) referrer.set("utm_term", dog);
 
     const url = new URL(PLAY_STORE_URL);
     url.searchParams.set("referrer", referrer.toString());

--- a/apps/nextjs/src/components/cta.tsx
+++ b/apps/nextjs/src/components/cta.tsx
@@ -1,7 +1,15 @@
+import type { StoreCampaign } from "@/app/store/store-urls";
+
+import { storeUrlFor } from "@/app/store/store-urls";
 import { StoreButton } from "@/components/store-button";
 import { t } from "@/lib/translate";
 
-export const Cta = () => {
+/**
+ * `campaign` is what the visitor arrived with. `/store` sends desktop traffic
+ * here rather than to a store nobody can install from, so these two badges are
+ * the end of that funnel and the last chance to keep the referrer attached.
+ */
+export const Cta = ({ campaign }: { campaign?: StoreCampaign }) => {
   return (
     <div className="self-center lg:self-start lg:min-w-[300px] max-w-[30rem] flex flex-col gap-8">
       <div className="flex flex-col gap-6">
@@ -14,11 +22,12 @@ export const Cta = () => {
       </div>
       <div className="appearFromBottom flex gap-3 flex-col lg:flex-row">
         <StoreButton
-          href="https://apps.apple.com/br/app/pegada/id6450865592"
+          href={storeUrlFor({ target: "ios", campaign })}
           target="_blank"
           page="landing"
           placement="hero"
           store="app_store"
+          referral={campaign?.ref ?? undefined}
         >
           <StoreButton.Icon
             width={20}
@@ -29,11 +38,12 @@ export const Cta = () => {
           <StoreButton.Text>{t("home.cta.appStore")}</StoreButton.Text>
         </StoreButton>
         <StoreButton
-          href="https://play.google.com/store/apps/details?id=app.pegada"
+          href={storeUrlFor({ target: "android", campaign })}
           target="_blank"
           page="landing"
           placement="hero"
           store="play_store"
+          referral={campaign?.ref ?? undefined}
         >
           <StoreButton.Icon
             width={24}

--- a/apps/nextjs/src/components/download-cta.tsx
+++ b/apps/nextjs/src/components/download-cta.tsx
@@ -33,15 +33,16 @@ export const DownloadCta = ({
   placement,
   store,
   dogId,
+  referral,
   onClick,
   ...props
 }: ComponentProps<"a"> & DownloadCtaClick) => {
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLAnchorElement>) => {
-      trackDownloadCtaClicked({ page, placement, store, dogId });
+      trackDownloadCtaClicked({ page, placement, store, dogId, referral });
       onClick?.(event);
     },
-    [page, placement, store, dogId, onClick],
+    [page, placement, store, dogId, referral, onClick],
   );
 
   return (

--- a/apps/nextjs/src/services/analytics.ts
+++ b/apps/nextjs/src/services/analytics.ts
@@ -31,19 +31,30 @@ export type DownloadCtaClick = {
   store: DownloadCtaStore;
   /** Only on `dog_share`: whose profile the visitor arrived through. */
   dogId?: string;
+  /**
+   * The `?ref=` the visitor arrived with: a user id when the app generated
+   * the link, or a hand typed channel token like `ig`. Reported so a click
+   * here can be lined up with the "Store Redirect" that follows it and with
+   * the install the store eventually attributes.
+   *
+   * Not named `ref`: React reserves that prop name, and this type is spread
+   * onto an anchor. It goes out as `ref`, the same key `/store` sends.
+   */
+  referral?: string;
 };
 
 /**
  * The property bag, split out from the capture so it can be asserted on
- * without a PostHog client. `dog_id` is omitted rather than sent as `null`
- * on the landing page: PostHog stores an explicit null and it would show up
- * as a real value in a breakdown.
+ * without a PostHog client. `dog_id` and `ref` are omitted rather than sent
+ * as `null` on the landing page: PostHog stores an explicit null and it would
+ * show up as a real value in a breakdown.
  */
 export const downloadCtaProperties = (click: DownloadCtaClick) => ({
   page: click.page,
   placement: click.placement,
   store: click.store,
   ...(click.dogId === undefined ? {} : { dog_id: click.dogId }),
+  ...(click.referral === undefined ? {} : { ref: click.referral }),
 });
 
 /**

--- a/apps/nextjs/tests/download-cta-event.test.mjs
+++ b/apps/nextjs/tests/download-cta-event.test.mjs
@@ -49,6 +49,40 @@ test("a share page click carries the dog it came from", () => {
   );
 });
 
+test("a click on a shared link carries the referrer it arrived with", () => {
+  // The same key `/store` sends on "Store Redirect", so the click and the
+  // redirect it causes can be lined up on one property.
+  assert.deepEqual(
+    analytics.downloadCtaProperties({
+      page: "dog_share",
+      placement: "desktop_copy",
+      store: "auto",
+      dogId: "dog_123",
+      referral: "ig",
+    }),
+    {
+      page: "dog_share",
+      placement: "desktop_copy",
+      store: "auto",
+      dog_id: "dog_123",
+      ref: "ig",
+    },
+  );
+});
+
+test("ref is absent rather than null when nobody referred the visitor", () => {
+  assert.equal(
+    "ref" in
+      analytics.downloadCtaProperties({
+        page: "dog_share",
+        placement: "desktop_copy",
+        store: "auto",
+        dogId: "dog_123",
+      }),
+    false,
+  );
+});
+
 test("dog_id is absent rather than null when there is no dog", () => {
   // An explicit null is a value PostHog stores and shows in a breakdown,
   // which would put a "null" row next to the real dog ids.

--- a/apps/nextjs/tests/store-urls.test.mjs
+++ b/apps/nextjs/tests/store-urls.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+/**
+ * The store is the blind spot in the share funnel: a tap leaves our origin,
+ * spends time in Apple's or Google's app, and comes back as an install with no
+ * memory of the dog card or the bio link that started it. These parameters are
+ * the only thing that survives that hop, so a typo in one of them is a week of
+ * attributed signups that silently reads zero.
+ *
+ * Imported as TypeScript on purpose. Node strips types on the versions this
+ * repo pins (.nvmrc 22.23, CI `node-version: 22.x`), which keeps the URL
+ * building in the module the route handler and the CTA actually import rather
+ * than in a copy that can drift from it.
+ */
+const {
+  APP_STORE_URL,
+  PLAY_STORE_URL,
+  WEBSITE_URL,
+  landingPathFor,
+  readCampaign,
+  storeTargetForUserAgent,
+  storeUrlFor,
+} = await import("../src/app/store/store-urls.ts");
+
+const REF = "cms9es4dr0001wbmv1a2b3c4d";
+
+const IPHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1";
+const ANDROID_UA =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36";
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+
+test("routes each user agent to its own store", () => {
+  assert.equal(storeTargetForUserAgent(IPHONE_UA), "ios");
+  assert.equal(storeTargetForUserAgent(ANDROID_UA), "android");
+  assert.equal(storeTargetForUserAgent(DESKTOP_UA), "web");
+  assert.equal(storeTargetForUserAgent(""), "web");
+});
+
+test("an App Store link carries the referrer as a campaign token", () => {
+  const url = new URL(storeUrlFor({ target: "ios", campaign: { ref: REF } }));
+
+  assert.equal(url.origin + url.pathname, APP_STORE_URL);
+  assert.equal(url.searchParams.get("ct"), REF);
+});
+
+test("a Play link carries the referrer as an install referrer string", () => {
+  // Google hands this through verbatim to the Install Referrer API, so the
+  // encoding is the contract: one parameter whose value is itself a query
+  // string.
+  const url = storeUrlFor({ target: "android", campaign: { ref: REF } });
+
+  assert.equal(
+    url,
+    `${PLAY_STORE_URL}&referrer=utm_source%3Dpegada%26utm_medium%3Dshare%26utm_content%3D${REF}`,
+  );
+
+  assert.equal(
+    new URL(url).searchParams.get("referrer"),
+    `utm_source=pegada&utm_medium=share&utm_content=${REF}`,
+  );
+});
+
+test("incoming utm values win over the share defaults on Play", () => {
+  // The bio link is a campaign in its own right, not a share, and the readout
+  // has to be able to separate the two.
+  const url = storeUrlFor({
+    target: "android",
+    campaign: {
+      ref: "ig",
+      utm_source: "instagram",
+      utm_medium: "bio",
+      utm_campaign: "launch",
+    },
+  });
+
+  assert.equal(
+    new URL(url).searchParams.get("referrer"),
+    "utm_source=instagram&utm_medium=bio&utm_campaign=launch&utm_content=ig",
+  );
+});
+
+test("a channel token is a valid referrer everywhere", () => {
+  // `ref=ig` is the Instagram bio link. It is not a user id and must not be
+  // dropped as if it were malformed.
+  assert.equal(
+    new URL(
+      storeUrlFor({ target: "ios", campaign: { ref: "ig" } }),
+    ).searchParams.get("ct"),
+    "ig",
+  );
+  assert.equal(landingPathFor({ ref: "ig" }), "/?ref=ig");
+});
+
+test("the desktop fallback stays on this site and keeps the campaign", () => {
+  // There is no install to send a desktop visitor to, and the landing page
+  // already shows both store badges.
+  assert.equal(
+    storeUrlFor({ target: "web", campaign: { ref: REF } }),
+    `${WEBSITE_URL}?ref=${REF}`,
+  );
+
+  assert.equal(landingPathFor({ ref: REF }), `/?ref=${REF}`);
+  assert.equal(
+    landingPathFor({ ref: "ig", utm_source: "instagram" }),
+    "/?ref=ig&utm_source=instagram",
+  );
+  assert.equal(landingPathFor(), "/");
+});
+
+test("a link with no campaign is the link we shipped before", () => {
+  for (const campaign of [undefined, {}, { ref: null }, { ref: "" }]) {
+    assert.equal(storeUrlFor({ target: "ios", campaign }), APP_STORE_URL);
+    assert.equal(storeUrlFor({ target: "android", campaign }), PLAY_STORE_URL);
+    assert.equal(storeUrlFor({ target: "web", campaign }), WEBSITE_URL);
+  }
+});
+
+test("a campaign value that could not have come from a link never reaches a store", () => {
+  // These arrive from a query string anyone can edit, and they end up inside
+  // Apple's and Google's analytics, not ours.
+  for (const ref of [
+    "a",
+    "../../admin",
+    `${REF}&pt=evil`,
+    "a".repeat(33),
+    "<script>alert(1)</script>",
+    "utm_source=x&utm_medium=y",
+  ]) {
+    assert.equal(
+      storeUrlFor({ target: "ios", campaign: { ref } }),
+      APP_STORE_URL,
+    );
+    assert.equal(
+      storeUrlFor({ target: "android", campaign: { ref } }),
+      PLAY_STORE_URL,
+    );
+    assert.equal(
+      storeUrlFor({ target: "web", campaign: { ref } }),
+      WEBSITE_URL,
+    );
+  }
+});
+
+test("readCampaign takes only the four parameters, validated", () => {
+  const params = new URLSearchParams(
+    "ref=ig&utm_source=instagram&utm_medium=bio&utm_campaign=a b&other=keepout",
+  );
+
+  assert.deepEqual(readCampaign(params), {
+    ref: "ig",
+    utm_source: "instagram",
+    utm_medium: "bio",
+    // A space cannot appear in a value we generated, so it is dropped rather
+    // than escaped into a store's campaign report.
+    utm_campaign: undefined,
+  });
+});

--- a/apps/nextjs/tests/store-urls.test.mjs
+++ b/apps/nextjs/tests/store-urls.test.mjs
@@ -24,6 +24,7 @@ const {
 } = await import("../src/app/store/store-urls.ts");
 
 const REF = "cms9es4dr0001wbmv1a2b3c4d";
+const DOG_ID = "cms9es4dr0002wbmv9z8y7x6w";
 
 const IPHONE_UA =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1";
@@ -144,17 +145,53 @@ test("a campaign value that could not have come from a link never reaches a stor
   }
 });
 
-test("readCampaign takes only the four parameters, validated", () => {
+test("readCampaign takes only the campaign parameters, validated", () => {
   const params = new URLSearchParams(
-    "ref=ig&utm_source=instagram&utm_medium=bio&utm_campaign=a b&other=keepout",
+    `ref=ig&dog=${DOG_ID}&utm_source=instagram&utm_medium=bio&utm_campaign=a b&other=keepout`,
   );
 
   assert.deepEqual(readCampaign(params), {
     ref: "ig",
+    dog: DOG_ID,
     utm_source: "instagram",
     utm_medium: "bio",
     // A space cannot appear in a value we generated, so it is dropped rather
     // than escaped into a store's campaign report.
     utm_campaign: undefined,
   });
+});
+
+test("the shared dog rides to Play as utm_term and nowhere on iOS", () => {
+  // The dog card is the whole point of the share, so an install has to be able
+  // to open on the dog that earned it. Google's referrer has room for it;
+  // Apple's `ct` is a single slot already spent on the referrer, so on iOS the
+  // dog is dropped rather than smuggled into the same token.
+  const campaign = { ref: REF, dog: DOG_ID };
+
+  assert.equal(
+    new URL(storeUrlFor({ target: "android", campaign })).searchParams.get(
+      "referrer",
+    ),
+    `utm_source=pegada&utm_medium=share&utm_content=${REF}&utm_term=${DOG_ID}`,
+  );
+
+  const ios = new URL(storeUrlFor({ target: "ios", campaign }));
+  assert.equal(ios.searchParams.get("ct"), REF);
+  assert.equal(ios.search, `?ct=${REF}`);
+});
+
+test("a dog that could not be an id never reaches Play", () => {
+  // `dog` is always written by this site, never typed by a human, so a channel
+  // token or anything shorter than an id is a tampered link.
+  for (const dog of [
+    "ig",
+    "../../admin",
+    `${DOG_ID}&pt=evil`,
+    "a".repeat(33),
+  ]) {
+    assert.equal(
+      storeUrlFor({ target: "android", campaign: { ref: REF, dog } }),
+      `${PLAY_STORE_URL}&referrer=utm_source%3Dpegada%26utm_medium%3Dshare%26utm_content%3D${REF}`,
+    );
+  }
 });

--- a/packages/api/src/errors/errors.ts
+++ b/packages/api/src/errors/errors.ts
@@ -16,6 +16,32 @@ export const sendError = (error: any, context?: Record<string, unknown>) => {
   observability.captureError(error, context);
 };
 
+/**
+ * Product events, on the same funnel as {@link sendError} and for the same
+ * reason: `shared/observability.ts` is the only module allowed to know which
+ * SDK is underneath, and everything that reports goes through this file.
+ *
+ * `distinctId` is a property rather than an argument because that is how the
+ * node adapter reads it; without one the event is attributed to `"server"`.
+ *
+ * The try/catch is not decoration. Every call site here sits on a path a user
+ * is waiting on, and an event that fails to serialise must not become a login
+ * that fails to complete.
+ */
+export const sendEvent = (
+  event: string,
+  properties?: Record<string, unknown>,
+) => {
+  try {
+    observability.capture(event, properties);
+  } catch (error) {
+    if (config.NODE_ENV === "development") {
+      // oxlint-disable-next-line no-console -- Development-only; a swallowed analytics failure is otherwise invisible.
+      console.error(error);
+    }
+  }
+};
+
 export const logDebug = (...props: unknown[]) => {
   if (config.NODE_ENV === "development") {
     // oxlint-disable-next-line no-console -- Development-only mirror of what gets reported to PostHog.

--- a/packages/api/src/routes/authentication.ts
+++ b/packages/api/src/routes/authentication.ts
@@ -1,3 +1,7 @@
+import {
+  REFERRAL_ID_REGEX,
+  REFERRAL_REF_REGEX,
+} from "@pegada/shared/utils/referral";
 import { z } from "zod";
 
 import { AuthenticationService } from "../services/authentication-service";
@@ -6,6 +10,24 @@ import { createTRPCRouter, publicProcedure } from "../trpc";
 const authenticationBodySchema = z.object({
   email: z.string().email(),
   code: z.string().optional(),
+  /**
+   * Where this install came from: a shared dog card, or a channel link such
+   * as the Instagram bio. `ref` is whatever was in the link; the service
+   * decides whether it names a user or a channel.
+   *
+   * `.catch(undefined)` rather than a hard reject: these values travel through
+   * chat apps, link previewers and store referrer strings, and a mangled one
+   * is a lost attribution, not a login the user should be locked out of. The
+   * regexes still run, so nothing unvalidated reaches a query.
+   */
+  referral: z
+    .object({
+      ref: z.string().regex(REFERRAL_REF_REGEX),
+      referredDogId: z.string().regex(REFERRAL_ID_REGEX).optional(),
+    })
+    .optional()
+    .catch(undefined),
+  platform: z.enum(["ios", "android", "web"]).optional().catch(undefined),
 });
 
 export const authenticationRouter = createTRPCRouter({
@@ -27,6 +49,8 @@ export const authenticationRouter = createTRPCRouter({
       const user = await authenticationService.login({
         email: input.email,
         code: input.code,
+        referral: input.referral,
+        platform: input.platform,
       });
 
       const token = ctx.jwtSign({ sub: user.id });

--- a/packages/api/src/services/authentication-service.test.ts
+++ b/packages/api/src/services/authentication-service.test.ts
@@ -7,6 +7,7 @@ import { AuthenticationService } from "./authentication-service";
 // `enqueue.test.ts` uses to keep that chain out of suites that don't test it.
 jest.mock("../errors/errors", () => ({
   sendError: jest.fn(),
+  sendEvent: jest.fn(),
   logDebug: () => undefined,
   errorDebug: () => undefined,
 }));

--- a/packages/api/src/services/authentication-service.ts
+++ b/packages/api/src/services/authentication-service.ts
@@ -11,6 +11,13 @@ import {
 import { enqueue } from "../queue/enqueue";
 import { TOPICS } from "../queue/topics";
 import { config, isMagicEmail } from "../shared/config";
+import {
+  attributionColumns,
+  attributionForNewAccount,
+  trackSignupAttributed,
+  type ReferralInput,
+  type ReferralPlatform,
+} from "./referral-attribution";
 
 /**
  * Compile `APPLE_MAGIC_EMAIL_REGEX` once at module load. Re-thrown invalid
@@ -88,9 +95,19 @@ export class AuthenticationService {
     this.language = props.language;
   }
 
-  async login({ email, code }: { email: string; code?: string }) {
+  async login({
+    email,
+    code,
+    referral,
+    platform,
+  }: {
+    email: string;
+    code?: string;
+    referral?: ReferralInput;
+    platform?: ReferralPlatform;
+  }) {
     if (!code) {
-      await this.sendVerification(email);
+      await this.sendVerification(email, { referral, platform });
       throw new OTPRequiredError();
     }
 
@@ -110,13 +127,24 @@ export class AuthenticationService {
       await purgeUserByEmail(email);
     }
 
+    // Reached only when the email has no row yet, which for a real address
+    // means the OTP was issued by a magic bypass rather than by
+    // `sendVerification`'s upsert below. Both entry points attribute the same
+    // way so it does not matter which one got there first.
+    const attribution = await attributionForNewAccount({ email, referral });
+
     const user = await prisma.user.upsert({
       where: { email },
       update: { deletedAt: null },
       create: {
         email,
+        ...(attribution ? attributionColumns(attribution) : {}),
       },
     });
+
+    if (attribution) {
+      trackSignupAttributed({ userId: user.id, attribution, platform });
+    }
 
     return user;
   }
@@ -125,7 +153,16 @@ export class AuthenticationService {
     return randomInt(0, 1_000_000).toString().padStart(6, "0");
   }
 
-  async sendVerification(email: string) {
+  /**
+   * `referral` is threaded through here rather than only into `login` because
+   * this is where a new account's row is actually born: asking for a code
+   * upserts the User, so by the time the code comes back the row exists and
+   * the create-only attribution columns would never be written.
+   */
+  async sendVerification(
+    email: string,
+    options?: { referral?: ReferralInput; platform?: ReferralPlatform },
+  ) {
     // Magic emails bypass real OTP delivery. APPLE_MAGIC_EMAIL accepts a
     // comma-separated list (see config.ts) so destructive E2E flows can use
     // a dedicated disposable account without nuking the primary review user.
@@ -144,11 +181,29 @@ export class AuthenticationService {
     const oneHour = 60 * 60 * 1000;
     const expiresAt = new Date(Date.now() + oneHour);
 
-    await prisma.user.upsert({
+    const attribution = await attributionForNewAccount({
+      email,
+      referral: options?.referral,
+    });
+
+    const user = await prisma.user.upsert({
       where: { email },
       update: { code, codeExpiresAt: expiresAt },
-      create: { email, code, codeExpiresAt: expiresAt },
+      create: {
+        email,
+        code,
+        codeExpiresAt: expiresAt,
+        ...(attribution ? attributionColumns(attribution) : {}),
+      },
     });
+
+    if (attribution) {
+      trackSignupAttributed({
+        userId: user.id,
+        attribution,
+        platform: options?.platform,
+      });
+    }
 
     // `fallbackInline` because this is the one job a user is actively waiting
     // on: the code row is already written, so a failed publish means a login

--- a/packages/api/src/services/referral-attribution.test.ts
+++ b/packages/api/src/services/referral-attribution.test.ts
@@ -1,0 +1,289 @@
+/**
+ * These cover the guards that stand between a link anyone can edit and three
+ * columns the readout depends on. The metric is attributed signups over
+ * signups: a `ref` that was never checked, or one that gets rewritten on a
+ * later login, does not make the number wrong in an obvious way. It makes it
+ * quietly wrong, which is worse than having no number at all.
+ */
+import prisma from "@pegada/database";
+
+import { sendEvent } from "../errors/errors";
+import { AuthenticationService } from "./authentication-service";
+import {
+  attributionForNewAccount,
+  trackSignupAttributed,
+} from "./referral-attribution";
+
+// Same mock the other auth suites use: `errors.ts` pulls in the ESM-only
+// `magic-observability/node`, which jest cannot parse.
+jest.mock("../errors/errors", () => ({
+  sendError: jest.fn(),
+  sendEvent: jest.fn(),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
+// The OTP request path publishes a mail job. This suite is about what lands in
+// the User row on the way past it, not about delivery.
+jest.mock("../queue/enqueue", () => ({ enqueue: jest.fn() }));
+
+const events = jest.mocked(sendEvent);
+
+const REFERRER_EMAIL = "referral-referrer@pegada.app";
+const INVITED_EMAIL = "referral-invited@pegada.app";
+const EMAILS = [REFERRER_EMAIL, INVITED_EMAIL];
+
+const CODE = "123456";
+
+/** Well formed, 25 characters like a cuid, belongs to nobody. */
+const MISSING_ID = "z".repeat(25);
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.user.deleteMany({ where: { email: { in: EMAILS } } });
+});
+
+const seedReferrer = () =>
+  prisma.user.create({ data: { email: REFERRER_EMAIL } });
+
+const seedInvitedWithCode = () =>
+  prisma.user.create({
+    data: {
+      email: INVITED_EMAIL,
+      code: CODE,
+      codeExpiresAt: new Date(Date.now() + 60_000),
+    },
+  });
+
+describe("attributionForNewAccount", () => {
+  it("attributes a new account to the user whose link it was", async () => {
+    const referrer = await seedReferrer();
+
+    await expect(
+      attributionForNewAccount({
+        email: INVITED_EMAIL,
+        referral: { ref: referrer.id, referredDogId: MISSING_ID },
+      }),
+    ).resolves.toEqual({
+      ref: referrer.id,
+      referredByUserId: referrer.id,
+      referredDogId: MISSING_ID,
+      referralSource: null,
+    });
+  });
+
+  it("keeps a channel token as a source rather than a referrer", async () => {
+    // `ref=ig` is the Instagram bio link. It names no account, and the readout
+    // still has to be able to tell it apart from an unattributed signup.
+    await expect(
+      attributionForNewAccount({
+        email: INVITED_EMAIL,
+        referral: { ref: "ig" },
+      }),
+    ).resolves.toEqual({
+      ref: "ig",
+      referredByUserId: null,
+      referredDogId: null,
+      referralSource: "ig",
+    });
+  });
+
+  it("attributes nothing when the account already exists", async () => {
+    const referrer = await seedReferrer();
+    await prisma.user.create({ data: { email: INVITED_EMAIL } });
+
+    await expect(
+      attributionForNewAccount({
+        email: INVITED_EMAIL,
+        referral: { ref: referrer.id },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("drops an id-shaped ref that names nobody", async () => {
+    // A dead link, not a channel. Storing it as a source would put junk in the
+    // column the readout groups by.
+    await expect(
+      attributionForNewAccount({
+        email: INVITED_EMAIL,
+        referral: { ref: MISSING_ID },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("drops an id-shaped ref whose owner is deleted", async () => {
+    const referrer = await prisma.user.create({
+      data: { email: REFERRER_EMAIL, deletedAt: new Date() },
+    });
+
+    await expect(
+      attributionForNewAccount({
+        email: INVITED_EMAIL,
+        referral: { ref: referrer.id },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("refuses a user referring their own email", async () => {
+    const referrer = await seedReferrer();
+
+    await expect(
+      attributionForNewAccount({
+        email: REFERRER_EMAIL,
+        referral: { ref: referrer.id },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("ignores refs that could not have come from one of our links", async () => {
+    const results = await Promise.all(
+      [
+        "",
+        "a",
+        "../../etc/passwd",
+        "a b",
+        'ig\'; DROP TABLE "User"; --',
+        "a".repeat(33),
+        "<script>",
+      ].map((ref) =>
+        attributionForNewAccount({ email: INVITED_EMAIL, referral: { ref } }),
+      ),
+    );
+
+    expect(results).toEqual(results.map(() => null));
+  });
+
+  it("keeps the referrer when only the dog id is malformed", async () => {
+    const referrer = await seedReferrer();
+
+    await expect(
+      attributionForNewAccount({
+        email: INVITED_EMAIL,
+        referral: { ref: referrer.id, referredDogId: "nope" },
+      }),
+    ).resolves.toMatchObject({
+      referredByUserId: referrer.id,
+      referredDogId: null,
+    });
+  });
+});
+
+describe("trackSignupAttributed", () => {
+  it("reports ids and a platform, and never an email", () => {
+    trackSignupAttributed({
+      userId: "user-id",
+      attribution: {
+        ref: "referrer-id",
+        referredByUserId: "referrer-id",
+        referredDogId: "dog-id",
+        referralSource: null,
+      },
+      platform: "ios",
+    });
+
+    expect(events).toHaveBeenCalledWith("Signup Attributed", {
+      distinctId: "user-id",
+      ref: "referrer-id",
+      referredByUserId: "referrer-id",
+      referredDogId: "dog-id",
+      referralSource: null,
+      platform: "ios",
+    });
+
+    const [, properties] = events.mock.calls[0] ?? [];
+    expect(JSON.stringify(properties)).not.toContain("@");
+  });
+});
+
+describe("AuthenticationService referral attribution", () => {
+  it("writes attribution on the account the OTP request creates", async () => {
+    const referrer = await seedReferrer();
+
+    await expect(
+      new AuthenticationService({}).login({
+        email: INVITED_EMAIL,
+        referral: { ref: referrer.id, referredDogId: MISSING_ID },
+        platform: "ios",
+      }),
+    ).rejects.toThrow();
+
+    await expect(
+      prisma.user.findUnique({ where: { email: INVITED_EMAIL } }),
+    ).resolves.toMatchObject({
+      referredByUserId: referrer.id,
+      referredDogId: MISSING_ID,
+      referralSource: null,
+    });
+
+    expect(events).toHaveBeenCalledWith(
+      "Signup Attributed",
+      expect.objectContaining({
+        ref: referrer.id,
+        referredByUserId: referrer.id,
+        referredDogId: MISSING_ID,
+        platform: "ios",
+      }),
+    );
+  });
+
+  it("records a channel signup with no referrer", async () => {
+    await expect(
+      new AuthenticationService({}).login({
+        email: INVITED_EMAIL,
+        referral: { ref: "ig" },
+        platform: "android",
+      }),
+    ).rejects.toThrow();
+
+    await expect(
+      prisma.user.findUnique({ where: { email: INVITED_EMAIL } }),
+    ).resolves.toMatchObject({
+      referredByUserId: null,
+      referralSource: "ig",
+    });
+  });
+
+  it("leaves an existing account's attribution alone on re-login", async () => {
+    const referrer = await seedReferrer();
+    const invited = await prisma.user.create({
+      data: {
+        email: INVITED_EMAIL,
+        code: CODE,
+        codeExpiresAt: new Date(Date.now() + 60_000),
+        referredByUserId: null,
+      },
+    });
+
+    await new AuthenticationService({}).login({
+      email: INVITED_EMAIL,
+      code: CODE,
+      referral: { ref: referrer.id },
+    });
+
+    await expect(
+      prisma.user.findUnique({ where: { id: invited.id } }),
+    ).resolves.toMatchObject({
+      referredByUserId: null,
+      referralSource: null,
+    });
+
+    expect(events).not.toHaveBeenCalled();
+  });
+
+  it("logs in normally when the referral is unusable", async () => {
+    const invited = await seedInvitedWithCode();
+
+    await expect(
+      new AuthenticationService({}).login({
+        email: INVITED_EMAIL,
+        code: CODE,
+        referral: { ref: MISSING_ID },
+      }),
+    ).resolves.toMatchObject({ id: invited.id });
+
+    expect(events).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/referral-attribution.ts
+++ b/packages/api/src/services/referral-attribution.ts
@@ -1,4 +1,5 @@
 import prisma from "@pegada/database";
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { isReferralId, isReferralRef } from "@pegada/shared/utils/referral";
 
 import { sendEvent } from "../errors/errors";
@@ -125,7 +126,7 @@ export const trackSignupAttributed = ({
   attribution: ReferralAttribution;
   platform?: ReferralPlatform;
 }) => {
-  sendEvent("Signup Attributed", {
+  sendEvent(ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED, {
     distinctId: userId,
     ref: attribution.ref,
     referredByUserId: attribution.referredByUserId,

--- a/packages/api/src/services/referral-attribution.ts
+++ b/packages/api/src/services/referral-attribution.ts
@@ -1,0 +1,136 @@
+import prisma from "@pegada/database";
+import { isReferralId, isReferralRef } from "@pegada/shared/utils/referral";
+
+import { sendEvent } from "../errors/errors";
+
+/** What a share link can tell us, once it has been through the input schema. */
+export type ReferralInput = {
+  /** A user id from a generated link, or a channel token like `ig`. */
+  ref: string;
+  referredDogId?: string;
+};
+
+/** Where the tap happened, for splitting the readout by store. */
+export type ReferralPlatform = "ios" | "android" | "web";
+
+/** The columns to write. `null` means "attribute nothing and say nothing". */
+export type ReferralAttribution = {
+  ref: string;
+  referredByUserId: string | null;
+  referredDogId: string | null;
+  referralSource: string | null;
+};
+
+/**
+ * Decide what a login should attribute, if anything.
+ *
+ * `ref` is resolved against the User table rather than trusted: a value that
+ * names a real account becomes a referrer, and anything else is kept as a raw
+ * source. That is what lets one parameter serve both a link the app generated
+ * and a channel token a human typed into a profile bio, without the readout
+ * having to guess which it was looking at.
+ *
+ * Returns non-null only when the account does not exist yet, because these are
+ * write-once columns: an account that is already there either has its
+ * attribution or was never attributed, and a second share link opened months
+ * later must not rewrite either answer. Callers put the result in the `create`
+ * branch of their upsert, so the database enforces the same rule a second time.
+ *
+ * Everything unusable resolves to `null` rather than throwing. A link
+ * truncated by a chat app, or someone forwarding their own link back to
+ * themselves, is not a reason to fail a login.
+ */
+export const attributionForNewAccount = async ({
+  email,
+  referral,
+}: {
+  email: string;
+  referral?: ReferralInput;
+}): Promise<ReferralAttribution | null> => {
+  if (!referral) return null;
+  if (!isReferralRef(referral.ref)) return null;
+
+  const referredDogId = isReferralId(referral.referredDogId)
+    ? referral.referredDogId
+    : null;
+
+  const [existing, referrer] = await Promise.all([
+    prisma.user.findUnique({ where: { email }, select: { id: true } }),
+    // Only an id-shaped `ref` can name a user, and asking the database about
+    // `ig` would be a query that can only ever come back empty.
+    isReferralId(referral.ref)
+      ? prisma.user.findUnique({
+          where: { id: referral.ref },
+          select: { id: true, email: true, deletedAt: true },
+        })
+      : null,
+  ]);
+
+  if (existing) return null;
+
+  const isUsableReferrer =
+    referrer !== null &&
+    !referrer.deletedAt &&
+    // Self-referral. Compared on email because that is the identity the login
+    // is being performed under; its account row may not exist yet.
+    referrer.email !== email;
+
+  if (isUsableReferrer) {
+    return {
+      ref: referral.ref,
+      referredByUserId: referrer.id,
+      referredDogId,
+      referralSource: null,
+    };
+  }
+
+  // An id-shaped ref that resolves to nobody is a dead link, not a channel.
+  // Storing it as a source would put junk in the column the readout groups by.
+  if (isReferralId(referral.ref)) return null;
+
+  return {
+    ref: referral.ref,
+    referredByUserId: null,
+    referredDogId,
+    referralSource: referral.ref,
+  };
+};
+
+/** The columns, without the `ref` that is only carried on the event. */
+export const attributionColumns = ({
+  referredByUserId,
+  referredDogId,
+  referralSource,
+}: ReferralAttribution) => ({
+  referredByUserId,
+  referredDogId,
+  referralSource,
+});
+
+/**
+ * The numerator of the metric this whole change exists to produce: attributed
+ * signups over signups, weekly. Fired once, next to the write that created the
+ * account, so the two numbers are counted at the same moment.
+ *
+ * No email, and no dog name. The properties are ids, a channel token and a
+ * platform, all of which are already in the database, so the event adds a
+ * timestamp and nothing a person could be identified by.
+ */
+export const trackSignupAttributed = ({
+  userId,
+  attribution,
+  platform,
+}: {
+  userId: string;
+  attribution: ReferralAttribution;
+  platform?: ReferralPlatform;
+}) => {
+  sendEvent("Signup Attributed", {
+    distinctId: userId,
+    ref: attribution.ref,
+    referredByUserId: attribution.referredByUserId,
+    referredDogId: attribution.referredDogId,
+    referralSource: attribution.referralSource,
+    platform: platform ?? "unknown",
+  });
+};

--- a/packages/database/migrations/20260901120000_add_user_referral_attribution/migration.sql
+++ b/packages/database/migrations/20260901120000_add_user_referral_attribution/migration.sql
@@ -1,0 +1,18 @@
+-- Attribution for the install and signup that came out of a shared dog card.
+--
+-- Two nullable columns and one index. Every existing row keeps NULL, which is
+-- what "we never knew" has to look like: the baseline this measures is
+-- attributed signups over all signups, and backfilling a default would put a
+-- number on weeks the link never carried a ref.
+ALTER TABLE "User" ADD COLUMN "referredByUserId" TEXT;
+ALTER TABLE "User" ADD COLUMN "referredDogId" TEXT;
+
+-- `ref` also carries channel tokens (`ig` for the Instagram bio link), which
+-- resolve to no user at all. Kept as its own column rather than stuffed into
+-- "referredByUserId", so a join against User stays a join and the readout can
+-- split "a friend shared this" from "they came from our own bio link".
+ALTER TABLE "User" ADD COLUMN "referralSource" TEXT;
+
+-- The readout is "how many accounts did this user bring in", so the query is
+-- always a lookup by referrer. Without this it is a sequential scan of User.
+CREATE INDEX "User_referredByUserId_idx" ON "User"("referredByUserId");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -86,9 +86,26 @@ model User {
 
   subscriptionEvents SubscriptionEvent[]
 
+  // Which shared dog card brought this account in. Both are plain ids rather
+  // than relations: `relationMode = "prisma"` would turn a relation into an
+  // application-side existence check on every write, and the referrer is
+  // already checked once, at signup, before either column is written.
+  //
+  // Write-once. Set in the `create` branch of the upserts in
+  // authentication-service.ts and never updated, so a returning user who
+  // opens someone else's share link keeps the attribution they signed up
+  // with.
+  referredByUserId String?
+  referredDogId    String?
+  // The raw `ref` when it was a channel token rather than a user id: `ig` for
+  // the Instagram bio link, and whatever the next channel is called. Exactly
+  // one of this and `referredByUserId` is set on an attributed account.
+  referralSource   String?
+
   @@index([latitude])
   @@index([longitude])
   @@index([lastActiveAt])
+  @@index([referredByUserId])
 }
 
 /// Append-only log of every RevenueCat webhook event, so trial conversion,

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -47,6 +47,7 @@ export const ANALYTICS_EVENTS = {
   PUSH_NOTIFICATION_OPENED: "Push Notification Opened",
   REENGAGEMENT_PUSH_SENT: "Reengagement Push Sent",
   PUSH_PERMISSION: "Push Permission",
+  REFERRAL_CAPTURED: "Referral Captured",
   RESTORE_PURCHASES: "RestorePurchases",
   RESTORE_PURCHASES_SUCCESS: "Restore Purchases Success",
   SAVE_PREFERENCES_PRESSED: "Save Preferences Pressed",
@@ -203,6 +204,15 @@ export type MobileEventProperties = {
    */
   [ANALYTICS_EVENTS.PUSH_NOTIFICATION_OPENED]: { kind?: string; url?: string };
   [ANALYTICS_EVENTS.PUSH_PERMISSION]: { status: PermissionStatus };
+  // Keys stay camelCase here: they are the same names the referral link and
+  // the server attribution already use, and matching them keeps a capture and
+  // the signup it leads to joinable without a translation step.
+  [ANALYTICS_EVENTS.REFERRAL_CAPTURED]: {
+    cold: boolean;
+    ref: string;
+    referredByUserId: string | null;
+    referredDogId: string | null;
+  };
   [ANALYTICS_EVENTS.RESTORE_PURCHASES]: undefined;
   [ANALYTICS_EVENTS.RESTORE_PURCHASES_SUCCESS]: undefined;
   [ANALYTICS_EVENTS.SAVE_PREFERENCES_PRESSED]: {
@@ -387,6 +397,7 @@ export const MOBILE_EVENT_NAMES = [
   ANALYTICS_EVENTS.PROFILE_PHOTO_ADDED,
   ANALYTICS_EVENTS.PUSH_NOTIFICATION_OPENED,
   ANALYTICS_EVENTS.PUSH_PERMISSION,
+  ANALYTICS_EVENTS.REFERRAL_CAPTURED,
   ANALYTICS_EVENTS.RESTORE_PURCHASES,
   ANALYTICS_EVENTS.RESTORE_PURCHASES_SUCCESS,
   ANALYTICS_EVENTS.SAVE_PREFERENCES_PRESSED,

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -55,6 +55,7 @@ export const ANALYTICS_EVENTS = {
   SHARE_COMPLETED: "Share Completed",
   SHARE_TAPPED: "Share Tapped",
   SIGN_IN_EMAIL_SUBMITTED: "Sign In Email Submitted",
+  SIGNUP_ATTRIBUTED: "Signup Attributed",
   SKIP_COMPLETE_DOG_PROFILE: "Skip Complete Dog Profile",
   SUBSCRIPTION_EVENT: "Subscription Event",
   SWIPE: "Swipe",
@@ -318,6 +319,17 @@ export type ServerEventProperties = {
     dedupe_key: string;
     kind: ReengagementPushKind;
   };
+  // Keys stay camelCase for the same reason "Referral Captured" keeps them:
+  // the two events are joined on `ref` and `referredByUserId`, and a capture
+  // that spells a key one way and the signup it produced another way is a
+  // funnel nobody can build.
+  [ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED]: {
+    platform: string;
+    ref: string;
+    referralSource: string | null;
+    referredByUserId: string | null;
+    referredDogId: string | null;
+  };
   [ANALYTICS_EVENTS.SUBSCRIPTION_EVENT]: {
     cancel_reason?: SubscriptionCancelReason | null;
     currency?: string | null;
@@ -415,6 +427,7 @@ export const SERVER_EVENT_NAMES = [
   ANALYTICS_EVENTS.MATCH_CREATED,
   ANALYTICS_EVENTS.MESSAGE_SENT,
   ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT,
+  ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED,
   ANALYTICS_EVENTS.SUBSCRIPTION_EVENT,
 ] as const;
 

--- a/packages/shared/utils/referral.ts
+++ b/packages/shared/utils/referral.ts
@@ -1,0 +1,33 @@
+/**
+ * Two different things travel in `?ref=`, and conflating them is how a share
+ * link ends up attributed to nobody.
+ *
+ * A user id is what the app puts on a link it generates. A channel token is
+ * what a human types once and pastes into a profile: `ref=ig` in the Instagram
+ * bio, and whatever the next channel is called. The signup path resolves the
+ * value against the User table and stores it as a referrer or as a raw source
+ * depending on which it turns out to be, so both need to survive validation.
+ */
+
+/**
+ * A Pegada id. Prisma's `@default(cuid())` is 25 lowercase alphanumerics; the
+ * bounds are a little wider so a cuid2 id or a shorter fixture still passes.
+ * Used for dog ids, and to decide whether a `ref` could be a user id at all.
+ */
+export const REFERRAL_ID_REGEX = /^[a-z0-9]{20,32}$/;
+
+export const isReferralId = (value: unknown): value is string =>
+  typeof value === "string" && REFERRAL_ID_REGEX.test(value);
+
+/**
+ * Anything `?ref=` is allowed to carry: an id, or a short channel token.
+ *
+ * Wide enough for `ig`, narrow enough that nothing with a slash, a dot, a
+ * space, a percent escape or a quote reaches a database query, an App Store
+ * campaign token or a Play install referrer. These values are typed by hand
+ * and arrive from the open internet, so the character set is the guardrail.
+ */
+export const REFERRAL_REF_REGEX = /^[a-zA-Z0-9_-]{2,32}$/;
+
+export const isReferralRef = (value: unknown): value is string =>
+  typeof value === "string" && REFERRAL_REF_REGEX.test(value);


### PR DESCRIPTION
## Summary
Shared dog links and the store link now carry who shared them, and a new account remembers which dog and which person brought it in.

## Details
- Hypothesis: sharing already sends people to the stores, but nothing links a share to an install or a signup. This PR is the instrument, so K factor and any future referral reward can be computed. Expected after two weeks with sharing live: at least 10 percent of new signups carry a referrer; under 3 percent means the share entry points are not worth more investment.
- Baseline: none. There is no referrer column and no attribution event. This PR establishes it.
- Readout: server event `Signup Attributed` with `ref`, `referredByUserId`, `referredDogId`, `referralSource` and `platform`, divided by signups per week. The event fires when the account row is created, which happens when the code is requested, so the denominator has to be account creations in the same window (`User.createdAt`), not verified sign ins. Web: `Store Redirect` on the store hop itself, and `Download CTA Clicked` with `page`, `placement`, `store` and `ref` on the button that leads to it. Mobile: `Referral Captured`. SQL fallback: count of users with `referredByUserId` or `referralSource` set over users created in the last 14 days.
- Links accept `?ref=<value>` where the value is either a user id or a channel token such as `ig`. Values are validated with a strict pattern; emails never appear in a URL or an event.
- Web: the dog page reads `ref` and forwards it into the download button #215 already put there, so there is still one button and one `Download CTA Clicked` event, now with the referrer on it and a `/store?ref=...&dog=...` href. `https://www.pegada.app/store` is now the canonical store link: it redirects by device to the App Store with `ct` or to Google Play with `referrer` (utm parameters folded in), desktop lands on the home page with the campaign kept in the store badges, and `/pt-br/store` and `/en-us/store` redirect there. The Instagram bio link should become `https://www.pegada.app/store?ref=ig` (see #211). Open Graph tags never include `ref`.
- App: the ref is captured from the link on cold start and while the app is open, kept until sign in completes, then sent with account creation and cleared. React Native's own URL parser does not handle custom schemes, so parsing is hand written and covered by tests.
- API: `User.referredByUserId`, `User.referredDogId` and `User.referralSource` are written only when the account is created; a later sign in never overwrites them, an unknown referrer is ignored, and the attribution event fires after the row exists.
- The app has no screen for `/dog/<id>` until #187 lands, and Expo Router mounted nothing for a deep link it cannot match, so a shared dog link left the app on the splash and the referral went with it. This PR adds a not found route that redirects to the root, so the root layout runs, the referral is captured and the person goes through the normal sign in. #187 adds the real dog screens and edits the root layout too, so whichever of #220 and #187 lands second resolves a small conflict there. #186 stays additive: its share link builder can wrap its URL with the new helper once both are merged. Both `Referral Captured` and `Signup Attributed` are registered in the shared event catalogue from #213.

Closes #196

## Testing steps
1. Open a shared dog link (the one that carries the sharer at the end) on a phone without the app installed. On the web page, tap the download button and confirm the store opens.
2. Open the same link on a phone with the app installed but signed out, then sign in with a brand new email. In the database the new account shows the referrer and the dog.
3. Sign out and sign in again with a different link. The original referrer stays.
4. Visit the store link from the Instagram bio on an iPhone, an Android phone and a laptop. The first two go straight to the store listing, the laptop shows the home page with the store badges.

## Screenshots
Sign in screen right after a cold start from a shared link, with the referrer kept for the signup that follows:

![sign in after link](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-referral-attribution/shots/verify-signin-after-cold-link.png)

Web dog page with the ref forwarded into the download button:

![dog page](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-referral-attribution/shots/web-dog-page-with-ref.png)

Desktop fallback for the store link:

![store fallback](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-referral-attribution/shots/web-store-desktop-fallback.png)



