### PR TITLE
feat(mobile): empty deck that keeps people around

### DIFF
--- a/apps/mobile/src/services/get-push-notification-token.ts
+++ b/apps/mobile/src/services/get-push-notification-token.ts
@@ -27,6 +27,13 @@ export enum NotificationTokenError {
 }
 
 /**
+ * A refusal is a normal outcome of asking, so callers that offer an opt-in
+ * record it and move on. Every other rejection is a real failure.
+ */
+export const isPushDeniedError = (error: unknown) =>
+  error instanceof Error && error.message === NotificationTokenError.Denied;
+
+/**
  * Records the standing permission state on the person, so "matched but never
  * messaged" can be split by whether the app was ever allowed to tell them.
  */

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -9,6 +9,7 @@ export enum StorageKeys {
   Language = "language",
   AppReviewRequestDate = "appReviewRequestDate",
   AppReviewStatus = "appReviewStatus",
+  NewDogsAlertRequested = "newDogsAlertRequested",
 }
 
 export enum Theme {
@@ -23,6 +24,7 @@ export type StorageDataTypes = {
   [StorageKeys.Language]: string;
   [StorageKeys.AppReviewRequestDate]: string;
   [StorageKeys.AppReviewStatus]: "completed";
+  [StorageKeys.NewDogsAlertRequested]: "requested";
 };
 
 export const storeData = async <T extends StorageKeys>(

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
@@ -29,6 +29,7 @@ import { getData, StorageKeys, storeData } from "@/services/storage";
 import { Actions } from "@/store/reducers";
 import { SceneName } from "@/types/scene-name";
 
+import { isNewDogsAlertRequested } from "./new-dogs-alert";
 import {
   Description,
   EmptyAnimation,
@@ -58,16 +59,26 @@ export const EmptyComponent = () => {
  */
 const NotifyNewDogsButton = () => {
   const { t } = useTranslation();
-  const [requested, setRequested] = useState(false);
+  const [storedLocally, setStoredLocally] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const requestAlert = api.user.requestNewDogsAlert.useMutation();
+  // The user carries the answer across installs and across a cleared local
+  // state, so the button cannot offer the opt-in a second time to someone who
+  // already took it. This is a plain query on purpose: the empty deck still
+  // has to render while it is in flight or failing.
+  const me = api.user.me.useQuery();
 
-  // The done state has to survive a re-render and a relaunch, and the deck is
-  // empty precisely when there is nothing else to read it from.
+  const requested = isNewDogsAlertRequested({
+    storedLocally,
+    requestedAt: me.data?.newDogsAlertRequestedAt,
+  });
+
+  // The local flag is the fast path: it answers before the request comes back
+  // and it keeps answering with no network at all.
   useEffect(() => {
     getData(StorageKeys.NewDogsAlertRequested)
-      .then((value) => setRequested(Boolean(value)))
+      .then((value) => setStoredLocally(Boolean(value)))
       .catch(sendError);
   }, []);
 
@@ -88,7 +99,7 @@ const NotifyNewDogsButton = () => {
     try {
       await requestAlert.mutateAsync();
       await storeData(StorageKeys.NewDogsAlertRequested, "requested");
-      setRequested(true);
+      setStoredLocally(true);
     } catch (error) {
       sendError(error);
       Alert.alert(t("common.somethingWrong"), t("common.tryAgainLater"));
@@ -99,7 +110,10 @@ const NotifyNewDogsButton = () => {
 
   return (
     <Button
-      disabled={requested}
+      // On a fresh install the answer is only on the server, so the button
+      // stays out of reach until it arrives. Offering it in that window lets
+      // someone who already opted in tap a second time.
+      disabled={requested || me.isPending}
       loading={loading}
       onPress={() => void handlePress()}
       variant={requested ? "outline" : "default"}
@@ -168,7 +182,7 @@ const EmptyState = () => {
   );
 };
 
-const SwipeRequestFeedback = () => {
+const SwipeRequestFeedback = ({ deckIsEmpty }: { deckIsEmpty: boolean }) => {
   const offline = useIsOffline();
   const request = useSelector((state: RootReducer) => state.dogs.request);
   const dispatch = useDispatch();
@@ -176,9 +190,10 @@ const SwipeRequestFeedback = () => {
   // This component sits behind the deck on every render, so mounting says
   // nothing about a deck being empty. It mounts mid-load, with cards, and on
   // the error screen. The event belongs to the one state that is genuinely
-  // empty: the request settled, it did not fail, we are online, and nothing
-  // came back. The ref re-arms when cards arrive, so a later refetch that
-  // returns empty again is a second event while a re-render is not.
+  // empty: the request settled, it did not fail, we are online, and there is
+  // no card left to act on. The ref re-arms when cards arrive, so a later
+  // refetch that returns empty again is a second event while a re-render is
+  // not.
   const isEmptyDeck =
     !request.loading && !request.error && !offline && request.data.length === 0;
   const hasReportedEmptyDeck = useRef(false);
@@ -212,6 +227,10 @@ const SwipeRequestFeedback = () => {
 
   if (offline) return <OfflineComponent reset={refetch} />;
   if (request.error) return <RequestErrorComponent reset={refetch} />;
+
+  // Mounting the empty state behind a full deck kept an animation running and
+  // asked the server about the alert opt-in for people who never see either.
+  if (!deckIsEmpty) return null;
 
   return <EmptyState />;
 };

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
@@ -1,7 +1,7 @@
 import type { RootReducer } from "@/store/reducers";
 
-import { useEffect, useRef } from "react";
-import { View } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import { Alert, Share, View } from "react-native";
 
 import { router } from "expo-router";
 
@@ -16,7 +16,16 @@ import {
   useIsOffline,
 } from "@/components/NetworkBoundary";
 import { Container, Content } from "@/components/NetworkBoundary/styles";
+import { APP_SHARE_LINK_BASE } from "@/constants";
+import { api } from "@/contexts/trpc-provider";
 import { analytics } from "@/services/analytics";
+import { sendError } from "@/services/error-tracking";
+import {
+  getPushNotificationToken,
+  isPushDeniedError,
+  setPushNotificationToken,
+} from "@/services/get-push-notification-token";
+import { getData, StorageKeys, storeData } from "@/services/storage";
 import { Actions } from "@/store/reducers";
 import { SceneName } from "@/types/scene-name";
 
@@ -42,6 +51,88 @@ export const EmptyComponent = () => {
   );
 };
 
+/**
+ * The opt-in for an alert that does not exist yet. Nothing sends a "new dogs
+ * near you" push today, so the button only stores the intent: the share of
+ * people who tap it here decides whether that alert is worth building.
+ */
+const NotifyNewDogsButton = () => {
+  const { t } = useTranslation();
+  const [requested, setRequested] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const requestAlert = api.user.requestNewDogsAlert.useMutation();
+
+  // The done state has to survive a re-render and a relaunch, and the deck is
+  // empty precisely when there is nothing else to read it from.
+  useEffect(() => {
+    getData(StorageKeys.NewDogsAlertRequested)
+      .then((value) => setRequested(Boolean(value)))
+      .catch(sendError);
+  }, []);
+
+  const handlePress = async () => {
+    setLoading(true);
+
+    try {
+      const token = await getPushNotificationToken();
+      if (token) await setPushNotificationToken(token);
+    } catch (error) {
+      // A refusal is one of the answers this button expects, so only the rest
+      // is worth reporting.
+      if (!isPushDeniedError(error)) sendError(error);
+    }
+
+    // A refused permission is still someone asking to be told, so the intent
+    // is recorded either way.
+    try {
+      await requestAlert.mutateAsync();
+      await storeData(StorageKeys.NewDogsAlertRequested, "requested");
+      setRequested(true);
+    } catch (error) {
+      sendError(error);
+      Alert.alert(t("common.somethingWrong"), t("common.tryAgainLater"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      disabled={requested}
+      loading={loading}
+      onPress={() => void handlePress()}
+      variant={requested ? "outline" : "default"}
+    >
+      {requested
+        ? t("swipeRequestFeedback.notifyNewDogsDone")
+        : t("swipeRequestFeedback.notifyNewDogsButton")}
+    </Button>
+  );
+};
+
+const InviteFriendButton = () => {
+  const { t } = useTranslation();
+
+  const handlePress = async () => {
+    try {
+      await Share.share({
+        message: t("swipeRequestFeedback.inviteFriendMessage", {
+          link: `${APP_SHARE_LINK_BASE}/store`,
+        }),
+      });
+    } catch (error) {
+      sendError(error);
+    }
+  };
+
+  return (
+    <Button onPress={() => void handlePress()} variant="outline">
+      {t("swipeRequestFeedback.inviteFriendButton")}
+    </Button>
+  );
+};
+
 const EmptyState = () => {
   const { t } = useTranslation();
 
@@ -61,12 +152,16 @@ const EmptyState = () => {
           <Description fontSize="xs" style={styles.description}>
             {t("swipeRequestFeedback.emptyDescription")}
           </Description>
-          <Button
-            onPress={() => router.push(SceneName.Preferences)}
-            variant="outline"
-          >
-            {t("swipeRequestFeedback.preferencesButton")}
-          </Button>
+          <View style={styles.actions}>
+            <NotifyNewDogsButton />
+            <InviteFriendButton />
+            <Button
+              onPress={() => router.push(SceneName.Preferences)}
+              variant="outline"
+            >
+              {t("swipeRequestFeedback.preferencesButton")}
+            </Button>
+          </View>
         </Animated.View>
       </View>
     </Content>
@@ -79,7 +174,7 @@ const SwipeRequestFeedback = () => {
   const dispatch = useDispatch();
 
   // This component sits behind the deck on every render, so mounting says
-  // nothing about a deck being empty — it mounts mid-load, with cards, and on
+  // nothing about a deck being empty. It mounts mid-load, with cards, and on
   // the error screen. The event belongs to the one state that is genuinely
   // empty: the request settled, it did not fail, we are online, and nothing
   // came back. The ref re-arms when cards arrive, so a later refetch that

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
@@ -1,5 +1,7 @@
 import type { RootReducer } from "@/store/reducers";
 
+import type { ShareAction } from "react-native";
+
 import { useEffect, useRef, useState } from "react";
 import { Alert, Share, View } from "react-native";
 
@@ -29,7 +31,13 @@ import { getData, StorageKeys, storeData } from "@/services/storage";
 import { Actions } from "@/store/reducers";
 import { SceneName } from "@/types/scene-name";
 
-import { isNewDogsAlertRequested } from "./new-dogs-alert";
+import {
+  EmptyDeckAction,
+  isNewDogsAlertRequested,
+  PushPermission,
+  pushPermissionFromToken,
+  shareOutcomeOf,
+} from "./new-dogs-alert";
 import {
   Description,
   EmptyAnimation,
@@ -85,17 +93,33 @@ const NotifyNewDogsButton = () => {
   const handlePress = async () => {
     setLoading(true);
 
+    let pushPermission = PushPermission.Unavailable;
+
     try {
       const token = await getPushNotificationToken();
+      pushPermission = pushPermissionFromToken(token);
       if (token) await setPushNotificationToken(token);
     } catch (error) {
       // A refusal is one of the answers this button expects, so only the rest
-      // is worth reporting.
-      if (!isPushDeniedError(error)) sendError(error);
+      // is worth reporting. The prompt itself already sent its own event, so
+      // this one only carries the outcome.
+      if (isPushDeniedError(error)) {
+        pushPermission = PushPermission.Denied;
+      } else {
+        sendError(error);
+      }
     }
 
+    analytics.track({
+      event_type: "Empty Deck Action Tapped",
+      event_properties: {
+        action: EmptyDeckAction.NotifyNewDogs,
+        push_permission: pushPermission,
+      },
+    });
+
     // A refused permission is still someone asking to be told, so the intent
-    // is recorded either way.
+    // is recorded either way and the readout keeps the two apart.
     try {
       await requestAlert.mutateAsync();
       await storeData(StorageKeys.NewDogsAlertRequested, "requested");
@@ -129,8 +153,10 @@ const InviteFriendButton = () => {
   const { t } = useTranslation();
 
   const handlePress = async () => {
+    let result: ShareAction | undefined;
+
     try {
-      await Share.share({
+      result = await Share.share({
         message: t("swipeRequestFeedback.inviteFriendMessage", {
           link: `${APP_SHARE_LINK_BASE}/store`,
         }),
@@ -138,6 +164,16 @@ const InviteFriendButton = () => {
     } catch (error) {
       sendError(error);
     }
+
+    // One event per tap, fired once the sheet settles, so the funnel counts
+    // taps and carries whether the invite actually went out.
+    analytics.track({
+      event_type: "Empty Deck Action Tapped",
+      event_properties: {
+        action: EmptyDeckAction.InviteFriend,
+        share_result: shareOutcomeOf(result),
+      },
+    });
   };
 
   return (
@@ -191,11 +227,13 @@ const SwipeRequestFeedback = ({ deckIsEmpty }: { deckIsEmpty: boolean }) => {
   // nothing about a deck being empty. It mounts mid-load, with cards, and on
   // the error screen. The event belongs to the one state that is genuinely
   // empty: the request settled, it did not fail, we are online, and there is
-  // no card left to act on. The ref re-arms when cards arrive, so a later
-  // refetch that returns empty again is a second event while a re-render is
-  // not.
+  // no card left to act on. `deckIsEmpty` rather than an empty list, because
+  // the card that was just swiped stays in the list so it can be swiped back:
+  // a deck swiped to the end never empties the list and would never have been
+  // counted. The ref re-arms when cards arrive, so a later refetch that
+  // returns empty again is a second event while a re-render is not.
   const isEmptyDeck =
-    !request.loading && !request.error && !offline && request.data.length === 0;
+    !request.loading && !request.error && !offline && deckIsEmpty;
   const hasReportedEmptyDeck = useRef(false);
 
   useEffect(() => {

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.test.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.test.ts
@@ -1,10 +1,55 @@
 /**
- * The alert opt-in is a fake door, so its done state has to be right in both
- * directions: offering it again to someone who already took it inflates the
- * intent number that decides whether the alert gets built, and hiding it too
- * early loses the answer.
+ * The empty deck funnel is only readable if "Empty Deck Action Tapped" carries
+ * properties that keep the possible answers apart. Both the push and the share
+ * APIs answer in three ways rather than two, and the alert opt-in has to know
+ * it was already taken or the intent number that decides whether the alert
+ * gets built counts the same person twice.
  */
-import { isNewDogsAlertRequested } from "./new-dogs-alert";
+import type { ShareAction } from "react-native";
+
+import {
+  isNewDogsAlertRequested,
+  PushPermission,
+  pushPermissionFromToken,
+  ShareOutcome,
+  shareOutcomeOf,
+} from "./new-dogs-alert";
+
+describe("pushPermissionFromToken", () => {
+  it("counts a token as granted", () => {
+    expect(pushPermissionFromToken("ExponentPushToken[abc]")).toBe(
+      PushPermission.Granted,
+    );
+  });
+
+  it("counts a missing token as unavailable rather than denied", () => {
+    // `getPushNotificationToken` returns undefined without prompting when it
+    // is not on a real device. Reading that as a refusal would put simulator
+    // and web sessions in the denied bucket.
+    expect(pushPermissionFromToken(undefined)).toBe(PushPermission.Unavailable);
+  });
+});
+
+describe("shareOutcomeOf", () => {
+  it("counts a completed share as shared", () => {
+    expect(shareOutcomeOf({ action: "sharedAction" } as ShareAction)).toBe(
+      ShareOutcome.Shared,
+    );
+  });
+
+  it("counts a cancelled sheet as dismissed", () => {
+    expect(shareOutcomeOf({ action: "dismissedAction" } as ShareAction)).toBe(
+      ShareOutcome.Dismissed,
+    );
+  });
+
+  it("counts a sheet that never opened as unavailable", () => {
+    // `Share.share` rejects where the sheet cannot be shown, and there is no
+    // result to read. Filing that under dismissed would read as people
+    // opening the invite and changing their minds.
+    expect(shareOutcomeOf(undefined)).toBe(ShareOutcome.Unavailable);
+  });
+});
 
 describe("isNewDogsAlertRequested", () => {
   it("is done when the local flag says so", () => {
@@ -15,8 +60,8 @@ describe("isNewDogsAlertRequested", () => {
 
   it("is done when the server has the request and the device does not", () => {
     // What a reinstall or a cleared local state looks like. Without the
-    // server value the button offers the opt-in again to someone who already
-    // opted in.
+    // server value the button offers the opt-in again and a second tap event
+    // lands in the funnel for someone who already opted in.
     expect(
       isNewDogsAlertRequested({
         storedLocally: false,

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.test.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The alert opt-in is a fake door, so its done state has to be right in both
+ * directions: offering it again to someone who already took it inflates the
+ * intent number that decides whether the alert gets built, and hiding it too
+ * early loses the answer.
+ */
+import { isNewDogsAlertRequested } from "./new-dogs-alert";
+
+describe("isNewDogsAlertRequested", () => {
+  it("is done when the local flag says so", () => {
+    expect(
+      isNewDogsAlertRequested({ storedLocally: true, requestedAt: null }),
+    ).toBe(true);
+  });
+
+  it("is done when the server has the request and the device does not", () => {
+    // What a reinstall or a cleared local state looks like. Without the
+    // server value the button offers the opt-in again to someone who already
+    // opted in.
+    expect(
+      isNewDogsAlertRequested({
+        storedLocally: false,
+        requestedAt: new Date("2026-01-01"),
+      }),
+    ).toBe(true);
+  });
+
+  it("is open while the server answer has not arrived", () => {
+    expect(
+      isNewDogsAlertRequested({ storedLocally: false, requestedAt: undefined }),
+    ).toBe(false);
+  });
+
+  it("is open when neither source has it", () => {
+    expect(
+      isNewDogsAlertRequested({ storedLocally: false, requestedAt: null }),
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
@@ -1,0 +1,12 @@
+/**
+ * The button is done when either source says so. The local flag answers
+ * immediately and keeps working offline, and the server value is what brings
+ * the state back after a reinstall or after local storage was cleared.
+ */
+export const isNewDogsAlertRequested = ({
+  storedLocally,
+  requestedAt,
+}: {
+  storedLocally: boolean;
+  requestedAt?: Date | null;
+}) => storedLocally || Boolean(requestedAt);

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
@@ -1,3 +1,49 @@
+import type { ShareAction } from "react-native";
+
+/**
+ * The values of the three enums below are the property values the catalogue
+ * declares for "Empty Deck Action Tapped", so `analytics.track` is what checks
+ * they stay in step.
+ */
+export enum EmptyDeckAction {
+  NotifyNewDogs = "notify_new_dogs",
+  InviteFriend = "invite_friend",
+}
+
+export enum PushPermission {
+  Granted = "granted",
+  Denied = "denied",
+  /** The platform never asked, which on a simulator is every time. */
+  Unavailable = "unavailable",
+}
+
+export enum ShareOutcome {
+  Shared = "shared",
+  Dismissed = "dismissed",
+  Unavailable = "unavailable",
+}
+
+/**
+ * `getPushNotificationToken` resolves with a token when the user allowed
+ * notifications and with `undefined` when it never got as far as asking,
+ * which is what happens off a real device.
+ */
+export const pushPermissionFromToken = (token: string | undefined) =>
+  token ? PushPermission.Granted : PushPermission.Unavailable;
+
+/**
+ * `undefined` is the sheet that never opened: `Share.share` rejects on a
+ * platform that cannot show it, and counting that as a dismissal would read
+ * as people changing their minds.
+ */
+export const shareOutcomeOf = (result: ShareAction | undefined) => {
+  if (!result) return ShareOutcome.Unavailable;
+
+  return result.action === "sharedAction"
+    ? ShareOutcome.Shared
+    : ShareOutcome.Dismissed;
+};
+
 /**
  * The button is done when either source says so. The local flag answers
  * immediately and keeps working offline, and the server value is what brings

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/styles.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/styles.ts
@@ -31,6 +31,9 @@ export const styles = StyleSheet.create((theme) => ({
     marginBottom: theme.spacing[4],
     maxWidth: 274,
   },
+  actions: {
+    gap: theme.spacing[3],
+  },
 }));
 
 export const Container = withUnistyles(LikeFeedbackStyles.Container);

--- a/apps/mobile/src/views/(tabs)/Swipe/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/index.tsx
@@ -50,6 +50,10 @@ const Matches = () => {
   const topInset = useCustomTopInset();
   const dispatch = useDispatch();
   const cards = useSelector(getCards);
+  // The card that was just swiped stays in the list so it can be swiped back,
+  // so the deck runs out when there is no card left to act on rather than when
+  // the list empties.
+  const currentCardId = useSelector(getCurrentCardId);
 
   useEffect(() => {
     trackUser();
@@ -81,7 +85,7 @@ const Matches = () => {
       <ChangeLocation />
       <Container style={styles.container} edges={["left", "right"]}>
         <SwipeBackButton />
-        <SwipeRequestFeedback />
+        <SwipeRequestFeedback deckIsEmpty={!currentCardId} />
         {cards
           .map((card) => <SwipeHandler key={card.id} card={card} />)
           .slice(0, MAX_TO_RENDER)

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -33,6 +33,17 @@ export const userRouter = createTRPCRouter({
     }),
 
   /**
+   * Interest signal from the empty swipe deck: the user wants to hear about it
+   * when a new dog turns up. Nothing sends that alert yet, so this only stores
+   * the intent and the share of empty-deck viewers who tap decides whether the
+   * alert is worth building.
+   */
+  requestNewDogsAlert: protectedProcedure.mutation(({ ctx }) => {
+    const userId = ctx.session.user.id;
+    return UserService.requestNewDogsAlert(userId);
+  }),
+
+  /**
    * Hard-delete the current user's account and every dependent record.
    * Required for App Store compliance (Guideline 5.1.1(v)).
    */

--- a/packages/api/src/routes/user.ts
+++ b/packages/api/src/routes/user.ts
@@ -33,6 +33,17 @@ export const userRouter = createTRPCRouter({
     }),
 
   /**
+   * The current user's own flags, kept to the few fields the app reads so a
+   * profile field added later does not start shipping to the client by
+   * accident. Today that is the empty-deck alert opt-in, which the app needs
+   * from the server because local storage does not survive a reinstall.
+   */
+  me: protectedProcedure.query(({ ctx }) => {
+    const userId = ctx.session.user.id;
+    return UserService.getMyFlags(userId);
+  }),
+
+  /**
    * Interest signal from the empty swipe deck: the user wants to hear about it
    * when a new dog turns up. Nothing sends that alert yet, so this only stores
    * the intent and the share of empty-deck viewers who tap decides whether the

--- a/packages/api/src/services/user-service.test.ts
+++ b/packages/api/src/services/user-service.test.ts
@@ -135,3 +135,30 @@ test("deletes the account even when a photo is on a retired storage origin", asy
   await expect(prisma.image.count()).resolves.toBe(0);
   await expect(prisma.dog.count()).resolves.toBe(0);
 });
+
+/**
+ * The empty-deck opt-in is an interest signal, and the question it answers is
+ * "when did this user first ask", not "when did they last tap". Overwriting
+ * the timestamp on a second tap would make every requester look like they
+ * asked today and would move the cohort every time someone reopened the
+ * screen.
+ */
+test("keeps the first new dogs alert request when the user asks twice", async () => {
+  const user = await prisma.user.create({
+    data: { email: "new-dogs-alert@pegada.app" },
+  });
+
+  await expect(UserService.requestNewDogsAlert(user.id)).resolves.toEqual({
+    alreadyRequested: false,
+  });
+  const first = await prisma.user.findUnique({ where: { id: user.id } });
+
+  await expect(UserService.requestNewDogsAlert(user.id)).resolves.toEqual({
+    alreadyRequested: true,
+  });
+  await expect(
+    prisma.user.findUnique({ where: { id: user.id } }),
+  ).resolves.toMatchObject({
+    newDogsAlertRequestedAt: first?.newDogsAlertRequestedAt,
+  });
+});

--- a/packages/api/src/services/user-service.test.ts
+++ b/packages/api/src/services/user-service.test.ts
@@ -162,3 +162,30 @@ test("keeps the first new dogs alert request when the user asks twice", async ()
     newDogsAlertRequestedAt: first?.newDogsAlertRequestedAt,
   });
 });
+
+/**
+ * The app asks the server whether the opt-in already happened, because local
+ * storage does not survive a reinstall and the button would otherwise be
+ * offered again to someone who already took it. The response stays a closed
+ * shape: everything else on the user row is private.
+ */
+test("reports the new dogs alert opt-in and nothing else about the user", async () => {
+  const user = await prisma.user.create({
+    data: {
+      email: "my-flags@pegada.app",
+      code: "654321",
+      pushToken: "ExponentPushToken[my-flags]",
+    },
+  });
+
+  await expect(UserService.getMyFlags(user.id)).resolves.toEqual({
+    newDogsAlertRequestedAt: null,
+  });
+
+  await UserService.requestNewDogsAlert(user.id);
+  const stored = await prisma.user.findUnique({ where: { id: user.id } });
+
+  await expect(UserService.getMyFlags(user.id)).resolves.toEqual({
+    newDogsAlertRequestedAt: stored?.newDogsAlertRequestedAt,
+  });
+});

--- a/packages/api/src/services/user-service.ts
+++ b/packages/api/src/services/user-service.ts
@@ -123,6 +123,20 @@ export class UserService {
   }
 
   /**
+   * The fields the signed-in app reads about its own user. Selected one by
+   * one: the row also holds the login code, the push token and the location,
+   * and none of that belongs in a response the client only needs a flag from.
+   */
+  static async getMyFlags(userId: string) {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { newDogsAlertRequestedAt: true },
+    });
+
+    return { newDogsAlertRequestedAt: user?.newDogsAlertRequestedAt ?? null };
+  }
+
+  /**
    * Record that the user asked to be told when a new dog shows up nearby.
    *
    * The empty swipe deck is where sessions end, so the button that writes this

--- a/packages/api/src/services/user-service.ts
+++ b/packages/api/src/services/user-service.ts
@@ -122,6 +122,24 @@ export class UserService {
     });
   }
 
+  /**
+   * Record that the user asked to be told when a new dog shows up nearby.
+   *
+   * The empty swipe deck is where sessions end, so the button that writes this
+   * is the interest signal for a "new dogs near you" alert that does not exist
+   * yet. Only the first request is kept: overwriting the timestamp on every tap
+   * would turn "when did they ask" into "when did they last tap", and the
+   * readout needs the former.
+   */
+  static async requestNewDogsAlert(userId: string) {
+    const { count } = await prisma.user.updateMany({
+      where: { id: userId, newDogsAlertRequestedAt: null },
+      data: { newDogsAlertRequestedAt: new Date() },
+    });
+
+    return { alreadyRequested: count === 0 };
+  }
+
   static async getSubscriptionType(userId: string) {
     const user = await prisma.user.findUnique({
       where: { id: userId },

--- a/packages/database/migrations/20260901120000_add_new_dogs_alert_requested_at/migration.sql
+++ b/packages/database/migrations/20260901120000_add_new_dogs_alert_requested_at/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "newDogsAlertRequestedAt" TIMESTAMP(3);

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -66,6 +66,7 @@ model User {
 
   // Push notifications
   pushToken String?
+  newDogsAlertRequestedAt DateTime?
 
   // Metadata
   createdAt DateTime  @default(now())

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -24,6 +24,7 @@ export const ANALYTICS_EVENTS = {
   DELETE_ACCOUNT_CANCELED: "Delete Account Canceled",
   DELETE_ACCOUNT_CONFIRMED: "Delete Account Confirmed",
   DELETE_ACCOUNT_PRESSED: "Delete Account Pressed",
+  EMPTY_DECK_ACTION_TAPPED: "Empty Deck Action Tapped",
   EMPTY_DECK_SHOWN: "Empty Deck Shown",
   FEEDBACK: "Feedback",
   INVALID_OTP_TYPED: "User Typed Invalid OTP code",
@@ -77,6 +78,24 @@ export type PaywallTrigger =
 /** An OS permission answer, collapsed to the two states that matter. */
 export type PermissionStatus = "denied" | "granted";
 
+/** The two things the empty swipe deck offers besides the preferences link. */
+export type EmptyDeckAction = "invite_friend" | "notify_new_dogs";
+
+/**
+ * The push answer as the empty deck sees it. Wider than
+ * {@link PermissionStatus} because the button also runs where the OS never
+ * asks at all, and reading that silence as a refusal would put every simulator
+ * session in the denied bucket.
+ */
+export type PushPermissionOutcome = "denied" | "granted" | "unavailable";
+
+/**
+ * What came back from the share sheet. "unavailable" is the sheet that never
+ * opened, which is a different thing from someone opening the invite and
+ * changing their mind.
+ */
+export type ShareOutcome = "dismissed" | "shared" | "unavailable";
+
 /**
  * Event name to property shape, for events sent from the app.
  *
@@ -100,6 +119,16 @@ export type MobileEventProperties = {
   [ANALYTICS_EVENTS.DELETE_ACCOUNT_CANCELED]: undefined;
   [ANALYTICS_EVENTS.DELETE_ACCOUNT_CONFIRMED]: undefined;
   [ANALYTICS_EVENTS.DELETE_ACCOUNT_PRESSED]: undefined;
+  /**
+   * One per tap on an empty deck action. `push_permission` rides on the notify
+   * action and `share_result` on the invite, so the funnel reads both the
+   * intent and what the phone did about it.
+   */
+  [ANALYTICS_EVENTS.EMPTY_DECK_ACTION_TAPPED]: {
+    action: EmptyDeckAction;
+    push_permission?: PushPermissionOutcome;
+    share_result?: ShareOutcome;
+  };
   [ANALYTICS_EVENTS.EMPTY_DECK_SHOWN]: undefined;
   [ANALYTICS_EVENTS.FEEDBACK]: { feedback: string };
   [ANALYTICS_EVENTS.INVALID_OTP_TYPED]: undefined;
@@ -279,6 +308,7 @@ export const MOBILE_EVENT_NAMES = [
   ANALYTICS_EVENTS.DELETE_ACCOUNT_CANCELED,
   ANALYTICS_EVENTS.DELETE_ACCOUNT_CONFIRMED,
   ANALYTICS_EVENTS.DELETE_ACCOUNT_PRESSED,
+  ANALYTICS_EVENTS.EMPTY_DECK_ACTION_TAPPED,
   ANALYTICS_EVENTS.EMPTY_DECK_SHOWN,
   ANALYTICS_EVENTS.FEEDBACK,
   ANALYTICS_EVENTS.INVALID_OTP_TYPED,

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -332,6 +332,10 @@
   "swipeRequestFeedback": {
     "emptyDescription": "But hang tight! We've just launched and still have small user base.\n\nWe're working hard to ensure a space filled with doggos very soon 🐶\n\nTry adjusting your preferences or check back later! 😉",
     "emptyTitle": "We couldn't find any more dogs!",
+    "inviteFriendButton": "Invite a friend",
+    "inviteFriendMessage": "Pegada is where my dog makes friends. Bring yours along:\n{{link}}",
+    "notifyNewDogsButton": "Tell me when a new dog arrives",
+    "notifyNewDogsDone": "We will let you know",
     "preferencesButton": "View Preferences"
   },
   "themes": {

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -332,6 +332,10 @@
   "swipeRequestFeedback": {
     "emptyDescription": "Mas calma! Acabamos de lançar e ainda temos poucos usuários.\n\nEstamos trabalhando para garantir um espaço cheio de doguinhos logo logo 🐶\n\nTente ajustar suas preferências ou volte mais tarde! 😉",
     "emptyTitle": "Parece que os doguinhos acabaram!",
+    "inviteFriendButton": "Convidar um amigo",
+    "inviteFriendMessage": "O Pegada é onde meu cachorro faz amigos. Traz o seu também:\n{{link}}",
+    "notifyNewDogsButton": "Avisar quando chegar dog novo",
+    "notifyNewDogsDone": "Vamos te avisar",
     "preferencesButton": "Ver Preferências"
   },
   "themes": {


### PR DESCRIPTION
## Summary

The empty swipe deck now offers two things to do instead of one: ask to be told when a new dog arrives, and invite a friend. Both are measured so we can read whether either one brings people back.

Closes #191

## Details

- Hypothesis: the empty deck is where sessions end. Giving people two things to do there raises the share of empty deck sessions that return within 7 days, and the alert opt in creates an intent signal for a future "new dogs near you" push.
- Baseline: "Empty Deck Shown" already exists in the analytics catalogue, but it only fired when a fresh fetch came back with zero dogs. It never fired for someone who swiped to the end of the deck, because it waited for the card list to empty and the card that was just swiped stays in that list so it can be swiped back. This PR points it at the same signal the screen uses to decide there is nothing left to act on, so its first weeks are the baseline for how often people reach the end of the deck.
- Readout: PostHog funnel from "Empty Deck Shown" to "Empty Deck Action Tapped". The tapped event carries `action` (`notify_new_dogs` or `invite_friend`), `push_permission` (`granted`, `denied` or `unavailable`) and `share_result` (`shared`, `dismissed` or `unavailable`). Opt in rate is users with the notify action over users with "Empty Deck Shown"; invite completions come from `share_result`; and D7 return is compared between users who tapped and users who did not. Notify taps at or above 15 percent of empty deck views is what would justify building a real new dogs alert.
- "Empty Deck Shown" counts arrivals at the empty deck, not renders of it. It fires on the transition into the state and re arms when cards come back, so a deck that refills and runs out again is a second event while a re render is not.
- The empty state renders only when the deck is really empty. It used to sit behind the card stack for the whole session, which kept an animation running and asked the server about the alert opt in for people who never saw either.
- The alert button is a fake door. Nothing sends that push yet. Tapping it re-uses the same notification token path the swipe screen already runs on open, so the system prompt only appears to someone who never answered it, and then records `newDogsAlertRequestedAt` on the user. Only the first request is kept, so the number stays "when did they ask" rather than "when did they last tap".
- A refused permission still counts as intent, so the record is written either way and the permission outcome rides along on the tapped event as `push_permission`. The prompt keeps sending its own "Push Permission" event, and the empty deck does not send a second one.
- The done state comes from the user as well as from local storage. The local flag answers immediately and keeps working offline, and the value on the user is what keeps the button in its done state after a reinstall or after local storage was cleared. On a fresh install the button stays out of reach until that answer arrives, so a tap in that window cannot count someone twice.
- The invite uses the store link the app already ships with. Its event fires once, after the share sheet settles, carrying whether the invite went out, was dismissed, or never opened at all.
- The database column and its migration are byte identical to the ones in the reengagement PR so the two can merge in either order.
- #221 adds a "share your dog" card above these actions and keeps its "invite a friend and earn Premium" fake door in the share sheet only, so there is no duplicate invite action on the empty deck. Whichever of the two lands second resolves a small conflict in the empty state files, `apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx` and `apps/mobile/src/services/storage.ts`.

## Testing steps

1. Open the app and sign in.
2. Swipe past every dog until the screen says there are no more dogs. If the list is long, open Preferences and narrow the filters (for example pick a coat colour no dog near you has) and come back to the swipe screen, which empties it immediately.
3. Tap "Avisar quando chegar dog novo". Accept or refuse the notification prompt, either is fine. The button turns into "Vamos te avisar" and can no longer be tapped.
4. Close the app fully and open it again. Go back to the empty screen and check the button is still in the "Vamos te avisar" state. Deleting and reinstalling the app leaves it in that state too.
5. Tap "Convidar um amigo". The phone's share sheet opens with a message about Pegada and a link. Send it or close it, both are handled.
6. "Ver Preferências" still opens the preferences screen as before.

## Screenshots

Empty deck with the two new actions:

![Empty deck](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-mobile-empty-deck-actions/shots/01-empty-deck.png)

After opting in to the alert:

![Opted in](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-mobile-empty-deck-actions/shots/02-notify-done.png)

Invite share sheet:

![Share sheet](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-mobile-empty-deck-actions/shots/03-share-sheet.png)

