### PR TITLE
feat(mobile): ask for a review right after the first match

### DIFF
--- a/apps/mobile/src/services/app-review-policy.test.ts
+++ b/apps/mobile/src/services/app-review-policy.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The review prompt is a one-shot resource: iOS shows the native rating sheet
+ * a handful of times per year per user and silently swallows the rest, so
+ * spending it badly is not recoverable. These tests pin the two things that
+ * make it easy to spend badly.
+ *
+ * First, the monthly throttle has to stay one rule. Three call sites now ask
+ * for the same prompt, and a throttle that each of them re-implemented would
+ * drift into three throttles and burn the quota in a week.
+ *
+ * Second, the skip reasons have to separate "something ate the prompt" from
+ * "this user has not got there yet". Only the first kind reaches PostHog:
+ * `NotFirstMatch` fires on every celebration screen every user ever sees, and
+ * as an event it would drown the signal the readout depends on.
+ */
+import {
+  ReviewSkipReason,
+  ReviewTrigger,
+  SECOND_MESSAGE_TRIGGER_COUNT,
+  shouldRequestReview,
+} from "./app-review-policy";
+
+const NOW = new Date("2026-06-15T12:00:00.000Z");
+
+/** An eligible first-match ask, which each test then breaks one way. */
+const input = (overrides: Partial<Parameters<typeof shouldRequestReview>[0]>) =>
+  ({
+    trigger: ReviewTrigger.FirstMatch,
+    matchCount: 1,
+    sentMessageCount: 0,
+    reviewStatus: null,
+    lastPromptAt: null,
+    now: NOW,
+    firstPromptSkipped: true,
+    isStoreReviewAvailable: true,
+    ...overrides,
+  }) satisfies Parameters<typeof shouldRequestReview>[0];
+
+describe("the first match trigger", () => {
+  it("asks on the very first match", () => {
+    expect(shouldRequestReview(input({}))).toStrictEqual({ allowed: true });
+  });
+
+  it("stays quiet on every match after it", () => {
+    expect(shouldRequestReview(input({ matchCount: 2 }))).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.NotFirstMatch,
+      blocked: false,
+    });
+  });
+
+  it("does not report the ordinary case, which is most match screens", () => {
+    const decision = shouldRequestReview(input({ matchCount: 7 }));
+
+    // An event here would fire once per celebration screen per user, and the
+    // readout divides ratings by prompts actually shown.
+    expect(decision).toMatchObject({ blocked: false });
+  });
+});
+
+describe("the second message trigger", () => {
+  const secondMessage = {
+    trigger: ReviewTrigger.SecondMessage,
+    matchCount: 3,
+    sentMessageCount: SECOND_MESSAGE_TRIGGER_COUNT,
+  };
+
+  it("catches the users the match prompt never reached", () => {
+    expect(shouldRequestReview(input(secondMessage))).toStrictEqual({
+      allowed: true,
+    });
+  });
+
+  it("waits for the second message, not the first", () => {
+    expect(
+      shouldRequestReview(input({ ...secondMessage, sentMessageCount: 1 })),
+    ).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.NotEnoughMessages,
+      blocked: false,
+    });
+  });
+
+  it("steps aside when the match prompt already landed", () => {
+    // Two asks for one user is how an app gets rated one star for nagging.
+    expect(
+      shouldRequestReview(
+        input({ ...secondMessage, firstPromptSkipped: false }),
+      ),
+    ).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.FirstPromptAlreadyShown,
+      blocked: false,
+    });
+  });
+});
+
+describe("the messages tab trigger", () => {
+  it("asks once the user has a match", () => {
+    expect(
+      shouldRequestReview(
+        input({ trigger: ReviewTrigger.MessagesTab, matchCount: 1 }),
+      ),
+    ).toStrictEqual({ allowed: true });
+  });
+
+  it("says nothing to a user with an empty list", () => {
+    expect(
+      shouldRequestReview(
+        input({ trigger: ReviewTrigger.MessagesTab, matchCount: 0 }),
+      ),
+    ).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.NoMatches,
+      blocked: false,
+    });
+  });
+});
+
+describe("the monthly throttle, which every trigger answers to", () => {
+  it("blocks an ask made three weeks after the last one", () => {
+    expect(
+      shouldRequestReview(input({ lastPromptAt: "2026-05-25T12:00:00.000Z" })),
+    ).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.Throttled,
+      blocked: true,
+    });
+  });
+
+  it("lets the next one through a month later", () => {
+    expect(
+      shouldRequestReview(input({ lastPromptAt: "2026-05-14T12:00:00.000Z" })),
+    ).toStrictEqual({ allowed: true });
+  });
+
+  it("applies to the message trigger too, not only the match one", () => {
+    expect(
+      shouldRequestReview(
+        input({
+          trigger: ReviewTrigger.SecondMessage,
+          sentMessageCount: SECOND_MESSAGE_TRIGGER_COUNT,
+          lastPromptAt: "2026-06-10T12:00:00.000Z",
+        }),
+      ),
+    ).toMatchObject({ reason: ReviewSkipReason.Throttled });
+  });
+
+  it("ignores a stored date it cannot read", () => {
+    // Treating an unparseable value as "recent" would lock the user out of
+    // the prompt permanently. The allowed path overwrites it with a good one.
+    expect(
+      shouldRequestReview(input({ lastPromptAt: "not-a-date" })),
+    ).toStrictEqual({
+      allowed: true,
+    });
+  });
+});
+
+describe("blockers outside the trigger", () => {
+  it("never asks a user who already went to the store", () => {
+    expect(
+      shouldRequestReview(input({ reviewStatus: "completed" })),
+    ).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.AlreadyReviewed,
+      blocked: true,
+    });
+  });
+
+  it("reports the platforms that have no rating sheet to offer", () => {
+    // TestFlight and the web resolve `isAvailableAsync` false. Reporting it
+    // is the point: a trigger that only ever fires on TestFlight builds looks
+    // identical to one nobody reaches.
+    expect(
+      shouldRequestReview(input({ isStoreReviewAvailable: false })),
+    ).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.StoreReviewUnavailable,
+      blocked: true,
+    });
+  });
+
+  it("prefers the trigger's own verdict over a global one", () => {
+    // A user on their fifth match who is also throttled has not reached this
+    // trigger at all, so counting them as "the throttle ate it" would inflate
+    // the number the readout uses to judge the throttle.
+    expect(
+      shouldRequestReview(
+        input({ matchCount: 5, lastPromptAt: "2026-06-14T12:00:00.000Z" }),
+      ),
+    ).toStrictEqual({
+      allowed: false,
+      reason: ReviewSkipReason.NotFirstMatch,
+      blocked: false,
+    });
+  });
+});

--- a/apps/mobile/src/services/app-review-policy.ts
+++ b/apps/mobile/src/services/app-review-policy.ts
@@ -1,0 +1,143 @@
+import { addMonths } from "date-fns/addMonths";
+import { isBefore } from "date-fns/isBefore";
+
+/**
+ * The review prompt had one passive trigger: opening the Messages tab with at
+ * least one match. That is a screen people open to do something else, and it
+ * lands long after the moment they are happiest with the app. The two new
+ * triggers ride that moment instead, and this module holds the decision they
+ * share so the monthly throttle stays a single rule rather than three.
+ *
+ * Everything with a side effect (storage, the store availability check, the
+ * modal) lives in `app-review.tsx`. This file is data in, verdict out, so the
+ * rules can be read and tested without a renderer.
+ */
+
+export enum ReviewTrigger {
+  /** The celebration screen, the first time this user ever matches. */
+  FirstMatch = "first_match",
+  /** The second message they send, when the match prompt never reached them. */
+  SecondMessage = "second_message",
+  /** The original trigger: the Messages tab with at least one match. */
+  MessagesTab = "messages_tab",
+}
+
+export enum ReviewSkipReason {
+  /** They already went to the store. Never ask again. */
+  AlreadyReviewed = "already_reviewed",
+  /** Asked within the last month, whatever the trigger was. */
+  Throttled = "throttled",
+  /** TestFlight, web, or Android below 5.0. */
+  StoreReviewUnavailable = "store_review_unavailable",
+  /** Not their first match, so this is not the peak we are aiming at. */
+  NotFirstMatch = "not_first_match",
+  /** Trigger 2 exists only for the users trigger 1 could not reach. */
+  FirstPromptAlreadyShown = "first_prompt_already_shown",
+  /** Still on their first message. */
+  NotEnoughMessages = "not_enough_messages",
+  /** The Messages tab with an empty list is nobody's happy moment. */
+  NoMatches = "no_matches",
+}
+
+/** The message trigger 2 waits for. */
+export const SECOND_MESSAGE_TRIGGER_COUNT = 2;
+
+/** One prompt a month, across every trigger. */
+const REVIEW_THROTTLE_MONTHS = 1;
+
+export type ReviewPolicyInput = {
+  trigger: ReviewTrigger;
+  /** Matches this user has, counting the one being celebrated. */
+  matchCount: number;
+  /** Messages this user has sent, counted on the device. */
+  sentMessageCount: number;
+  /** `"completed"` once they have been handed to the store. */
+  reviewStatus: "completed" | null;
+  /** ISO date of the last prompt, whichever trigger produced it. */
+  lastPromptAt: string | null;
+  now: Date;
+  /** True when the first-match prompt never reached this user. */
+  firstPromptSkipped: boolean;
+  /** `StoreReview.isAvailableAsync()`. */
+  isStoreReviewAvailable: boolean;
+};
+
+export type ReviewDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: ReviewSkipReason;
+      /**
+       * True when the user reached the trigger and something outside it ate
+       * the prompt, which is the case worth an analytics event. The plain
+       * "not yet" verdicts are false: `NotFirstMatch` alone would fire on
+       * every celebration screen every user ever sees.
+       */
+      blocked: boolean;
+    };
+
+const deny = (reason: ReviewSkipReason, blocked: boolean): ReviewDecision => ({
+  allowed: false,
+  reason,
+  blocked,
+});
+
+/**
+ * A stored date we cannot parse is treated as no date at all. Reading it as
+ * "throttled" would lock the user out of the prompt forever, and the allowed
+ * path overwrites it with a fresh one.
+ */
+const isThrottled = (lastPromptAt: string, now: Date) => {
+  const lastPrompt = new Date(lastPromptAt);
+  if (Number.isNaN(lastPrompt.getTime())) return false;
+
+  return isBefore(now, addMonths(lastPrompt, REVIEW_THROTTLE_MONTHS));
+};
+
+/** Whether this trigger has earned the right to ask, ignoring the throttle. */
+const isTriggerReached = ({
+  trigger,
+  matchCount,
+  sentMessageCount,
+  firstPromptSkipped,
+}: ReviewPolicyInput): ReviewDecision => {
+  switch (trigger) {
+    case ReviewTrigger.FirstMatch:
+      if (matchCount !== 1) return deny(ReviewSkipReason.NotFirstMatch, false);
+      return { allowed: true };
+
+    case ReviewTrigger.SecondMessage:
+      if (!firstPromptSkipped) {
+        return deny(ReviewSkipReason.FirstPromptAlreadyShown, false);
+      }
+      if (sentMessageCount < SECOND_MESSAGE_TRIGGER_COUNT) {
+        return deny(ReviewSkipReason.NotEnoughMessages, false);
+      }
+      return { allowed: true };
+
+    case ReviewTrigger.MessagesTab:
+      if (matchCount < 1) return deny(ReviewSkipReason.NoMatches, false);
+      return { allowed: true };
+  }
+};
+
+export const shouldRequestReview = (
+  input: ReviewPolicyInput,
+): ReviewDecision => {
+  const triggerReached = isTriggerReached(input);
+  if (!triggerReached.allowed) return triggerReached;
+
+  if (input.reviewStatus === "completed") {
+    return deny(ReviewSkipReason.AlreadyReviewed, true);
+  }
+
+  if (!input.isStoreReviewAvailable) {
+    return deny(ReviewSkipReason.StoreReviewUnavailable, true);
+  }
+
+  if (input.lastPromptAt && isThrottled(input.lastPromptAt, input.now)) {
+    return deny(ReviewSkipReason.Throttled, true);
+  }
+
+  return { allowed: true };
+};

--- a/apps/mobile/src/services/app-review-policy.ts
+++ b/apps/mobile/src/services/app-review-policy.ts
@@ -1,3 +1,8 @@
+import type {
+  ReviewSkipReason as ReviewSkipReasonValue,
+  ReviewTrigger as ReviewTriggerValue,
+} from "@pegada/shared/analytics/events";
+
 import { addMonths } from "date-fns/addMonths";
 import { isBefore } from "date-fns/isBefore";
 
@@ -13,31 +18,40 @@ import { isBefore } from "date-fns/isBefore";
  * rules can be read and tested without a renderer.
  */
 
-export enum ReviewTrigger {
-  /** The celebration screen, the first time this user ever matches. */
-  FirstMatch = "first_match",
-  /** The second message they send, when the match prompt never reached them. */
-  SecondMessage = "second_message",
-  /** The original trigger: the Messages tab with at least one match. */
-  MessagesTab = "messages_tab",
-}
+/**
+ * Named constants over the vocabulary the analytics catalogue owns, rather
+ * than enums of their own: the values travel as event properties, so the
+ * catalogue is where they have to be declared, and a second declaration here
+ * would be a copy to keep in step.
+ */
+export type ReviewTrigger = ReviewTriggerValue;
+export type ReviewSkipReason = ReviewSkipReasonValue;
 
-export enum ReviewSkipReason {
+export const ReviewTrigger = {
+  /** The celebration screen, the first time this user ever matches. */
+  FirstMatch: "first_match",
+  /** The second message they send, when the match prompt never reached them. */
+  SecondMessage: "second_message",
+  /** The original trigger: the Messages tab with at least one match. */
+  MessagesTab: "messages_tab",
+} as const satisfies Record<string, ReviewTrigger>;
+
+export const ReviewSkipReason = {
   /** They already went to the store. Never ask again. */
-  AlreadyReviewed = "already_reviewed",
+  AlreadyReviewed: "already_reviewed",
   /** Asked within the last month, whatever the trigger was. */
-  Throttled = "throttled",
+  Throttled: "throttled",
   /** TestFlight, web, or Android below 5.0. */
-  StoreReviewUnavailable = "store_review_unavailable",
+  StoreReviewUnavailable: "store_review_unavailable",
   /** Not their first match, so this is not the peak we are aiming at. */
-  NotFirstMatch = "not_first_match",
+  NotFirstMatch: "not_first_match",
   /** Trigger 2 exists only for the users trigger 1 could not reach. */
-  FirstPromptAlreadyShown = "first_prompt_already_shown",
+  FirstPromptAlreadyShown: "first_prompt_already_shown",
   /** Still on their first message. */
-  NotEnoughMessages = "not_enough_messages",
+  NotEnoughMessages: "not_enough_messages",
   /** The Messages tab with an empty list is nobody's happy moment. */
-  NoMatches = "no_matches",
-}
+  NoMatches: "no_matches",
+} as const satisfies Record<string, ReviewSkipReason>;
 
 /** The message trigger 2 waits for. */
 export const SECOND_MESSAGE_TRIGGER_COUNT = 2;

--- a/apps/mobile/src/services/app-review.test.tsx
+++ b/apps/mobile/src/services/app-review.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * `app-review-policy.test.ts` pins the rules. This file pins the wiring around
+ * them, which is where the trigger change can go wrong without any rule being
+ * wrong: reading the right storage keys, emitting the two events the readout
+ * depends on under exactly the right conditions, and leaving behind the
+ * marker that stops trigger 2 from asking a user trigger 1 already asked.
+ *
+ * Every React Native flavoured import is stubbed, matching the other tests in
+ * this package: there is no RN transform here, and nothing below renders.
+ */
+import * as StoreReview from "expo-store-review";
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { magicModal } from "react-native-magic-modal";
+
+import { analytics } from "@/services/analytics";
+import { ReviewTrigger } from "@/services/app-review-policy";
+import { StorageKeys } from "@/services/storage";
+
+const mockMyDogQuery = jest.fn(() =>
+  Promise.resolve({ user: { email: "someone@pegada.app" } }),
+);
+
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  KeyboardAvoidingView: () => null,
+  Platform: { OS: "ios" },
+  View: () => null,
+}));
+
+jest.mock<Partial<typeof import("expo-store-review")>>(
+  "expo-store-review",
+  () => ({
+    isAvailableAsync: jest.fn(() => Promise.resolve(true)),
+    requestReview: jest.fn(() => Promise.resolve()),
+  }),
+);
+
+jest.mock<Record<string, unknown>>("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock<Record<string, unknown>>("react-native-magic-modal", () => ({
+  magicModal: { show: jest.fn() },
+  useMagicModal: () => ({ hide: jest.fn() }),
+}));
+
+jest.mock<Record<string, unknown>>("react-native-magic-toast", () => ({
+  magicToast: { success: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("react-native-unistyles", () => ({
+  StyleSheet: { create: () => ({}) },
+  useUnistyles: () => ({ theme: { spacing: {} } }),
+  withUnistyles: (component: unknown) => component,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/Button", () => ({
+  Button: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/Input", () => ({
+  Input: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/components/text", () => ({
+  Text: () => null,
+}));
+
+jest.mock<Record<string, unknown>>("@/contexts/trcp-context", () => ({
+  getTrcpContext: () => ({
+    client: { myDog: { get: { query: mockMyDogQuery } } },
+  }),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { track: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+// The storage service itself stays real, the way `storage.test.ts` runs it,
+// so these tests exercise the key names the shipped build actually reads.
+jest.mock<
+  Partial<typeof import("@react-native-async-storage/async-storage").default>
+>("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock<Partial<typeof import("expo-secure-store")>>(
+  "expo-secure-store",
+  () => ({
+    getItemAsync: jest.fn(),
+    setItemAsync: jest.fn(),
+    deleteItemAsync: jest.fn(),
+  }),
+);
+
+import {
+  handleMessageSentAppReview,
+  handleRequestAppReview,
+} from "./app-review";
+
+const asyncStorage = jest.mocked(AsyncStorage);
+const track = jest.mocked(analytics.track);
+const show = jest.mocked(magicModal.show);
+
+/** Answers reads per key, so a test only names the keys it cares about. */
+const givenStorage = (values: Partial<Record<StorageKeys, string>>) => {
+  asyncStorage.getItem.mockImplementation((key) =>
+    Promise.resolve(values[key as StorageKeys] ?? null),
+  );
+};
+
+beforeEach(() => {
+  givenStorage({});
+  jest.mocked(StoreReview.isAvailableAsync).mockResolvedValue(true);
+});
+
+describe("the first match trigger", () => {
+  it("asks, records the ask, and names the trigger in the event", async () => {
+    await handleRequestAppReview({
+      trigger: ReviewTrigger.FirstMatch,
+      matchCount: 1,
+    });
+
+    expect(show).toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith({
+      event_type: "review_prompt_requested",
+      event_properties: { trigger: ReviewTrigger.FirstMatch },
+    });
+    // Without this marker the second-message trigger would ask the same user
+    // again as soon as the month is up.
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(
+      StorageKeys.AppReviewMatchPrompted,
+      "true",
+    );
+  });
+
+  it("stays silent, and unreported, on a later match", async () => {
+    await handleRequestAppReview({
+      trigger: ReviewTrigger.FirstMatch,
+      matchCount: 4,
+    });
+
+    expect(show).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("reports the throttle, because that is the number the readout divides by", async () => {
+    givenStorage({
+      [StorageKeys.AppReviewRequestDate]: new Date().toISOString(),
+    });
+
+    await handleRequestAppReview({
+      trigger: ReviewTrigger.FirstMatch,
+      matchCount: 1,
+    });
+
+    expect(show).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith({
+      event_type: "review_prompt_skipped",
+      event_properties: {
+        trigger: ReviewTrigger.FirstMatch,
+        reason: "throttled",
+      },
+    });
+  });
+
+  it("reports a platform with no rating sheet rather than asking anyway", async () => {
+    jest.mocked(StoreReview.isAvailableAsync).mockResolvedValue(false);
+
+    await handleRequestAppReview({
+      trigger: ReviewTrigger.FirstMatch,
+      matchCount: 1,
+    });
+
+    expect(show).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith({
+      event_type: "review_prompt_skipped",
+      event_properties: {
+        trigger: ReviewTrigger.FirstMatch,
+        reason: "store_review_unavailable",
+      },
+    });
+  });
+
+  it("never asks a test account, and marks it done so it is never asked again", async () => {
+    mockMyDogQuery.mockResolvedValueOnce({ user: { email: "qa@test.com" } });
+
+    await handleRequestAppReview({
+      trigger: ReviewTrigger.FirstMatch,
+      matchCount: 1,
+    });
+
+    expect(show).not.toHaveBeenCalled();
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(
+      StorageKeys.AppReviewStatus,
+      "completed",
+    );
+  });
+});
+
+describe("the second message trigger", () => {
+  it("counts the first message without asking", async () => {
+    await handleMessageSentAppReview();
+
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(
+      StorageKeys.AppReviewSentMessageCount,
+      "1",
+    );
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it("asks on the second, for a user the match prompt never reached", async () => {
+    givenStorage({ [StorageKeys.AppReviewSentMessageCount]: "1" });
+
+    await handleMessageSentAppReview();
+
+    expect(show).toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith({
+      event_type: "review_prompt_requested",
+      event_properties: { trigger: ReviewTrigger.SecondMessage },
+    });
+  });
+
+  it("holds its peace when the match prompt already landed", async () => {
+    givenStorage({
+      [StorageKeys.AppReviewSentMessageCount]: "1",
+      [StorageKeys.AppReviewMatchPrompted]: "true",
+    });
+
+    await handleMessageSentAppReview();
+
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it("stops touching storage once it is past the message it waits for", async () => {
+    givenStorage({ [StorageKeys.AppReviewSentMessageCount]: "2" });
+
+    await handleMessageSentAppReview();
+
+    // Every message a chatty user sends would otherwise be a write and a
+    // native store-availability call for a question already answered.
+    expect(asyncStorage.setItem).not.toHaveBeenCalled();
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it("treats an unreadable counter as no messages yet", async () => {
+    givenStorage({ [StorageKeys.AppReviewSentMessageCount]: "not-a-number" });
+
+    await handleMessageSentAppReview();
+
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(
+      StorageKeys.AppReviewSentMessageCount,
+      "1",
+    );
+  });
+});

--- a/apps/mobile/src/services/app-review.test.tsx
+++ b/apps/mobile/src/services/app-review.test.tsx
@@ -138,6 +138,53 @@ describe("the first match trigger", () => {
       StorageKeys.AppReviewMatchPrompted,
       "true",
     );
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(
+      StorageKeys.AppReviewRequestDate,
+      expect.any(String),
+    );
+  });
+
+  it("charges the month to a prompt that reached the screen, and nothing else", async () => {
+    // The celebration screen hands this in and answers false once a CTA has
+    // been pressed, because everything above the modal is asynchronous: three
+    // storage reads, the native availability check, and an API round trip.
+    // A prompt withdrawn in there used to still write the throttle date,
+    // which bought a month of silence for a question nobody was asked, and
+    // the match marker, which switched off the second-message fallback too.
+    await handleRequestAppReview({
+      trigger: ReviewTrigger.FirstMatch,
+      matchCount: 1,
+      canStillAsk: () => false,
+    });
+
+    expect(show).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalled();
+    expect(asyncStorage.setItem).not.toHaveBeenCalledWith(
+      StorageKeys.AppReviewRequestDate,
+      expect.any(String),
+    );
+    expect(asyncStorage.setItem).not.toHaveBeenCalledWith(
+      StorageKeys.AppReviewMatchPrompted,
+      "true",
+    );
+  });
+
+  it("shows one prompt when two triggers arrive together", async () => {
+    // The celebration timer and a message sent from the chat can overlap by
+    // seconds. Both would read the same storage, both would pass the same
+    // throttle, and the second modal would land on top of the first.
+    await Promise.all([
+      handleRequestAppReview({
+        trigger: ReviewTrigger.FirstMatch,
+        matchCount: 1,
+      }),
+      handleRequestAppReview({
+        trigger: ReviewTrigger.MessagesTab,
+        matchCount: 1,
+      }),
+    ]);
+
+    expect(show).toHaveBeenCalledTimes(1);
   });
 
   it("stays silent, and unreported, on a later match", async () => {

--- a/apps/mobile/src/services/app-review.test.tsx
+++ b/apps/mobile/src/services/app-review.test.tsx
@@ -1,9 +1,10 @@
 /**
  * `app-review-policy.test.ts` pins the rules. This file pins the wiring around
  * them, which is where the trigger change can go wrong without any rule being
- * wrong: reading the right storage keys, emitting the two events the readout
- * depends on under exactly the right conditions, and leaving behind the
- * marker that stops trigger 2 from asking a user trigger 1 already asked.
+ * wrong: reading the right storage keys, handing the modal the trigger the
+ * readout is built on, reporting the users who were blocked, and leaving
+ * behind the marker that stops trigger 2 asking a user trigger 1 already
+ * asked.
  *
  * Every React Native flavoured import is stubbed, matching the other tests in
  * this package: there is no RN transform here, and nothing below renders.
@@ -108,6 +109,19 @@ const asyncStorage = jest.mocked(AsyncStorage);
 const track = jest.mocked(analytics.track);
 const show = jest.mocked(magicModal.show);
 
+/**
+ * The trigger the modal was handed. "App Review Request" is sent from the
+ * modal's own mount, which nothing here renders, so the assertion that the
+ * trigger survives the trip is made on the element instead.
+ */
+const shownTrigger = () => {
+  const render = show.mock.calls[0]?.[0] as
+    | (() => { props: { trigger?: string } })
+    | undefined;
+
+  return render?.().props.trigger;
+};
+
 /** Answers reads per key, so a test only names the keys it cares about. */
 const givenStorage = (values: Partial<Record<StorageKeys, string>>) => {
   asyncStorage.getItem.mockImplementation((key) =>
@@ -121,17 +135,14 @@ beforeEach(() => {
 });
 
 describe("the first match trigger", () => {
-  it("asks, records the ask, and names the trigger in the event", async () => {
+  it("asks, names the trigger, and records the ask", async () => {
     await handleRequestAppReview({
       trigger: ReviewTrigger.FirstMatch,
       matchCount: 1,
     });
 
     expect(show).toHaveBeenCalled();
-    expect(track).toHaveBeenCalledWith({
-      event_type: "review_prompt_requested",
-      event_properties: { trigger: ReviewTrigger.FirstMatch },
-    });
+    expect(shownTrigger()).toBe(ReviewTrigger.FirstMatch);
     // Without this marker the second-message trigger would ask the same user
     // again as soon as the month is up.
     expect(asyncStorage.setItem).toHaveBeenCalledWith(
@@ -209,7 +220,7 @@ describe("the first match trigger", () => {
 
     expect(show).not.toHaveBeenCalled();
     expect(track).toHaveBeenCalledWith({
-      event_type: "review_prompt_skipped",
+      event_type: "App Review Skipped",
       event_properties: {
         trigger: ReviewTrigger.FirstMatch,
         reason: "throttled",
@@ -227,7 +238,7 @@ describe("the first match trigger", () => {
 
     expect(show).not.toHaveBeenCalled();
     expect(track).toHaveBeenCalledWith({
-      event_type: "review_prompt_skipped",
+      event_type: "App Review Skipped",
       event_properties: {
         trigger: ReviewTrigger.FirstMatch,
         reason: "store_review_unavailable",
@@ -268,10 +279,7 @@ describe("the second message trigger", () => {
     await handleMessageSentAppReview();
 
     expect(show).toHaveBeenCalled();
-    expect(track).toHaveBeenCalledWith({
-      event_type: "review_prompt_requested",
-      event_properties: { trigger: ReviewTrigger.SecondMessage },
-    });
+    expect(shownTrigger()).toBe(ReviewTrigger.SecondMessage);
   });
 
   it("holds its peace when the match prompt already landed", async () => {

--- a/apps/mobile/src/services/app-review.tsx
+++ b/apps/mobile/src/services/app-review.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import * as React from "react";
 import { KeyboardAvoidingView, Platform, View } from "react-native";
 
@@ -92,6 +93,16 @@ const AreYouLikingTheAppModal: React.FC<{ trigger: ReviewTrigger }> = ({
 }) => {
   const { t } = useTranslation();
   const { hide } = useMagicModal();
+
+  // Sent from the modal's own mount, which is the only place that can honestly
+  // claim the user was asked. Everything upstream is a decision that can still
+  // come to nothing.
+  useEffect(() => {
+    analytics.track({
+      event_type: "App Review Request",
+      event_properties: { trigger },
+    });
+  }, [trigger]);
 
   const openReviewModal = () => {
     analytics.track({
@@ -200,7 +211,7 @@ export const handleRequestAppReview = async ({
     if (!decision.allowed) {
       if (decision.blocked) {
         analytics.track({
-          event_type: "review_prompt_skipped",
+          event_type: "App Review Skipped",
           event_properties: { trigger, reason: decision.reason },
         });
       }
@@ -221,12 +232,9 @@ export const handleRequestAppReview = async ({
     // caller aimed at can be gone by the time they all answer.
     if (canStillAsk?.() === false) return;
 
-    analytics.track({
-      event_type: "review_prompt_requested",
-      event_properties: { trigger },
-    });
-
-    // Finally, we ask for a review
+    // Finally, we ask for a review. "App Review Request" rides the modal's own
+    // mount rather than this line, so the event and the question the user sees
+    // are the same moment.
     magicModal.show(() => <AreYouLikingTheAppModal trigger={trigger} />);
 
     // Recorded after the modal is up, never before. These two are what the

--- a/apps/mobile/src/services/app-review.tsx
+++ b/apps/mobile/src/services/app-review.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import * as React from "react";
 import { KeyboardAvoidingView, Platform, View } from "react-native";
 
@@ -18,12 +17,20 @@ import { Input } from "@/components/Input";
 import { Text } from "@/components/text";
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
+import {
+  ReviewTrigger,
+  SECOND_MESSAGE_TRIGGER_COUNT,
+  shouldRequestReview,
+} from "@/services/app-review-policy";
 import { sendError } from "@/services/error-tracking";
 import { getData, StorageKeys, storeData } from "@/services/storage";
 
-const handleReview = async () => {
+const handleReview = async (trigger: ReviewTrigger) => {
   try {
-    analytics.track({ event_type: "App Review" });
+    analytics.track({
+      event_type: "App Review",
+      event_properties: { trigger },
+    });
     await StoreReview.requestReview();
     await storeData(StorageKeys.AppReviewStatus, "completed");
   } catch (error) {
@@ -80,13 +87,11 @@ const NotLikingTheAppModal: React.FC = () => {
   );
 };
 
-const AreYouLikingTheAppModal: React.FC = () => {
+const AreYouLikingTheAppModal: React.FC<{ trigger: ReviewTrigger }> = ({
+  trigger,
+}) => {
   const { t } = useTranslation();
   const { hide } = useMagicModal();
-
-  useEffect(() => {
-    analytics.track({ event_type: "App Review Request" });
-  }, []);
 
   const openReviewModal = () => {
     analytics.track({
@@ -96,7 +101,7 @@ const AreYouLikingTheAppModal: React.FC = () => {
 
     hide();
 
-    void handleReview();
+    void handleReview(trigger);
   };
 
   const openNotLikingTheAppModal = () => {
@@ -138,19 +143,52 @@ const AreYouLikingTheAppModal: React.FC = () => {
   );
 };
 
-const isOlderThanAMonth = (date: string) =>
-  new Date(date) < new Date(new Date().setMonth(new Date().getMonth() - 1));
+type RequestAppReviewOptions = {
+  trigger: ReviewTrigger;
+  /** Matches the user has, counting the one being celebrated. */
+  matchCount?: number;
+  /** Messages the user has sent, counted on the device. */
+  sentMessageCount?: number;
+};
 
-export const handleRequestAppReview = async () => {
-  const appReviewStatus = await getData(StorageKeys.AppReviewStatus);
+export const handleRequestAppReview = async ({
+  trigger,
+  matchCount = 0,
+  sentMessageCount = 0,
+}: RequestAppReviewOptions) => {
+  const [reviewStatus, lastPromptAt, matchPrompted, isStoreReviewAvailable] =
+    await Promise.all([
+      getData(StorageKeys.AppReviewStatus),
+      getData(StorageKeys.AppReviewRequestDate),
+      getData(StorageKeys.AppReviewMatchPrompted),
+      // Resolves false on TestFlight, on the web, and on Android below 5.0.
+      StoreReview.isAvailableAsync().catch(() => false),
+    ]);
 
-  // The user has already reviewed the app
-  if (appReviewStatus === "completed") return;
+  const decision = shouldRequestReview({
+    trigger,
+    matchCount,
+    sentMessageCount,
+    reviewStatus,
+    lastPromptAt,
+    now: new Date(),
+    // Absence of the marker covers both halves of "skipped": the prompt was
+    // blocked on the celebration screen, or the user was already past their
+    // first match when this shipped and never saw that screen at all.
+    firstPromptSkipped: matchPrompted !== "true",
+    isStoreReviewAvailable,
+  });
 
-  const lastRequestedDate = await getData(StorageKeys.AppReviewRequestDate);
+  if (!decision.allowed) {
+    if (decision.blocked) {
+      analytics.track({
+        event_type: "review_prompt_skipped",
+        event_properties: { trigger, reason: decision.reason },
+      });
+    }
 
-  // We have already asked for a review recently
-  if (lastRequestedDate && !isOlderThanAMonth(lastRequestedDate)) return;
+    return;
+  }
 
   await storeData(StorageKeys.AppReviewRequestDate, new Date().toISOString());
 
@@ -159,8 +197,42 @@ export const handleRequestAppReview = async () => {
   const isTestAccount = dog?.user.email.endsWith("@test.com");
   if (isTestAccount) return storeData(StorageKeys.AppReviewStatus, "completed");
 
+  if (trigger === ReviewTrigger.FirstMatch) {
+    await storeData(StorageKeys.AppReviewMatchPrompted, "true");
+  }
+
+  analytics.track({
+    event_type: "review_prompt_requested",
+    event_properties: { trigger },
+  });
+
   // Finally, we ask for a review
-  magicModal.show(() => <AreYouLikingTheAppModal />);
+  magicModal.show(() => <AreYouLikingTheAppModal trigger={trigger} />);
+};
+
+/**
+ * Trigger 2, the catch-up for everyone trigger 1 could not reach. The count
+ * lives on the device because the server has no per-user sent-message total
+ * and this only ever has to answer "was that the second one".
+ */
+export const handleMessageSentAppReview = async () => {
+  const stored = Number(await getData(StorageKeys.AppReviewSentMessageCount));
+  const sentMessageCount = (Number.isFinite(stored) ? stored : 0) + 1;
+
+  // The counter exists to spot message number two. Past it, stop writing.
+  if (sentMessageCount > SECOND_MESSAGE_TRIGGER_COUNT) return;
+
+  await storeData(
+    StorageKeys.AppReviewSentMessageCount,
+    String(sentMessageCount),
+  );
+
+  if (sentMessageCount < SECOND_MESSAGE_TRIGGER_COUNT) return;
+
+  await handleRequestAppReview({
+    trigger: ReviewTrigger.SecondMessage,
+    sentMessageCount,
+  });
 };
 
 const styles = StyleSheet.create((theme) => ({

--- a/apps/mobile/src/services/app-review.tsx
+++ b/apps/mobile/src/services/app-review.tsx
@@ -149,65 +149,98 @@ type RequestAppReviewOptions = {
   matchCount?: number;
   /** Messages the user has sent, counted on the device. */
   sentMessageCount?: number;
+  /**
+   * Asked again once everything below has been decided, right before the
+   * modal goes up. A caller that owns a moment rather than a screen state
+   * uses this to withdraw the ask while it is still in the air.
+   */
+  canStillAsk?: () => boolean;
 };
+
+/**
+ * One ask at a time. Two triggers can overlap by seconds, and without this
+ * the second one reads the storage the first has not written yet, passes the
+ * same throttle, and stacks a second modal on the first.
+ */
+let isAskInFlight = false;
 
 export const handleRequestAppReview = async ({
   trigger,
   matchCount = 0,
   sentMessageCount = 0,
+  canStillAsk,
 }: RequestAppReviewOptions) => {
-  const [reviewStatus, lastPromptAt, matchPrompted, isStoreReviewAvailable] =
-    await Promise.all([
-      getData(StorageKeys.AppReviewStatus),
-      getData(StorageKeys.AppReviewRequestDate),
-      getData(StorageKeys.AppReviewMatchPrompted),
-      // Resolves false on TestFlight, on the web, and on Android below 5.0.
-      StoreReview.isAvailableAsync().catch(() => false),
-    ]);
+  if (isAskInFlight) return;
+  isAskInFlight = true;
 
-  const decision = shouldRequestReview({
-    trigger,
-    matchCount,
-    sentMessageCount,
-    reviewStatus,
-    lastPromptAt,
-    now: new Date(),
-    // Absence of the marker covers both halves of "skipped": the prompt was
-    // blocked on the celebration screen, or the user was already past their
-    // first match when this shipped and never saw that screen at all.
-    firstPromptSkipped: matchPrompted !== "true",
-    isStoreReviewAvailable,
-  });
+  try {
+    const [reviewStatus, lastPromptAt, matchPrompted, isStoreReviewAvailable] =
+      await Promise.all([
+        getData(StorageKeys.AppReviewStatus),
+        getData(StorageKeys.AppReviewRequestDate),
+        getData(StorageKeys.AppReviewMatchPrompted),
+        // Resolves false on TestFlight, on the web, and on Android below 5.0.
+        StoreReview.isAvailableAsync().catch(() => false),
+      ]);
 
-  if (!decision.allowed) {
-    if (decision.blocked) {
-      analytics.track({
-        event_type: "review_prompt_skipped",
-        event_properties: { trigger, reason: decision.reason },
-      });
+    const decision = shouldRequestReview({
+      trigger,
+      matchCount,
+      sentMessageCount,
+      reviewStatus,
+      lastPromptAt,
+      now: new Date(),
+      // Absence of the marker covers both halves of "skipped": the prompt was
+      // blocked on the celebration screen, or the user was already past their
+      // first match when this shipped and never saw that screen at all.
+      firstPromptSkipped: matchPrompted !== "true",
+      isStoreReviewAvailable,
+    });
+
+    if (!decision.allowed) {
+      if (decision.blocked) {
+        analytics.track({
+          event_type: "review_prompt_skipped",
+          event_properties: { trigger, reason: decision.reason },
+        });
+      }
+
+      return;
     }
 
-    return;
+    // Prevent asking for a review in test accounts
+    const dog = await getTrcpContext().client.myDog.get.query();
+    const isTestAccount = dog?.user.email.endsWith("@test.com");
+    if (isTestAccount) {
+      await storeData(StorageKeys.AppReviewStatus, "completed");
+      return;
+    }
+
+    // Last gate before the modal. Three storage reads, a native availability
+    // check and an API round trip sit above this line, and the moment the
+    // caller aimed at can be gone by the time they all answer.
+    if (canStillAsk?.() === false) return;
+
+    analytics.track({
+      event_type: "review_prompt_requested",
+      event_properties: { trigger },
+    });
+
+    // Finally, we ask for a review
+    magicModal.show(() => <AreYouLikingTheAppModal trigger={trigger} />);
+
+    // Recorded after the modal is up, never before. These two are what the
+    // user pays for being asked: a month of silence from every trigger, and
+    // in the first-match case the end of the second-message fallback. An ask
+    // that never reached the screen must not charge them for it.
+    await storeData(StorageKeys.AppReviewRequestDate, new Date().toISOString());
+
+    if (trigger === ReviewTrigger.FirstMatch) {
+      await storeData(StorageKeys.AppReviewMatchPrompted, "true");
+    }
+  } finally {
+    isAskInFlight = false;
   }
-
-  await storeData(StorageKeys.AppReviewRequestDate, new Date().toISOString());
-
-  // Prevent asking for a review in test accounts
-  const dog = await getTrcpContext().client.myDog.get.query();
-  const isTestAccount = dog?.user.email.endsWith("@test.com");
-  if (isTestAccount) return storeData(StorageKeys.AppReviewStatus, "completed");
-
-  if (trigger === ReviewTrigger.FirstMatch) {
-    await storeData(StorageKeys.AppReviewMatchPrompted, "true");
-  }
-
-  analytics.track({
-    event_type: "review_prompt_requested",
-    event_properties: { trigger },
-  });
-
-  // Finally, we ask for a review
-  magicModal.show(() => <AreYouLikingTheAppModal trigger={trigger} />);
 };
 
 /**

--- a/apps/mobile/src/services/logout.ts
+++ b/apps/mobile/src/services/logout.ts
@@ -17,6 +17,15 @@ export const logout = async () => {
 
     await deleteData(StorageKeys.Token);
 
+    // The review triggers ask "is this YOUR first match, YOUR second
+    // message", so their counters belong to the session that is ending. The
+    // monthly throttle and the completed status stay: those guard the store's
+    // per-device prompt quota, which the next account shares.
+    await Promise.all([
+      deleteData(StorageKeys.AppReviewMatchPrompted),
+      deleteData(StorageKeys.AppReviewSentMessageCount),
+    ]);
+
     // Clear redux store
     store.dispatch(Actions.logout.logout());
 

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -10,6 +10,8 @@ export enum StorageKeys {
   AppReviewRequestDate = "appReviewRequestDate",
   AppReviewStatus = "appReviewStatus",
   NewDogsAlertRequested = "newDogsAlertRequested",
+  AppReviewMatchPrompted = "appReviewMatchPrompted",
+  AppReviewSentMessageCount = "appReviewSentMessageCount",
 }
 
 export enum Theme {
@@ -25,6 +27,8 @@ export type StorageDataTypes = {
   [StorageKeys.AppReviewRequestDate]: string;
   [StorageKeys.AppReviewStatus]: "completed";
   [StorageKeys.NewDogsAlertRequested]: "requested";
+  [StorageKeys.AppReviewMatchPrompted]: "true";
+  [StorageKeys.AppReviewSentMessageCount]: string;
 };
 
 export const storeData = async <T extends StorageKeys>(

--- a/apps/mobile/src/views/(tabs)/Messages/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Messages/index.tsx
@@ -15,6 +15,7 @@ import { Text } from "@/components/text";
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { api } from "@/contexts/trpc-provider";
 import { handleRequestAppReview } from "@/services/app-review";
+import { ReviewTrigger } from "@/services/app-review-policy";
 import { sendError } from "@/services/error-tracking";
 import { SceneName } from "@/types/scene-name";
 import { Header } from "@/views/(tabs)/Messages/components/Header";
@@ -46,10 +47,13 @@ const Messages = () => {
   });
 
   useEffect(() => {
-    if (matches.length > 0) {
-      // If the user has matches, we request the app review
-      handleRequestAppReview().catch(sendError);
-    }
+    // The fallback trigger, for users the two peak moments never caught. The
+    // "has matches" condition moved into the policy so all three triggers
+    // answer to one set of rules.
+    handleRequestAppReview({
+      trigger: ReviewTrigger.MessagesTab,
+      matchCount: matches.length,
+    }).catch(sendError);
 
     for (const { dog } of matches) {
       getTrcpContext().dog.get.setData({ id: dog.id }, dog);

--- a/apps/mobile/src/views/(tabs)/Profile/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Profile/index.tsx
@@ -56,7 +56,10 @@ const openPrivacyPolicy = () => {
 
 const openRateTheApp = async () => {
   try {
-    analytics.track({ event_type: "App Review" });
+    analytics.track({
+      event_type: "App Review",
+      event_properties: { trigger: "settings" },
+    });
     await StoreReview.requestReview();
     await storeData(StorageKeys.AppReviewStatus, "completed");
   } catch (error) {

--- a/apps/mobile/src/views/Chat/hooks/use-send-message.ts
+++ b/apps/mobile/src/views/Chat/hooks/use-send-message.ts
@@ -6,6 +6,7 @@ import { v4 as uuidV4 } from "uuid";
 
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
+import { handleMessageSentAppReview } from "@/services/app-review";
 import { sendError } from "@/services/error-tracking";
 import { queryClient } from "@/services/query-client";
 
@@ -129,6 +130,11 @@ export const useSendMessage = () => {
           match_id: String(matchId),
         },
       });
+
+      // Same reason, same place: only sends that landed count towards the
+      // second message the review prompt waits for. Fire and forget, because
+      // the prompt must never hold up the message the user just wrote.
+      handleMessageSentAppReview().catch(sendError);
     } catch (error) {
       sendError(error);
 

--- a/apps/mobile/src/views/NewMatch/index.test.tsx
+++ b/apps/mobile/src/views/NewMatch/index.test.tsx
@@ -111,7 +111,30 @@ jest.mock<Record<string, unknown>>("@/contexts/trpc-provider", () => ({
         useSuspenseQuery: () => [{ id: "dog-matchme", name: "MatchMe" }],
       },
     },
+    // Feeds the review trigger its match count. The screen reads it as a
+    // plain query so a slow answer cannot hold up the celebration.
+    match: {
+      getAll: {
+        useQuery: () => ({ data: [{ id: "match-42" }] }),
+      },
+    },
   },
+}));
+
+// The review ask sits behind a `setTimeout` in a `useEffect`, and neither
+// runs under `renderToStaticMarkup`. Its rules are covered in
+// `services/app-review-policy.test.ts`; these stubs only keep the import
+// graph from reaching real storage and a real store review call.
+jest.mock<Record<string, unknown>>("@/services/app-review", () => ({
+  handleRequestAppReview: () => Promise.resolve(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: () => undefined,
+}));
+
+jest.mock<Record<string, unknown>>("@/services/e2e", () => ({
+  isMaestroE2EBuild: () => false,
 }));
 
 jest.mock<Record<string, unknown>>(

--- a/apps/mobile/src/views/NewMatch/index.test.tsx
+++ b/apps/mobile/src/views/NewMatch/index.test.tsx
@@ -18,6 +18,21 @@ import { SceneName } from "@/types/scene-name";
 
 const mockHandlers = new Map<string, () => Promise<void> | void>();
 const mockBackHandlers: (() => boolean)[] = [];
+const mockEffects: (() => (() => void) | void)[] = [];
+
+jest.mock<Record<string, unknown>>("react", () => {
+  const actual = jest.requireActual<typeof React>("react");
+
+  return {
+    ...actual,
+    // A static render never runs effects, and the review ask lives in one.
+    // Collected here and run by `render` instead, which is what lets a test
+    // watch the timer that ask is scheduled on.
+    useEffect: (effect: () => (() => void) | void) => {
+      mockEffects.push(effect);
+    },
+  };
+});
 
 const mockRouter = {
   back: jest.fn(),
@@ -121,12 +136,22 @@ jest.mock<Record<string, unknown>>("@/contexts/trpc-provider", () => ({
   },
 }));
 
-// The review ask sits behind a `setTimeout` in a `useEffect`, and neither
-// runs under `renderToStaticMarkup`. Its rules are covered in
-// `services/app-review-policy.test.ts`; these stubs only keep the import
-// graph from reaching real storage and a real store review call.
+// What the ask decides once it is made is covered in
+// `services/app-review-policy.test.ts` and `services/app-review.test.tsx`.
+// This stub is about whether the screen makes it at all.
+type ReviewAskOptions = {
+  trigger: string;
+  matchCount?: number;
+  canStillAsk?: () => boolean;
+};
+
+const mockHandleRequestAppReview = jest.fn<Promise<void>, [ReviewAskOptions]>(
+  () => Promise.resolve(),
+);
+
 jest.mock<Record<string, unknown>>("@/services/app-review", () => ({
-  handleRequestAppReview: () => Promise.resolve(),
+  handleRequestAppReview: (options: ReviewAskOptions) =>
+    mockHandleRequestAppReview(options),
 }));
 
 jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
@@ -170,13 +195,25 @@ jest.mock<Record<string, unknown>>("./styles", () => ({
   styles: {},
 }));
 
-import NewMatchScreen from ".";
+import NewMatchScreen, { REVIEW_PROMPT_DELAY_MS } from ".";
 
 const render = () => {
   mockHandlers.clear();
   mockBackHandlers.length = 0;
+  mockEffects.length = 0;
+
   renderToStaticMarkup(<NewMatchScreen />);
+
+  return mockEffects.map((effect) => effect());
 };
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 describe("NewMatch exits", () => {
   it("swaps itself for the chat instead of stacking it on top", async () => {
@@ -220,5 +257,76 @@ describe("NewMatch exits", () => {
     await Promise.resolve();
 
     expect(mockRouter.back).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the first match review ask", () => {
+  it("waits out the confetti before asking", () => {
+    render();
+
+    jest.advanceTimersByTime(REVIEW_PROMPT_DELAY_MS - 1);
+    expect(mockHandleRequestAppReview).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(mockHandleRequestAppReview).toHaveBeenCalledWith(
+      expect.objectContaining({ matchCount: 1, trigger: "first_match" }),
+    );
+  });
+
+  it.each(["new-match-send", "new-match-skip"])(
+    "drops the ask the instant %s is pressed",
+    (testID) => {
+      render();
+
+      // Deliberately not awaited. Both CTAs wait on the interstitial before
+      // they navigate, so the screen stays mounted for seconds after the
+      // press and the timer would otherwise still be running under a full
+      // screen ad, where the prompt is invisible and in the way of closing
+      // it. The cancel has to land in the press itself, before any await.
+      void mockHandlers.get(testID)?.();
+
+      jest.advanceTimersByTime(REVIEW_PROMPT_DELAY_MS * 4);
+
+      expect(mockHandleRequestAppReview).not.toHaveBeenCalled();
+    },
+  );
+
+  it("leaves the second message fallback armed when a CTA cancels it", async () => {
+    render();
+
+    const pressed = mockHandlers.get("new-match-send")?.();
+    jest.advanceTimersByTime(REVIEW_PROMPT_DELAY_MS * 4);
+    await pressed;
+
+    // The marker that switches the fallback off is written by the ask, and
+    // only once the prompt is on screen. No ask, no marker, so the second
+    // message still gets to try.
+    expect(mockHandleRequestAppReview).not.toHaveBeenCalled();
+    expect(mockRouter.replace).toHaveBeenCalled();
+  });
+
+  it("withdraws an ask that is already in flight", () => {
+    render();
+
+    jest.advanceTimersByTime(REVIEW_PROMPT_DELAY_MS);
+
+    // The ask reads storage and calls the API before it shows anything, so a
+    // press can land while it is still deciding.
+    const options = mockHandleRequestAppReview.mock.calls[0]?.[0];
+    expect(options?.canStillAsk?.()).toBe(true);
+
+    void mockHandlers.get("new-match-skip")?.();
+
+    expect(options?.canStillAsk?.()).toBe(false);
+  });
+
+  it("stops the timer when the screen goes away", () => {
+    const cleanups = render();
+
+    for (const cleanup of cleanups) cleanup?.();
+
+    jest.advanceTimersByTime(REVIEW_PROMPT_DELAY_MS * 4);
+
+    expect(mockHandleRequestAppReview).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/views/NewMatch/index.tsx
+++ b/apps/mobile/src/views/NewMatch/index.tsx
@@ -14,12 +14,19 @@ import { Text } from "@/components/text";
 import { api } from "@/contexts/trpc-provider";
 import { useForAdRequestTracked } from "@/services/advertisement/interstitial";
 import { analytics } from "@/services/analytics";
+import { handleRequestAppReview } from "@/services/app-review";
+import { ReviewTrigger } from "@/services/app-review-policy";
+import { isMaestroE2EBuild } from "@/services/e2e";
+import { sendError } from "@/services/error-tracking";
 import { haptics } from "@/services/haptics";
 import { SceneName } from "@/types/scene-name";
 
 import AnimatedCards from "./animated-cards";
 import { ConfettiAnimation } from "./confetti-animation";
 import { Content, MatchCaption, MatchWordmark, styles } from "./styles";
+
+/** Long enough for the confetti to land and the cards to settle. */
+const REVIEW_PROMPT_DELAY_MS = 2500;
 
 const NewMatch: React.FC = () => {
   const { matchId, matchDogId } = useLocalSearchParams<{
@@ -31,6 +38,13 @@ const NewMatch: React.FC = () => {
     { id: matchDogId as string },
     { refetchOnMount: false },
   );
+
+  // The same query the Messages tab reads, and the swipe saga invalidates it
+  // on its way here, so this is the count including the match on screen.
+  // Deliberately not a suspense query: a slow answer must not hold up the
+  // confetti, and no answer at all just means no prompt.
+  const { data: matches } = api.match.getAll.useQuery();
+  const matchCount = matches?.length;
 
   const { safeLoadAndShow } = useForAdRequestTracked({
     ios: "ca-app-pub-6276873083446538/8154113808",
@@ -108,6 +122,31 @@ const NewMatch: React.FC = () => {
   useEffect(() => {
     haptics.success();
   }, []);
+
+  // The first match is the high point of the whole app, which is why the
+  // review prompt now asks here. It waits out the confetti first: a modal on
+  // top of the celebration would spend the good mood instead of riding it.
+  // Taking either CTA before the delay is up unmounts the screen and cancels
+  // the ask, so the prompt never lands on the chat.
+  useEffect(() => {
+    if (matchCount === undefined) return;
+
+    // Skipped in the Maestro build for the same reason interstitials are: it
+    // is a modal that arrives on a timer this screen owns, it eats the tap
+    // aimed at the CTA underneath, and no flow can wait for a schedule it
+    // cannot see. Both 22-new-match-journey and the grand journey tap a CTA
+    // here within seconds of the screen appearing.
+    if (isMaestroE2EBuild()) return;
+
+    const timeout = setTimeout(() => {
+      handleRequestAppReview({
+        trigger: ReviewTrigger.FirstMatch,
+        matchCount,
+      }).catch(sendError);
+    }, REVIEW_PROMPT_DELAY_MS);
+
+    return () => clearTimeout(timeout);
+  }, [matchCount]);
 
   return (
     <View style={styles.container} testID="new-match-screen">

--- a/apps/mobile/src/views/NewMatch/index.tsx
+++ b/apps/mobile/src/views/NewMatch/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import * as React from "react";
 import { BackHandler, ScrollView, View } from "react-native";
 
@@ -26,7 +26,7 @@ import { ConfettiAnimation } from "./confetti-animation";
 import { Content, MatchCaption, MatchWordmark, styles } from "./styles";
 
 /** Long enough for the confetti to land and the cards to settle. */
-const REVIEW_PROMPT_DELAY_MS = 2500;
+export const REVIEW_PROMPT_DELAY_MS = 2500;
 
 const NewMatch: React.FC = () => {
   const { matchId, matchDogId } = useLocalSearchParams<{
@@ -57,7 +57,26 @@ const NewMatch: React.FC = () => {
 
   const router = useRouter();
 
-  const handleSendMessage = async () => {
+  // Flipped the instant a CTA is pressed, before anything is awaited.
+  //
+  // Both CTAs wait on the interstitial, which keeps this screen mounted for
+  // as long as the ad takes to load and for the whole time it is up. The
+  // review prompt is a magic modal, and outside the Maestro build those
+  // render in RNScreens' FullWindowOverlay, a separate native window. Landing
+  // one on top of a full screen ad meant the user could no longer reach the
+  // ad's close button, the CLOSED event the CTA is awaiting never arrived,
+  // and the screen sat there with no way forward.
+  const exitStartedRef = useRef(false);
+  const reviewTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const cancelReviewPrompt = useCallback(() => {
+    exitStartedRef.current = true;
+    clearTimeout(reviewTimeoutRef.current);
+  }, []);
+
+  const handleSendMessage = useCallback(async () => {
+    cancelReviewPrompt();
+
     analytics.track({
       event_type: "New Match",
       event_properties: {
@@ -77,9 +96,11 @@ const NewMatch: React.FC = () => {
       pathname: `${SceneName.Chat}/[matchId]`,
       params: { dogId: matchDogId, matchId },
     });
-  };
+  }, [cancelReviewPrompt, matchDogId, matchId, router, safeLoadAndShow]);
 
   const handleSkip = useCallback(async () => {
+    cancelReviewPrompt();
+
     analytics.track({
       event_type: "New Match",
       event_properties: {
@@ -90,7 +111,7 @@ const NewMatch: React.FC = () => {
     await safeLoadAndShow();
 
     router.back();
-  }, [router, safeLoadAndShow]);
+  }, [cancelReviewPrompt, router, safeLoadAndShow]);
 
   // Assume 'skip' if the user presses the back button.
   // This is pertinent to Android devices only.
@@ -126,10 +147,13 @@ const NewMatch: React.FC = () => {
   // The first match is the high point of the whole app, which is why the
   // review prompt now asks here. It waits out the confetti first: a modal on
   // top of the celebration would spend the good mood instead of riding it.
-  // Taking either CTA before the delay is up unmounts the screen and cancels
-  // the ask, so the prompt never lands on the chat.
+  // The ask belongs to this screen while this screen is the one in front of
+  // the user, and a CTA press ends both at once.
   useEffect(() => {
     if (matchCount === undefined) return;
+
+    // The count arrives from a query, so this effect can run after a press.
+    if (exitStartedRef.current) return;
 
     // Skipped in the Maestro build for the same reason interstitials are: it
     // is a modal that arrives on a timer this screen owns, it eats the tap
@@ -139,11 +163,22 @@ const NewMatch: React.FC = () => {
     if (isMaestroE2EBuild()) return;
 
     const timeout = setTimeout(() => {
+      // A press clears this timeout synchronously, so getting here at all
+      // means none had landed when the timer was queued. Re-read anyway: a
+      // press in the same tick as the timer is a coin toss otherwise.
+      if (exitStartedRef.current) return;
+
       handleRequestAppReview({
         trigger: ReviewTrigger.FirstMatch,
         matchCount,
+        // Read again just before the modal goes up, after the storage reads
+        // and the API call in there. Everything the prompt costs, the month
+        // long throttle included, is spent on this side of it.
+        canStillAsk: () => !exitStartedRef.current,
       }).catch(sendError);
     }, REVIEW_PROMPT_DELAY_MS);
+
+    reviewTimeoutRef.current = timeout;
 
     return () => clearTimeout(timeout);
   }, [matchCount]);

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -17,6 +17,7 @@ export const ANALYTICS_EVENTS = {
   ADVERTISEMENT: "Advertisement",
   APP_REVIEW: "App Review",
   APP_REVIEW_REQUEST: "App Review Request",
+  APP_REVIEW_SKIPPED: "App Review Skipped",
   CHAT_OPENED: "Chat Opened",
   COMPLETE_DOG_PROFILE: "Complete Dog Profile",
   CREATE_DOG_PROFILE: "Create Dog Profile",
@@ -111,6 +112,31 @@ export type ReengagementPushKind =
   | "unanswered_match";
 
 /**
+ * The moment that produced a review prompt. The whole point of the review
+ * instrumentation: ratings per prompt only means something per trigger.
+ */
+export type ReviewTrigger = "first_match" | "messages_tab" | "second_message";
+
+/**
+ * Where a store rating sheet was reached from: the three prompts, plus the
+ * row in Settings that has always let people rate the app on purpose.
+ */
+export type ReviewSource = ReviewTrigger | "settings";
+
+/**
+ * Why a review prompt did not happen. Only the reasons a user who reached the
+ * trigger can hit are ever sent: a plain "not yet" is not a skip.
+ */
+export type ReviewSkipReason =
+  | "already_reviewed"
+  | "first_prompt_already_shown"
+  | "no_matches"
+  | "not_enough_messages"
+  | "not_first_match"
+  | "store_review_unavailable"
+  | "throttled";
+
+/**
  * Event name to property shape, for events sent from the app.
  *
  * `analytics.track` is typed against this, so an unknown name or a property
@@ -119,8 +145,12 @@ export type ReengagementPushKind =
  */
 export type MobileEventProperties = {
   [ANALYTICS_EVENTS.ADVERTISEMENT]: { action: string; type: string };
-  [ANALYTICS_EVENTS.APP_REVIEW]: undefined;
-  [ANALYTICS_EVENTS.APP_REVIEW_REQUEST]: undefined;
+  [ANALYTICS_EVENTS.APP_REVIEW]: { trigger: ReviewSource };
+  [ANALYTICS_EVENTS.APP_REVIEW_REQUEST]: { trigger: ReviewTrigger };
+  [ANALYTICS_EVENTS.APP_REVIEW_SKIPPED]: {
+    reason: ReviewSkipReason;
+    trigger: ReviewTrigger;
+  };
   [ANALYTICS_EVENTS.CHAT_OPENED]: { match_id: string };
   [ANALYTICS_EVENTS.COMPLETE_DOG_PROFILE]: {
     has_birth_date: boolean;
@@ -329,6 +359,7 @@ export const MOBILE_EVENT_NAMES = [
   ANALYTICS_EVENTS.ADVERTISEMENT,
   ANALYTICS_EVENTS.APP_REVIEW,
   ANALYTICS_EVENTS.APP_REVIEW_REQUEST,
+  ANALYTICS_EVENTS.APP_REVIEW_SKIPPED,
   ANALYTICS_EVENTS.CHAT_OPENED,
   ANALYTICS_EVENTS.COMPLETE_DOG_PROFILE,
   ANALYTICS_EVENTS.CREATE_DOG_PROFILE,


### PR DESCRIPTION
## Summary
The app now asks for a store review right after a user's first match, while the celebration is still on screen, instead of waiting for them to open the Messages tab. If that ask never reaches them, it tries once more after the second message they send.
Closes #192

## Details
- Hypothesis: asking at the first match, the emotional peak, produces more store ratings per prompt than the current passive trigger on the Messages tab, so the ratings count grows faster on the same prompt budget.
- Baseline: today the prompt fires on the Messages tab, once a month, for anyone with at least one match, and nothing records which moment produced it, so prompts per trigger is unknown. Ratings count and average are visible in App Store Connect and Play Console. Published category figures put prompt to rating conversion around 3 to 5 percent. The instrumentation below is therefore the first deliverable, and it is what establishes the baseline.
- Readout: `App Review Request`, the event that already fires when the question appears, now carries a `trigger` property (`first_match`, `second_message`, `messages_tab`), and so does `App Review`, the event for reaching the store rating sheet. A new `App Review Skipped` carries `trigger` plus a `reason` for the users who reached a trigger and were blocked anyway (throttled, already reviewed, no rating sheet on the platform). In PostHog, read prompts per trigger per week. The operating systems never tell an app whether a rating was actually left, so the other half of the ratio has to come from App Store Connect and Play Console over the same weeks. Compare ratings per 100 prompts by trigger, and keep the change if `first_match` beats `messages_tab` after 200 prompts on `first_match`.
- The monthly throttle stays the single rule for all three triggers, so the prompt quota Apple and Google allow is spent at most once a month whichever moment wins.
- The decision itself moved into a pure policy module with its own tests, so the rules are readable in one place instead of inferred from three call sites, and the wiring around it has tests too.
- On the celebration screen the ask waits a couple of seconds so it does not cut across the confetti. Pressing either button in that window cancels it on the spot, before anything else happens, and the ask is dropped again just before the question would appear if a press landed while it was still deciding. Both buttons wait on an interstitial ad before they navigate, so the screen stays up for seconds after the press, and a question arriving in that window would sit on top of a full screen ad with no way past it.
- Nothing is recorded until the question is actually on screen. The month long throttle and the marker that retires the second message fallback are written after it appears, so an ask that was cancelled costs the user nothing and the fallback still gets its turn.
- A match only shows the celebration screen to the person who swiped. When the other side liked last and the match arrives passively, there is no celebration and `first_match` never fires for them, which is what the second message trigger is for.
- The Maestro build skips the celebration trigger, the same way it skips interstitial ads: it is a modal on a timer, it covers the button underneath, and no flow can wait for a schedule it cannot see.
- Logging out clears the two new per user counters. "Your first match" and "your second message" belong to the account that is leaving, while the throttle and the completed status stay because those guard a per device quota the next account shares.
- The trigger and skip reason vocabularies live in the shared analytics catalogue alongside the event names, since they travel as event properties, and the policy module reads them from there rather than keeping a second copy.

## Testing steps
1. Sign in with an account that has never matched with anyone.
2. Swipe right on a dog that has already liked you, so a match happens.
3. Stay on the celebration screen. After a moment the "Are you liking the app?" question appears over it.
4. Answer it, match with another dog, and check that the question does not come back.
5. Sign in with a different account, get a match, and leave the celebration straight away by tapping one of the two buttons. The question does not appear and the conversation opens normally. Send two messages in it, and the question appears after the second one.

## Screenshots
The question on the celebration screen, a couple of seconds after the match.

![Review prompt on the new match screen](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-mobile-review-after-match/shots/first-match-review-prompt.png)

The same question in the conversation, for someone who left the celebration before it could ask.

![Review prompt after the second message](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-mobile-review-after-match/shots/second-message-review-prompt.png)
