### PR TITLE
fix(mobile): stop the swipe screen replaying the last notification tap

### DIFF
--- a/apps/mobile/src/services/linking/handlers/initial-notification.ts
+++ b/apps/mobile/src/services/linking/handlers/initial-notification.ts
@@ -1,24 +1,67 @@
 /**
- * The notification URL the app was cold-launched from, if any.
+ * The notification tap waiting to be handled, if any.
  *
  * Held in a module-local binding with an accessor rather than exported as a
  * `let`: a re-exported mutable binding is a live view of someone else's
  * variable, which is exactly the shape `import/no-mutable-exports` exists to
  * stop, and callers only ever need "read it" and "clear it".
+ *
+ * Every tap lands here, because the listener in `_layout.tsx` runs for the
+ * whole app lifetime, cold start and warm tap alike. Only one of them still
+ * needs handling from here: a warm tap is already handled on the spot by the
+ * listener `processLinks` registers. So the store is consume-once, keyed by
+ * the notification id, and the pair below is what enforces it.
  */
-let initialNotificationUrl: string | undefined;
-let initialNotificationKind: string | undefined;
+type StoredNotification = {
+  id: string;
+  url?: string;
+  /**
+   * Which scheduled nudge the notification came from, if any. Kept beside the
+   * url so the open reported on launch carries the same breakdown the one
+   * reported while the app runs does.
+   */
+  kind?: string;
+};
 
-export const getInitialNotification = () => initialNotificationUrl;
+let storedNotification: StoredNotification | undefined;
+let lastHandledId: string | undefined;
+
+export const setInitialNotification = (
+  notification?: StoredNotification,
+): void => {
+  storedNotification = notification;
+};
 
 /**
- * Which scheduled nudge the cold-start notification came from, if any. Kept
- * beside the url so the open reported on launch carries the same breakdown the
- * one reported while the app runs does.
+ * Takes ownership of a tap. Returns false when this exact tap was already
+ * handled, which is what keeps one tap to one `Push Notification Opened`.
+ *
+ * A single id is enough memory: only one tap is ever stored at a time, so the
+ * only replay to defend against is of the tap that was just handled.
  */
-export const getInitialNotificationKind = () => initialNotificationKind;
+export const claimNotification = (id: string): boolean => {
+  if (id && id === lastHandledId) return false;
 
-export const setInitialNotification = (url?: string, kind?: string) => {
-  initialNotificationUrl = url;
-  initialNotificationKind = kind;
+  lastHandledId = id;
+  // The tap being handled right now is also sitting in the store, written
+  // there by the app-wide listener. Dropping it as it is claimed is what
+  // stops the next mount of the Swipe screen replaying it.
+  if (storedNotification?.id === id) storedNotification = undefined;
+
+  return true;
+};
+
+/**
+ * Reads the stored tap and clears it in the same call, so a second read can
+ * never see it. Returns nothing when the tap was already handled elsewhere.
+ */
+export const consumeInitialNotification = ():
+  | StoredNotification
+  | undefined => {
+  const notification = storedNotification;
+  storedNotification = undefined;
+
+  if (!notification || !claimNotification(notification.id)) return undefined;
+
+  return notification;
 };

--- a/apps/mobile/src/services/linking/handlers/notification.ts
+++ b/apps/mobile/src/services/linking/handlers/notification.ts
@@ -31,6 +31,18 @@ export const getNotificationKind = (
   return response.notification.request.content.data?.kind as string | undefined;
 };
 
+/**
+ * Identity of a tap, so the same one is never reported twice. Two listeners
+ * see every warm tap (one in `_layout.tsx`, one in `processLinks`) and
+ * `getLastNotificationResponseAsync` keeps handing the last one back, so
+ * "have I already handled this?" needs something stable to ask about.
+ */
+export const getNotificationId = (
+  response: Notifications.NotificationResponse,
+): string => {
+  return response.notification.request.identifier;
+};
+
 const handleUnknownNotification = (url: string) => {
   sendError(new Error(`Unknown notification: ${url}`));
 };

--- a/apps/mobile/src/services/linking/index.test.ts
+++ b/apps/mobile/src/services/linking/index.test.ts
@@ -9,16 +9,28 @@ jest.mock<Partial<typeof import("expo-router")>>("expo-router", () => ({
 
 // The module under test also wires up notification handling
 // (useGetInitialNotifications / processLinks), which pulls in
-// expo-notifications and the observability stack at import time. Neither
-// runs in this test — only usePendingDogProfile does — so both are stubbed
-// to keep the import side-effect-free, the same way action.test.ts mocks
-// error-tracking for the same reason.
+// expo-notifications and the observability stack at import time. The stub
+// keeps the import side-effect-free the way action.test.ts mocks
+// error-tracking, and doubles as the tap simulator the replay tests drive:
+// it hands back the registered listeners so a tap can be delivered to every
+// one of them, exactly as the native module does.
 jest.mock<Record<string, unknown>>("expo-notifications", () => ({
-  addNotificationResponseReceivedListener: jest.fn(() => ({
-    remove: jest.fn(),
-  })),
-  getLastNotificationResponseAsync: jest.fn(() => Promise.resolve(null)),
+  addNotificationResponseReceivedListener: (
+    listener: (response: unknown) => void,
+  ) => {
+    mockResponseListeners.add(listener);
+    return {
+      remove: () => {
+        mockResponseListeners.delete(listener);
+      },
+    };
+  },
+  getLastNotificationResponseAsync: () =>
+    Promise.resolve(mockLastNotificationResponse),
 }));
+
+const mockResponseListeners = new Set<(response: unknown) => void>();
+let mockLastNotificationResponse: unknown = null;
 
 jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
   sendError: jest.fn(),
@@ -58,7 +70,12 @@ jest.mock<Record<string, unknown>>("react", () => {
 
 import { analytics } from "@/services/analytics";
 
-import { usePendingDogProfile } from ".";
+import {
+  processLinks,
+  useGetInitialNotifications,
+  usePendingDogProfile,
+} from ".";
+import { setInitialNotification } from "./handlers/initial-notification";
 
 const push = jest.mocked(router.push);
 const track = jest.mocked(analytics.track);
@@ -71,9 +88,39 @@ const Harness = ({ enabled }: { enabled: boolean }) => {
 const render = (enabled: boolean) =>
   renderToStaticMarkup(React.createElement(Harness, { enabled }));
 
+const notificationResponse = (identifier: string, url: string) => ({
+  notification: { request: { identifier, content: { data: { url } } } },
+});
+
+/** Mounts the root layout, which is where the app wide tap listener lives. */
+const mountLayout = async () => {
+  const LayoutHarness = () => {
+    useGetInitialNotifications();
+    return null;
+  };
+
+  renderToStaticMarkup(React.createElement(LayoutHarness));
+  // getLastNotificationResponseAsync resolves on a microtask, and the cold
+  // start tap is only stored once it does.
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+/** Delivers a tap to every registered listener, the way the OS does. */
+const tap = (response: ReturnType<typeof notificationResponse>) => {
+  for (const listener of mockResponseListeners) listener(response);
+};
+
+const countReported = (eventType: string) =>
+  track.mock.calls.filter(([event]) => event.event_type === eventType).length;
+
 afterEach(() => {
   mockPendingDogProfileId = undefined;
+  mockResponseListeners.clear();
+  mockLastNotificationResponse = null;
+  setInitialNotification(undefined);
   track.mockClear();
+  push.mockClear();
 });
 
 test("does not navigate while disabled, even with a pending id", () => {
@@ -137,4 +184,69 @@ test("pushes again for a second id that arrives while already enabled", () => {
     pathname: "/profile/[id]",
     params: { id: "dog-2" },
   });
+});
+
+test("reports a cold start tap once, and not again when Swipe remounts", async () => {
+  mockLastNotificationResponse = notificationResponse("cold-1", "swipe");
+  await mountLayout();
+
+  const firstMount = processLinks();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+
+  firstMount.remove();
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+});
+
+test("reports a tap taken while the app is open once, and not again when Swipe remounts", async () => {
+  await mountLayout();
+  const firstMount = processLinks();
+
+  tap(notificationResponse("warm-1", "swipe"));
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+
+  firstMount.remove();
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+});
+
+test("handles a tap taken while Swipe is unmounted on the next mount, once", async () => {
+  await mountLayout();
+  processLinks().remove();
+
+  tap(notificationResponse("warm-2", "swipe"));
+
+  expect(countReported("Push Notification Opened")).toBe(0);
+
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+});
+
+test("reports nothing when Swipe mounts with no tap waiting", async () => {
+  await mountLayout();
+
+  processLinks().remove();
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(0);
+  expect(push).not.toHaveBeenCalled();
 });

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -8,12 +8,13 @@ import { sendError } from "@/services/error-tracking";
 import { SceneName } from "@/types/scene-name";
 
 import {
-  getInitialNotification,
-  getInitialNotificationKind,
+  claimNotification,
+  consumeInitialNotification,
   setInitialNotification,
 } from "./handlers/initial-notification";
 import {
   customNotificationHandler,
+  getNotificationId,
   getNotificationKind,
   getNotificationUrl,
 } from "./handlers/notification";
@@ -23,7 +24,11 @@ import {
 } from "./handlers/pending-dog-profile";
 
 export const processLinks = () => {
-  const initialNotification = getInitialNotification();
+  // Consuming clears the stored tap in the same call, and hands back nothing
+  // for a tap the listener below already handled. Without that, every mount of
+  // this screen re-ran the whole handler on the last tap: a second
+  // "Push Notification Opened", and a second jump to the notification target.
+  const initialNotification = consumeInitialNotification();
 
   if (initialNotification) {
     // The handler is synchronous — expo-router's push is — so a rejected
@@ -31,19 +36,22 @@ export const processLinks = () => {
     // url" was, and `.catch` never saw it.
     try {
       customNotificationHandler(
-        initialNotification,
-        getInitialNotificationKind(),
+        initialNotification.url,
+        initialNotification.kind,
       );
     } catch (error) {
       sendError(error);
     }
   }
 
-  setInitialNotification(undefined);
-
   // When the app is already running, and the user clicks on a notification
   const notificationSubscription =
     Notifications.addNotificationResponseReceivedListener((response) => {
+      // Claiming here is what marks the tap as spent for the mount path, and
+      // it also covers two of these listeners briefly overlapping while the
+      // screen remounts.
+      if (!claimNotification(getNotificationId(response))) return;
+
       const url = getNotificationUrl(response);
       try {
         customNotificationHandler(url, getNotificationKind(response));
@@ -65,10 +73,11 @@ export const useGetInitialNotifications = () => {
     Notifications.getLastNotificationResponseAsync()
       .then((response) => {
         if (!response) return;
-        setInitialNotification(
-          getNotificationUrl(response),
-          getNotificationKind(response),
-        );
+        setInitialNotification({
+          id: getNotificationId(response),
+          url: getNotificationUrl(response),
+          kind: getNotificationKind(response),
+        });
         return undefined;
       })
       .catch(sendError);
@@ -76,10 +85,11 @@ export const useGetInitialNotifications = () => {
     // When the app is already running, and the user clicks on a notification
     const notificationSubscription =
       Notifications.addNotificationResponseReceivedListener((response) => {
-        setInitialNotification(
-          getNotificationUrl(response),
-          getNotificationKind(response),
-        );
+        setInitialNotification({
+          id: getNotificationId(response),
+          url: getNotificationUrl(response),
+          kind: getNotificationKind(response),
+        });
       });
 
     return () => {

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -67,30 +67,28 @@ export const processLinks = () => {
   };
 };
 
+const storeNotification = (response: Notifications.NotificationResponse) => {
+  setInitialNotification({
+    id: getNotificationId(response),
+    url: getNotificationUrl(response),
+    kind: getNotificationKind(response),
+  });
+};
+
 export const useGetInitialNotifications = () => {
   useEffect(() => {
     // When the app is not already running, and the user clicks on a notification
     Notifications.getLastNotificationResponseAsync()
       .then((response) => {
         if (!response) return;
-        setInitialNotification({
-          id: getNotificationId(response),
-          url: getNotificationUrl(response),
-          kind: getNotificationKind(response),
-        });
+        storeNotification(response);
         return undefined;
       })
       .catch(sendError);
 
     // When the app is already running, and the user clicks on a notification
     const notificationSubscription =
-      Notifications.addNotificationResponseReceivedListener((response) => {
-        setInitialNotification({
-          id: getNotificationId(response),
-          url: getNotificationUrl(response),
-          kind: getNotificationKind(response),
-        });
-      });
+      Notifications.addNotificationResponseReceivedListener(storeNotification);
 
     return () => {
       notificationSubscription.remove();


### PR DESCRIPTION
## Summary
The swipe deck replayed the last notification tap every time it was mounted, so one tap could report several opens and could send the user to the notification target again.
A tap is now handled exactly once, whether it arrived on launch or while the app was already open.

Closes #229

## Details
- The app wide listener in the root layout stores every notification tap. The swipe deck read that stored tap on mount and only cleared it after handling it, so a tap that had already been handled by the deck's own listener stayed behind and ran again on the next mount.
- The store is now consume-once: reading it clears it in the same call, and it hands back nothing for a tap that was already handled.
- Taps carry the notification identifier, so the deck's live listener and the mount path can tell they are looking at the same tap. That also covers two listeners briefly overlapping while the screen remounts.
- A tap taken while the deck is not mounted is still picked up on the next mount, once. Cold start is unchanged apart from the clearing being atomic.
- The shared dog link flow is untouched. It runs through its own pending id store and was already consume-once.

### Hypothesis
Push open rate is overstated because the same tap is reported more than once. Making the stored tap consume-once should bring both `Push Notification Opened` and `Deep Link Opened` down to one event per tap.

### Baseline
The behaviour described in the issue: one tap taken while the app is open produces one open at the moment of the tap, then another one for every later mount of the swipe deck. Leaving the deck tab and coming back is enough to trigger it, so the count grows with ordinary navigation.

### Readout
In PostHog, count `Push Notification Opened` and `Deep Link Opened` grouped by `distinct_id`, `url` and session. Sessions with several swipe deck mounts after a single tap should now show exactly one of each instead of one per mount. The ratio of opens to pushes actually delivered should drop accordingly.

### Verification on device
```
One push tapped while the app was open on the deck, then three round trips
off the deck tab and back. A temporary console line beside each analytics
call made the two events visible; it is not part of this change.

 LOG  [verify] Push Notification Opened {"kind": "new_dogs_nearby", "url": "swipe"}
 LOG  [verify] Deep Link Opened {"url": "swipe"}

Nothing after that. The deck really did remount each time: the API log shows
a fresh swipe.all fetch per return, and that fetch is dispatched by the same
mount effect that runs the link handling.

 GET /api/trpc/swipe.all?batch=1... 200 in 75ms
 GET /api/trpc/swipe.all?batch=1... 200 in 170ms
 GET /api/trpc/swipe.all?batch=1... 200 in 100ms
```

## Testing steps
1. Open the app and stay on the deck of dogs.
2. Send yourself a notification and tap it. The app takes you where the notification points.
3. Move to another tab, then come back to the deck.
4. The app stays where you left it. Before this change it jumped to the notification target a second time.
5. Repeat the tab round trip a couple more times. Nothing happens.
6. Open a shared dog link while the app is running. The dog profile opens once, and coming back to the deck does not open it again.

## Screenshots
Not applicable. This is a logic fix with no visible surface of its own, so the evidence is the log excerpt in Details.
