### PR TITLE
fix(web): restore the dog share card's link preview

### DIFF
--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -10,6 +10,7 @@ import { isReferralRef } from "@pegada/shared/utils/referral";
 import { DownloadCta } from "@/components/download-cta";
 import { gilroy } from "@/lib/fonts";
 import { getSafeLocale } from "@/lib/get-safe-locale";
+import { toLocalePath, toOpenGraphLocale } from "@/lib/locales";
 import { t } from "@/lib/translate";
 import { cn } from "@/lib/utils";
 
@@ -36,6 +37,9 @@ type DogProfileProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
+/** Where these pages live, before the locale prefix is put back on. */
+const ROUTE_PATH = "/dog";
+
 export const generateMetadata = async ({
   params,
 }: DogProfileProps): Promise<Metadata> => {
@@ -51,13 +55,45 @@ export const generateMetadata = async ({
   const lng = getSafeLocale();
   const title = t("dog.metadata.title", { name: dog.name, lng });
   const description = getDogDescription(dog, lng);
+  const url = toLocalePath(lng, `${ROUTE_PATH}/${id}`);
 
+  // `opengraph-image.tsx` next door is picked up by file convention, but the
+  // URL Next writes for it is the rewritten, always-prefixed path
+  // (`/en-us/dog/…`), which 307s to the unprefixed one on the default locale,
+  // and it is resolved against the request host instead of `metadataBase`. A
+  // scraper that does not follow redirects shows no card at all, which is
+  // every English share. Naming the image here puts it on the path the locale
+  // actually serves, and a relative URL is resolved against the layout's
+  // `metadataBase`, so previews point at the canonical domain from any
+  // deployment.
+  const images = [
+    {
+      url: `${url}/opengraph-image`,
+      width: 1200,
+      height: 630,
+      type: "image/png",
+      alt: t("dog.metadata.ogImageAlt", { name: dog.name, lng }),
+    },
+  ];
+
+  // `openGraph` replaces the root layout's wholesale rather than merging into
+  // it, so `url`, `siteName` and `locale` have to be restated here or this
+  // page's card loses them, same as `/story`. `alternates` is a separate field
+  // and still comes from the layout.
   return {
     title,
     description,
     robots: { index: false, follow: false },
-    openGraph: { title, description, type: "profile" },
-    twitter: { card: "summary_large_image" },
+    openGraph: {
+      type: "profile",
+      locale: toOpenGraphLocale(lng),
+      siteName: "Pegada",
+      url,
+      title,
+      description,
+      images,
+    },
+    twitter: { card: "summary_large_image", title, description, images },
   };
 };
 
@@ -165,11 +201,13 @@ const DogProfile = async ({ params, searchParams }: DogProfileProps) => {
             )}
 
             {Boolean(dog.breed?.name) && (
-              // Mirrors the app's own breed tag (`breed-tag.tsx` +
-              // `Glassmorphism`): a frosted, bordered pill, not an uppercase
-              // dark badge — same casing, same md radius, same light glass
-              // tint the app uses over photos.
-              <div className="absolute right-4 top-4 flex h-8 items-center rounded-xl border border-white/30 bg-white/20 px-3 leading-none text-white backdrop-blur-md">
+              // Same frosted pill as the app's breed tag (`breed-tag.tsx` +
+              // `Glassmorphism`), with the fill inverted. In the app that tag
+              // sits on a photo the deck has already darkened; here it sits on
+              // the raw photo, and a white tint on a white dog leaves white
+              // text on white. A dark fill carries its own contrast, so it
+              // reads on a snow shot and on a black lab alike.
+              <div className="absolute right-4 top-4 flex h-8 items-center rounded-xl border border-white/15 bg-black/55 px-3 leading-none text-white backdrop-blur-md">
                 <span className="text-sm font-medium">
                   {t(`${dog.breed?.slug as BreedSlug}`, {
                     ns: Namespace.Breed,

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -121,7 +121,8 @@
   "dog": {
     "metadata": {
       "title": "{{name}} | Pegada",
-      "descriptionSuffix": "Meet {{name}} and other dogs near you on Pegada."
+      "descriptionSuffix": "Meet {{name}} and other dogs near you on Pegada.",
+      "ogImageAlt": "A photo of {{name}} on a Pegada card, next to the name, breed and age."
     },
     "hero": {
       "invite": "{{name}} wants to make friends",

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -121,7 +121,8 @@
   "dog": {
     "metadata": {
       "title": "{{name}} | Pegada",
-      "descriptionSuffix": "Conheça {{name}} e outros cachorros perto de você no Pegada."
+      "descriptionSuffix": "Conheça {{name}} e outros cachorros perto de você no Pegada.",
+      "ogImageAlt": "Uma foto de {{name}} em um card do Pegada, ao lado do nome, da raça e da idade."
     },
     "hero": {
       "invite": "{{article}} {{name}} quer fazer amigos",


### PR DESCRIPTION
## Summary

The dog share page was losing most of its link preview: no site name, no language, no alt text, and on English links a card image that never loaded.
The breed pill on the photo also gets a dark fill. On a light dog it was white on white.

## Details

- The page set its own Open Graph block. Next replaces the site-wide one with it instead of merging the two, and the address, the site name and the language fell off every dog card. They are restated on the page now, the way the story page already does it.
- The card image address came from the file convention, which writes the internal, always-prefixed path. On English links that path redirects, and a scraper that does not follow redirects shows a card with no image at all. The page names the image itself now, on the path each language actually serves. Both languages return it on the first request.
- That address resolves against the site's canonical domain instead of whichever host answered the request. A preview deployment or a local run can no longer end up inside a shared card.
- The card image has alt text in both languages.
- The breed pill was white text on a white tint sitting on the raw photo. Measured on a near-white photo, the label came out at 1.01:1 against its own fill. A dark fill with a hairline white border puts it at 4.82:1 on the same photo and keeps the frosted look on a normal one.
- Hypothesis: an English dog link whose card image never loads, and any preview missing the site name and language, loses install taps.
- Baseline: none measured, nobody has counted preview impressions yet.
- Readout: Download CTA Clicked from the dog page, split by language, for the two weeks before and the two weeks after this ships.

## Testing steps

1. Paste a dog's link into WhatsApp, in Portuguese and in English. Both previews should show the dog's photo card, the dog's name and Pegada as the source.
2. Do the same in Slack.
3. On a phone, open a dog whose photo is very light, shot against snow or a white wall. The breed label in the top right corner should be readable.
4. Open a dog with a dark photo and check the same label still sits on the photo without looking heavy.

## Screenshots

Breed pill on a light photo, at phone size.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-dog-share-preview/shots/before-breedpill-light-photo-iphone390.png) | ![after](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-dog-share-preview/shots/after-breedpill-light-photo-iphone390.png) |
| ![before pill](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-dog-share-preview/shots/before-breedpill-light-photo-iphone390-pill.png) | ![after pill](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-dog-share-preview/shots/after-breedpill-light-photo-iphone390-pill.png) |

The same pill on a normal photo, unchanged in feel:

![pill on a real photo](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-dog-share-preview/shots/after-breedpill-real-photo-iphone390-pill.png)

The card image both languages now serve directly, Portuguese and English:

![Portuguese card](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-dog-share-preview/shots/after-og-image-rex-ptbr.png)

![English card](https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-dog-share-preview/shots/after-og-image-bella-en.png)
