### PR TITLE
fix(web): localize the 404 and put it on the theme palette

### DIFF
--- a/apps/nextjs/src/app/not-found.tsx
+++ b/apps/nextjs/src/app/not-found.tsx
@@ -1,25 +1,45 @@
 import Link from "next/link";
 
+import { getSafeLocale } from "@/lib/get-safe-locale";
+import { toLocalePath } from "@/lib/locales";
+import { t } from "@/lib/translate";
+
+/**
+ * The only 404 in the app. `[locale]` has no `not-found.tsx` of its own, so
+ * every `notFound()` under it lands here: a dead `/dog/[id]` share link, the
+ * locale layout rejecting a segment it does not serve, and any unmatched
+ * top-level route.
+ *
+ * Next never hands this file `params`, so the locale comes off the request the
+ * same way the root layout and the footer read it, from the header next-intl's
+ * middleware sets. On the paths the middleware's matcher skips there is no
+ * header and `getSafeLocale` falls back to the default locale.
+ */
 const NotFoundPage = () => {
+  const locale = getSafeLocale();
+
   return (
-    <section className="bg-white dark:bg-gray-900 min-h-screen flex items-center">
-      <div className="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
-        <div className="mx-auto max-w-screen-sm text-center gap-4">
-          <h1 className="text-7xl tracking-tight font-extrabold lg:text-9xl text-primary-600 dark:text-primary-500">
+    <section className="flex min-h-screen items-center bg-background">
+      <div className="mx-auto max-w-screen-xl px-4 py-8 lg:px-6 lg:py-16">
+        <div className="mx-auto flex max-w-screen-sm flex-col items-center gap-4 text-center">
+          <h1 className="text-7xl font-extrabold tracking-tight text-primary lg:text-9xl">
             404
           </h1>
-          <p className="mb-4 text-2xl tracking-tight font-bold text-gray-900 md:text-3xl">
-            Something&apos;s missing.
+          <p className="text-2xl font-bold tracking-tight text-text md:text-3xl">
+            {t("notFound.title")}
           </p>
-          <p className="text-lg font-light text-gray-500 dark:text-gray-400">
-            Sorry, we can&apos;t find that page. You&apos;ll find lots to
-            explore on the home page.
+          <p className="text-lg font-light text-subtitle">
+            {t("notFound.description")}
           </p>
+          {/*
+           * Back to the home of the locale the visitor is already in; a bare
+           * "/" would hand a Portuguese reader to the middleware's guess.
+           */}
           <Link
-            href="/"
-            className="inline-flex text-white bg-primary hover:scale-105 transition-all focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:focus:ring-primary-900 my-4"
+            href={toLocalePath(locale, "/")}
+            className="mt-2 inline-flex min-h-[44px] items-center rounded-full bg-primary px-8 py-4 font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
           >
-            Back to Homepage
+            {t("notFound.action")}
           </Link>
         </div>
       </div>

--- a/apps/nextjs/src/components/something-went-wrong.tsx
+++ b/apps/nextjs/src/components/something-went-wrong.tsx
@@ -10,23 +10,23 @@
  */
 export const SomethingWentWrong = ({ reset }: { reset?: () => void }) => {
   return (
-    <section className="bg-white dark:bg-gray-900 min-h-screen flex items-center">
-      <div className="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
-        <div className="mx-auto max-w-screen-sm text-center gap-4">
-          <h1 className="text-7xl tracking-tight font-extrabold lg:text-9xl text-primary-600 dark:text-primary-500">
+    <section className="flex min-h-screen items-center bg-background">
+      <div className="mx-auto max-w-screen-xl px-4 py-8 lg:px-6 lg:py-16">
+        <div className="mx-auto flex max-w-screen-sm flex-col items-center gap-4 text-center">
+          <h1 className="text-7xl font-extrabold tracking-tight text-primary lg:text-9xl">
             500
           </h1>
-          <p className="mb-4 text-2xl tracking-tight font-bold text-gray-900 md:text-3xl">
+          <p className="text-2xl font-bold tracking-tight text-text md:text-3xl">
             Something went wrong
           </p>
-          <p className="text-lg font-light text-gray-500 dark:text-gray-400">
+          <p className="text-lg font-light text-subtitle">
             We encountered an error. Please try again later.
           </p>
           {reset ? (
             <button
               type="button"
               onClick={reset}
-              className="inline-flex text-white bg-primary hover:scale-105 transition-all focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:focus:ring-primary-900 my-4"
+              className="mt-2 inline-flex min-h-[44px] items-center rounded-full bg-primary px-8 py-4 font-semibold text-white transition-transform duration-200 ease-in-out hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
             >
               Try again
             </button>

--- a/packages/shared/i18n/locales/en/web.json
+++ b/packages/shared/i18n/locales/en/web.json
@@ -153,5 +153,10 @@
       "title": "Pegada | Request Data Deletion"
     },
     "content": "### Request Data Deletion\n\nTo request account and data deletion outside the app, please send an\nemail to [support@pegada.app](mailto:support@pegada.app) and your request will be processed shortly."
+  },
+  "notFound": {
+    "title": "This page doesn't exist",
+    "description": "The link might have expired, or the profile is gone.",
+    "action": "Back to home"
   }
 }

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -153,5 +153,10 @@
       "title": "Pegada | Solicitar Exclusão de Conta"
     },
     "content": "### Solicitar Exclusão de Conta\n\nPara solicitar a exclusão da conta e dos dados fora do aplicativo, envie um e-mail para [support@pegada.app](mailto:support@pegada.app) e sua solicitação será processada em breve."
+  },
+  "notFound": {
+    "title": "Essa página não existe",
+    "description": "O link pode ter expirado ou o perfil saiu do ar.",
+    "action": "Voltar pro início"
   }
 }


### PR DESCRIPTION
## Summary

A shared dog link that no longer resolves dropped Portuguese visitors on a hardcoded English 404, with the big "404" rendering in default black. The page now reads the request locale the same way the rest of the site does, uses the theme palette, and sends people back to the home page of the language they were already in.

## Details

- The 404 copy was hardcoded English. It now goes through the site's `t()` helper against new `notFound` keys in `packages/shared/i18n/locales/{pt-BR,en}/web.json`. Each language has its own line, written for that audience.
- Next never passes `params` to `not-found.tsx`. The locale comes off the header next-intl's middleware sets, the same source the root layout and the footer already read.
- One 404 file covers the whole app. `[locale]` has no `not-found.tsx` of its own, so a missing dog, a locale segment the site does not serve, and any unmatched top-level route all land on it. All of those render localized now and still answer with HTTP 404.
- Two different shells serve that page. An address that matches no route gets the root layout, so the response opens with `<html lang="pt-br">`. A `notFound()` raised at runtime by a page (the dog card, when the dog is gone) opens with `<html id="__next_error__">` and no `lang`: the status has to be 404 and the headers are not out yet, so Next throws away the shell it had started and streams the real document into an error shell. The localized markup is in that response and React swaps the document in, so a visitor sees the right page, but the `lang` on the first byte is wrong until then. Measured against both dev and `next build`: a `not-found.tsx` inside `[locale]` changes nothing, `experimental.globalNotFound` changes nothing, moving the lookup into a layout above the page changes nothing, and a Suspense boundary above the page fixes the shell at the cost of turning the response into a 200. Keeping the 404 is worth more than the attribute on a page that is already `noindex`.
- `text-primary-600`, `text-gray-900`, `text-gray-500` and every `dark:` class on this page were absent from the generated CSS. The Tailwind theme replaces the palette with named colors and no numeric scale, so the heading fell back to default black and the dark variants were dead code. They are now `text-primary`, `text-text`, `text-subtitle` and `bg-background`, with the dark variants removed.
- The button was 171x40 with an 8px radius, which matched nothing else on the site. It is now the same pill the dog share page uses for its download CTA: full radius, semibold, 32px of horizontal padding, 56px tall with a 44px floor. The white on pink fill is unchanged.
- That button pointed at a bare `/`, which handed a Portuguese reader back to the middleware's language guess. It now points at the home page of the current locale.
- The 500 screen shares the same markup, so it got the palette and button fix too. Its copy stays English: it renders inside a client error boundary and the web app has no client-side i18n to read from.
- Hypothesis: a Portuguese visitor who opens a dead shared link lands on a page they cannot read and closes the tab.
- Baseline: none. Nothing counts 404 views today.
- Readout would be the `Landing View` event on the home page, filtered to visitors who arrived from a 404. Nothing reads that today. Filed as a quality fix.

## Testing steps

1. On the Portuguese site, open a dog link that no longer works. Everything on the page should be in Portuguese, the big 404 should be pink, and the button should read "Voltar pro início".
2. Tap that button. It should land on the Portuguese home page.
3. Do the same on the English site. The copy should be in English and the button should land on the English home page.
4. Make up an address that does not exist on the site and open it, on both the Portuguese and the English site. Same page, same language each time.

## Screenshots

`/pt-br/dog/doesnotexist`

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/before-ptbr-dog-390x844.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/after-ptbr-dog-390x844.png" width="300"> |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/before-ptbr-dog-1440x900.png" width="480"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/after-ptbr-dog-1440x900.png" width="480"> |

`/dog/doesnotexist`

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/before-en-dog-390x844.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/after-en-dog-390x844.png" width="300"> |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/before-en-dog-1440x900.png" width="480"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-web-not-found/shots/after-en-dog-1440x900.png" width="480"> |
