### PR TITLE
fix(database): apply migrations during Vercel production builds

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "pnpm -F @pegada/database build && next build",
+    "build": "pnpm -F @pegada/database build && pnpm -F @pegada/database migrate:vercel && next build",
     "start": "next start",
     "test": "node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -32,6 +32,7 @@
     "test:db:up": "if [ -n \"$CI\" ]; then echo 'CI supplies Postgres as a workflow service container, skipping docker-compose'; else docker-compose -f docker-compose.test.yml up --build --detach; fi",
     "test:db:setup": "pnpm test:db:up && pnpm migrate deploy",
     "migrate": "npx prisma migrate",
+    "migrate:vercel": "bash ./scripts/migrate-deploy-vercel.sh",
     "postinstall": "pnpm run build"
   },
   "dependencies": {

--- a/packages/database/scripts/migrate-deploy-vercel.sh
+++ b/packages/database/scripts/migrate-deploy-vercel.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Applies pending migrations as part of a Vercel production build.
+#
+# The gap this closes: Vercel builds and promotes every push to `main`, and the
+# build only ran `prisma generate`. Nothing ever ran `prisma migrate deploy`
+# against the production database, so the generated client and the live schema
+# drifted apart on their own. Prisma selects every scalar column of a model
+# unless a query names a `select`, so the first deploy carrying a new column is
+# also the deploy where `prisma.user.findUnique({ where: { id } })` starts
+# asking for a column that was never created and the request 500s. Nothing in
+# the build is red when that happens: the deploy is green and the API is down.
+#
+# So the migration has to run in the same build that ships the client that
+# expects it, before `next build`, and it has to be able to fail the build.
+#
+# Scope, in order of the checks below:
+#
+# `VERCEL_ENV` is set by Vercel and by nothing else, so an unset value is a
+# local build or a CI job and this is a no-op there. Preview deploys are
+# excluded too: they point at whatever database the preview environment
+# configures, and a preview of an unmerged branch must not be what applies a
+# migration to it.
+#
+# `DIRECT_URL` is the datasource's `directUrl` (see schema.prisma). Migrations
+# are DDL and advisory locks, which a connection pooler in transaction mode
+# cannot carry, so `DATABASE_URL` is the wrong URL for this even when it works.
+# Prisma picks `directUrl` up on its own for migrate commands; the check here
+# is so a missing value stops the deploy with a sentence that says what to set,
+# instead of a Prisma error about an environment variable.
+#
+# Missing `DIRECT_URL` is a hard failure rather than a fallback to the pooled
+# URL on purpose. A production deploy that cannot apply its migrations is the
+# exact situation this script exists to prevent, and quietly continuing would
+# reintroduce it.
+set -euo pipefail
+
+if [ "${VERCEL_ENV:-}" != "production" ]; then
+  echo "migrate deploy: skipped, VERCEL_ENV is '${VERCEL_ENV:-unset}' and not 'production'."
+  exit 0
+fi
+
+if [ -z "${DIRECT_URL:-}" ]; then
+  echo "migrate deploy: DIRECT_URL is not set." >&2
+  echo "Production deploys apply migrations over a direct (non-pooled) connection." >&2
+  echo "Add DIRECT_URL to the Vercel production environment and redeploy." >&2
+  exit 1
+fi
+
+echo "migrate deploy: applying pending migrations to the production database."
+
+# No `|| true` and no retry. `set -e` carries the exit code out to the build,
+# which is the point: a failed migration must stop the deploy before
+# `next build` produces an artifact that expects the schema it did not get.
+npx prisma migrate deploy
+
+echo "migrate deploy: migrations applied."


### PR DESCRIPTION
## Summary

Vercel promotes every push to main, but the production build only generated the Prisma client and never applied migrations, so a deploy could ship code that expects columns the production database does not have.

This runs the migration as part of the production build, before the app is built, and fails the deploy if it does not succeed.

## Details

- Hypothesis: the deploy pipeline can ship a Prisma client ahead of the database schema, and when it does, every logged in user gets a 500. Prisma selects all scalar columns of a model unless a query names an explicit set, so the account lookup that runs on app launch asks for whatever column the newest migration added. Baseline right now: two migrations sit unapplied against production, one adding the subscription events table and a premium expiry column, one adding a last active column. The deploy that carries them is already live and green.
- Readout: the log of the next production deploy contains the line saying migrations were applied, and the two new columns plus the subscription events table exist on the production database. After that, no further deploy can be green while its migrations are unapplied.
- Metric this protects: revenue and retention both run through the authenticated API. A deploy that breaks the account lookup takes purchases, matches and messages down with it, and the churn reporting the subscription events table exists to feed cannot be read until the table is really there.
- The migration runs over the direct connection declared as the datasource direct URL, not the pooled one. Migrations are schema changes and advisory locks, which a pooler in transaction mode cannot carry.
- Guarded on the Vercel production environment variable. That variable is set by Vercel and nothing else, so local builds and CI skip the step entirely, and preview deploys skip it too because a preview of an unmerged branch must not be the thing that migrates a shared database.
- Failure is loud on purpose. There is no fallback and no retry: if the migration cannot run, the build stops before it produces an app that expects a schema it did not get. A missing direct URL is also a hard stop, with a message saying what to set.
- For Gabriel, to unblock production right now before this merges: `cd packages/database && DATABASE_URL=<prod> DIRECT_URL=<prod direct> npx prisma migrate deploy`
- One prerequisite: the Vercel production environment needs `DIRECT_URL` alongside `DATABASE_URL`. If it is missing, the first deploy after this merges will stop with the message above rather than ship a half applied schema.

## Testing steps

1. Build the web app on your own machine the normal way. It finishes as it always has, and the output says the migration step was skipped because it is not a production deploy.
2. Do the same with the environment marked as a production deploy, pointed at a throwaway database. The output says migrations were applied, and the new columns and the new table are there afterwards.
3. Repeat that with a database that cannot be reached. The build stops at the migration step and never reaches the app build, which is the whole point.

## Screenshots

Build configuration only, nothing visible changed.
