### PR TITLE
fix(nextjs): serve the Play app signing key in assetlinks

### DIFF
--- a/apps/nextjs/src/lib/app-links.ts
+++ b/apps/nextjs/src/lib/app-links.ts
@@ -7,19 +7,25 @@
  * is fine even though the build keeps it out of app.config.ts (it was
  * removed from `appleTeamId` there in favor of an EAS build secret).
  *
- * Android SHA256 fingerprint(s) are different: they live in EAS credentials,
- * not in this repo. The entry below is the EAS upload key (`eas credentials`
- * -> Android -> select the `app.pegada` app -> "Keystore" -> "SHA256
- * Fingerprint"). If Google Play App Signing is on for this app, Play
- * re-signs the uploaded bundle with its own app signing key before
- * distributing it, and that key's fingerprint (Play Console -> Setup -> App
- * integrity -> App signing key certificate) must be appended here too, or
- * devices that installed from Play will fail verification.
+ * Android SHA256 fingerprint(s) are different: they live in EAS credentials
+ * and in the Play Console, not in this repo. Play App Signing is on for this
+ * app, so two distinct keys touch a release and both have to be listed:
+ * Android compares the certificate of the installed APK, and which key that
+ * is depends on how the build reached the device.
  */
 export const APPLE_TEAM_ID = "23DRM684H8";
 
 export const ANDROID_SHA256_CERT_FINGERPRINTS = [
+  // Upload key. Signs the bundle we hand to Play, and the one Play strips off
+  // before distributing. Read from `eas credentials` -> Android -> the
+  // `app.pegada` app -> "Keystore" -> "SHA256 Fingerprint". Kept because
+  // internal-testing and sideloaded builds reach devices signed with it.
   "36:51:99:FC:45:EF:55:03:38:23:04:05:C5:B6:C9:F1:C9:39:69:10:9D:64:8D:4D:DC:C3:01:E4:70:E1:9A:8B",
+  // Play app signing key. Play re-signs every build with this one before
+  // sending it to a device, so it is the certificate on every store install.
+  // Read from Play Console -> Setup -> App integrity -> App signing key
+  // certificate -> "SHA-256 certificate fingerprint".
+  "BB:15:EB:D3:9D:EB:29:94:C5:B4:11:D4:C9:1D:65:19:9C:81:60:28:E8:BE:6B:29:96:32:7B:2B:18:43:29:C3",
 ];
 
 export const APP_BUNDLE_ID = "app.pegada";

--- a/apps/nextjs/tests/assetlinks.test.mjs
+++ b/apps/nextjs/tests/assetlinks.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+/**
+ * The defect: this file listed only the EAS upload key. Play App Signing is
+ * on, so Play strips that signature off every upload and re-signs with its
+ * own app signing key before sending the build to a device. The certificate
+ * Android compares against on a store install is therefore never the one we
+ * were publishing, verification failed for every Play user, and pegada.app
+ * links opened in Chrome instead of the app. Nothing surfaces that: there is
+ * no error, no crash, just a browser where the app should have been.
+ *
+ * Both keys stay listed. Upload-key signatures still reach devices through
+ * internal testing tracks and sideloads, so dropping either one breaks a real
+ * install path.
+ *
+ * The route handler is executed rather than read as text, so what is asserted
+ * is the bytes Android would fetch. It imports through the `@/` alias, which
+ * only the bundler understands, hence the resolve hook.
+ */
+
+const SRC = pathToFileURL(
+  path.join(import.meta.dirname, "..", "src") + path.sep,
+);
+
+registerHooks({
+  resolve(specifier, context, next) {
+    if (!specifier.startsWith("@/")) return next(specifier, context);
+    return next(new URL(`${specifier.slice(2)}.ts`, SRC).href, context);
+  },
+});
+
+const { GET: serveAssetLinks } =
+  await import("../src/app/.well-known/assetlinks.json/route.ts");
+
+const served = await serveAssetLinks().json();
+
+/** Play Console -> Setup -> App integrity -> App signing key certificate. */
+const PLAY_APP_SIGNING_KEY =
+  "BB:15:EB:D3:9D:EB:29:94:C5:B4:11:D4:C9:1D:65:19:9C:81:60:28:E8:BE:6B:29:96:32:7B:2B:18:43:29:C3";
+
+/** `eas credentials` -> Android -> app.pegada -> Keystore. */
+const UPLOAD_KEY =
+  "36:51:99:FC:45:EF:55:03:38:23:04:05:C5:B6:C9:F1:C9:39:69:10:9D:64:8D:4D:DC:C3:01:E4:70:E1:9A:8B";
+
+const [statement, ...extraStatements] = served;
+
+test("grants app.pegada permission to handle every pegada.app URL", () => {
+  assert.equal(extraStatements.length, 0);
+  assert.deepEqual(statement.relation, [
+    "delegate_permission/common.handle_all_urls",
+  ]);
+  assert.equal(statement.target.namespace, "android_app");
+  assert.equal(statement.target.package_name, "app.pegada");
+});
+
+test("serves both the upload key and the Play app signing key", () => {
+  assert.deepEqual(statement.target.sha256_cert_fingerprints, [
+    UPLOAD_KEY,
+    PLAY_APP_SIGNING_KEY,
+  ]);
+});
+
+test("every fingerprint is a SHA-256 digest, not a SHA-1 one", () => {
+  // Play Console shows MD5, SHA-1 and SHA-256 for the same certificate, one
+  // under the other. Copying the wrong row costs a release to notice, because
+  // Android rejects the statement without saying which field was wrong.
+  for (const fingerprint of statement.target.sha256_cert_fingerprints) {
+    assert.match(fingerprint, /^(?:[0-9A-F]{2}:){31}[0-9A-F]{2}$/);
+  }
+});


### PR DESCRIPTION
## Summary

Android was never able to verify pegada.app links for anyone who installed from the Play Store, because the file it checks listed only the key we upload with and not the key Play actually signs with.

Shared dog links opened in Chrome instead of the app for every Play install.

## Details

- Play App Signing is on. Play strips our upload signature off every bundle and re-signs it with its own app signing key before sending it to a device, so the certificate on a store install is never the one we were publishing. Android compares certificates, finds no match, and stops verifying the domain. There is no error and no crash, which is why this went unnoticed.
- Added the Play app signing key alongside the upload key, with a comment on each saying which is which and where it was read from (`eas credentials` for the upload key, Play Console under Setup, App integrity for the other).
- Kept the upload key. Internal testing tracks and sideloaded builds still reach devices signed with it, so removing it would break those.
- The route handler already spread the whole list, so it picks the second key up with no change.
- New test executes the route handler and asserts on the response body rather than on the source text, so what it checks is the bytes Android would fetch. It covers both fingerprints, the package name, and the shape of each fingerprint, since Play Console shows MD5, SHA-1 and SHA-256 stacked and copying the wrong row is the easy mistake.

Hypothesis: Android link verification succeeds for store installed builds.

Baseline: the served file currently lists only the upload key, so verification fails on every Play install. Confirmed today against production:

```json
[{"relation":["delegate_permission/common.handle_all_urls"],"target":{"namespace":"android_app","package_name":"app.pegada","sha256_cert_fingerprints":["36:51:99:FC:45:EF:55:03:38:23:04:05:C5:B6:C9:F1:C9:39:69:10:9D:64:8D:4D:DC:C3:01:E4:70:E1:9A:8B"]}}]
```

Served by this branch on a local server:

```json
[{"relation":["delegate_permission/common.handle_all_urls"],"target":{"namespace":"android_app","package_name":"app.pegada","sha256_cert_fingerprints":["36:51:99:FC:45:EF:55:03:38:23:04:05:C5:B6:C9:F1:C9:39:69:10:9D:64:8D:4D:DC:C3:01:E4:70:E1:9A:8B","BB:15:EB:D3:9D:EB:29:94:C5:B4:11:D4:C9:1D:65:19:9C:81:60:28:E8:BE:6B:29:96:32:7B:2B:18:43:29:C3"]}}]
```

Readout: after deploy, Google's statement list returns both certificates for the app, and `Dog Link Opened` events with platform android start appearing in PostHog. That event count is flat at zero for Android today, so any movement is the fix landing.

## Testing steps

1. Once this is live, open Google's own link checker for pegada.app: https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://www.pegada.app&relation=delegate_permission/common.handle_all_urls
2. The page should list two entries for Pegada. Today it lists one. Google reads our site the same way a phone does, so two entries there means a phone will accept it.
3. On an Android phone with Pegada installed from the Play Store, send yourself a shared dog link over WhatsApp and tap it. It should open inside Pegada. Before this change it opened in the browser.
4. Tap a shared link again after force closing Pegada, to check it still lands in the app rather than the browser.

## Screenshots

No interface changed. This is a file the website hands to Android, and its full contents before and after are quoted above.
