### PR TITLE
fix(mobile): make the empty deck reachable and its done state readable

### DIFF
--- a/apps/mobile/src/components/NetworkBoundary/styles.tsx
+++ b/apps/mobile/src/components/NetworkBoundary/styles.tsx
@@ -16,7 +16,13 @@ const ThemedLottieView = withUnistyles(LottieView);
 /** Every one of these was a static `.attrs`, which beat the caller's prop. */
 type IllustrationProps = Omit<LottieViewProps, "source">;
 
-const CONTENT_CONTAINER_STYLE = { flex: 1 };
+/**
+ * `flexGrow` rather than `flex`, which pins the content to the viewport height
+ * and leaves nothing to scroll: the empty deck grew past one screen and its
+ * last button became unreachable. Growing still centres a short state and lets
+ * a tall one scroll.
+ */
+const CONTENT_CONTAINER_STYLE = { flexGrow: 1 };
 
 /**
  * This boundary can replace the whole navigation tree, so nothing themed
@@ -27,6 +33,7 @@ const CONTENT_CONTAINER_STYLE = { flex: 1 };
  */
 export const Container = ({ style, ...props }: ScrollViewProps) => (
   <ScrollView
+    bounces={false}
     {...props}
     contentContainerStyle={CONTENT_CONTAINER_STYLE}
     style={[styles.container, style]}

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeBackButton/styles.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeBackButton/styles.ts
@@ -10,16 +10,26 @@ export const styles = StyleSheet.create((theme) => ({
     position: "absolute",
     right: 0,
   },
+  /**
+   * Sits inside the card rather than against the screen edge. It used to be a
+   * 68 wide box pinned to `right: 0` with only its left corners rounded and
+   * the arrow pushed to one side by a left padding, which reads as a pill that
+   * ran off the screen. Rounded on all four corners, inset past the card's own
+   * margin and with the arrow centred, it reads as the floating control it is.
+   */
   goBack: {
-    width: 68,
+    width: 56,
     height: 50,
     borderTopLeftRadius: theme.radii.md,
+    borderTopRightRadius: theme.radii.md,
+    borderBottomRightRadius: theme.radii.md,
     borderBottomLeftRadius: theme.radii.md,
     backgroundColor: theme.colors.card,
+    alignItems: "center",
     justifyContent: "center",
     marginLeft: "auto",
     marginTop: theme.spacing[24],
-    paddingLeft: theme.spacing[4],
+    marginRight: theme.spacing[4],
     shadowColor: GO_BACK_SHADOW_COLOR,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.025,

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.test.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.test.tsx
@@ -28,6 +28,7 @@ type RequestState = {
 let mockRequest: RequestState = { loading: false, error: false, data: [] };
 let mockLastCardId: string | undefined;
 let mockOffline = false;
+let mockAlertRequestedAt: Date | undefined;
 
 // The two buttons this screen already owned both talk to the API, and the
 // real client reaches `expo-constants`, which ships untransformed ESM.
@@ -37,7 +38,12 @@ jest.mock<Record<string, unknown>>("@/contexts/trpc-provider", () => ({
       requestNewDogsAlert: {
         useMutation: () => ({ mutateAsync: () => Promise.resolve() }),
       },
-      me: { useQuery: () => ({ data: undefined, isPending: false }) },
+      me: {
+        useQuery: () => ({
+          data: { newDogsAlertRequestedAt: mockAlertRequestedAt },
+          isPending: false,
+        }),
+      },
     },
   },
 }));
@@ -66,10 +72,13 @@ jest.mock<Record<string, unknown>>("./styles", () => {
   return {
     styles: {
       container: {},
+      scroll: {},
       emptyAnimation: {},
       logoLoading: {},
       title: {},
       description: {},
+      notifyDone: {},
+      notifyDoneText: {},
     },
     Container: passthrough("div"),
     Content: passthrough("div"),
@@ -77,6 +86,8 @@ jest.mock<Record<string, unknown>>("./styles", () => {
     LogoLoading: passthrough("div"),
     Title: passthrough("span"),
     Description: passthrough("span"),
+    DoneCheck: () => createElement("svg", null),
+    DoneLabel: passthrough("span"),
   };
 });
 
@@ -184,6 +195,21 @@ beforeEach(() => {
   mockRequest = { loading: false, error: false, data: [] };
   mockLastCardId = undefined;
   mockOffline = false;
+  mockAlertRequestedAt = undefined;
+});
+
+test("drops the button chrome once the notify opt-in has been taken", () => {
+  mockAlertRequestedAt = new Date();
+
+  const html = renderToStaticMarkup(<SwipeRequestFeedback deckIsEmpty />);
+  const done = "swipeRequestFeedback.notifyNewDogsDone";
+
+  // A disabled button paints its label at half opacity, which put this at
+  // 1.7:1 on the light background with nothing saying why it would not
+  // respond. There is nothing to press any more, so it is not a button.
+  expect(html).toContain(done);
+  expect(html).not.toContain(`<button type="button">${done}`);
+  expect(html).not.toContain("swipeRequestFeedback.notifyNewDogsButton");
 });
 
 test("renders the share prompt when the deck came back with nobody on it", () => {

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
@@ -41,6 +41,8 @@ import {
 } from "./new-dogs-alert";
 import {
   Description,
+  DoneCheck,
+  DoneLabel,
   EmptyAnimation,
   LogoLoading,
   Title,
@@ -133,19 +135,36 @@ const NotifyNewDogsButton = () => {
     }
   };
 
+  // Once the opt-in is taken there is nothing left to press, so it stops being
+  // a button. It used to stay one and go disabled, which paints the whole
+  // control at half opacity: pale pink on white, 1.7:1, and no sign of why it
+  // would not respond. A check and a full contrast label say the same thing
+  // and read as an answer rather than a dead control.
+  if (requested) {
+    return (
+      <View style={styles.notifyDone}>
+        <DoneCheck width={16} height={15} />
+        <DoneLabel
+          fontSize="lg"
+          fontWeight="bold"
+          style={styles.notifyDoneText}
+        >
+          {t("swipeRequestFeedback.notifyNewDogsDone")}
+        </DoneLabel>
+      </View>
+    );
+  }
+
   return (
     <Button
       // On a fresh install the answer is only on the server, so the button
       // stays out of reach until it arrives. Offering it in that window lets
       // someone who already opted in tap a second time.
-      disabled={requested || me.isPending}
+      disabled={me.isPending}
       loading={loading}
       onPress={() => void handlePress()}
-      variant={requested ? "outline" : "default"}
     >
-      {requested
-        ? t("swipeRequestFeedback.notifyNewDogsDone")
-        : t("swipeRequestFeedback.notifyNewDogsButton")}
+      {t("swipeRequestFeedback.notifyNewDogsButton")}
     </Button>
   );
 };
@@ -188,46 +207,51 @@ const EmptyState = () => {
   const { t } = useTranslation();
 
   return (
-    <Content>
-      <View>
-        <LogoLoading
-          style={styles.logoLoading}
-          autoPlay
-          source={require("@/assets/animations/loadingLogo.json")}
-          speed={0.5}
-        />
-        <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
-          <Title fontWeight="bold" style={styles.title}>
-            {t("swipeRequestFeedback.emptyTitle")}
-          </Title>
-          <Description fontSize="xs" style={styles.description}>
-            {t("swipeRequestFeedback.emptyDescription")}
-          </Description>
-          <View style={styles.actions}>
-            <NotifyNewDogsButton />
-            <InviteFriendButton />
-            {/*
-              Sits below the two actions rather than above them: those two are
-              what this screen was built to offer, and the share ask is the
-              third thing to try, not the headline. The card owns the gap
-              between itself and the preferences link below.
+    // The column runs past the fold on a short phone, and the last thing in it
+    // is the preferences button the copy points at. Scrolling is the safety
+    // net: `Content` still centres the column whenever it fits.
+    <Container style={styles.scroll}>
+      <Content>
+        <View>
+          <LogoLoading
+            style={styles.logoLoading}
+            autoPlay
+            source={require("@/assets/animations/loadingLogo.json")}
+            speed={0.5}
+          />
+          <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
+            <Title fontWeight="bold" style={styles.title}>
+              {t("swipeRequestFeedback.emptyTitle")}
+            </Title>
+            <Description fontSize="xs" style={styles.description}>
+              {t("swipeRequestFeedback.emptyDescription")}
+            </Description>
+            <View style={styles.actions}>
+              <NotifyNewDogsButton />
+              <InviteFriendButton />
+              {/*
+                Sits below the two actions rather than above them: those two are
+                what this screen was built to offer, and the share ask is the
+                third thing to try, not the headline. The card owns the gap
+                between itself and the preferences link below.
 
-              No render gate of its own. The whole component already returns
-              null unless the deck is empty, and the card waits for the dog
-              before it paints, so `Share Prompt Shown` cannot fire for a
-              prompt nobody saw.
-            */}
-            <SharePromptCard placement="empty_deck" />
-            <Button
-              onPress={() => router.push(SceneName.Preferences)}
-              variant="outline"
-            >
-              {t("swipeRequestFeedback.preferencesButton")}
-            </Button>
-          </View>
-        </Animated.View>
-      </View>
-    </Content>
+                No render gate of its own. The whole component already returns
+                null unless the deck is empty, and the card waits for the dog
+                before it paints, so `Share Prompt Shown` cannot fire for a
+                prompt nobody saw.
+              */}
+              <SharePromptCard placement="empty_deck" />
+              <Button
+                onPress={() => router.push(SceneName.Preferences)}
+                variant="outline"
+              >
+                {t("swipeRequestFeedback.preferencesButton")}
+              </Button>
+            </View>
+          </Animated.View>
+        </View>
+      </Content>
+    </Container>
   );
 };
 

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
@@ -242,7 +242,13 @@ const EmptyState = () => {
               */}
               <SharePromptCard placement="empty_deck" />
               <Button
-                onPress={() => router.push(SceneName.Preferences)}
+                onPress={() => {
+                  analytics.track({
+                    event_type: "Empty Deck Action Tapped",
+                    event_properties: { action: EmptyDeckAction.Preferences },
+                  });
+                  router.push(SceneName.Preferences);
+                }}
                 variant="outline"
               >
                 {t("swipeRequestFeedback.preferencesButton")}

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
@@ -8,6 +8,11 @@ import type { ShareAction } from "react-native";
 export enum EmptyDeckAction {
   NotifyNewDogs = "notify_new_dogs",
   InviteFriend = "invite_friend",
+  /**
+   * The body copy tells people to adjust their preferences and this is the
+   * only way there from here, so the funnel has to be able to count it.
+   */
+  Preferences = "preferences",
 }
 
 export enum PushPermission {

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/styles.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/styles.ts
@@ -1,12 +1,42 @@
 import LottieView from "lottie-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 
+import Check from "@/assets/images/Check.svg";
 import * as LikeFeedbackStyles from "@/components/FeedbackCard/components/LikeFeedback/styles";
 import { Text } from "@/components/text";
 
 export const styles = StyleSheet.create((theme) => ({
   container: {
     backgroundColor: "transparent",
+  },
+  /**
+   * The empty state is taller than one screen once the share card is in it,
+   * and the preferences button is the last thing in the column — the copy asks
+   * people to adjust their preferences, so that button has to be reachable on
+   * the shortest phone we support.
+   */
+  scroll: {
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    backgroundColor: "transparent",
+  },
+  notifyDone: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+    alignItems: "center",
+    justifyContent: "center",
+    paddingTop: theme.spacing[4],
+    paddingBottom: theme.spacing[4],
+  },
+  /**
+   * The label takes the body text colour and only the check is pink. The
+   * primary pink is a 3:1 foreground on the light background, which is under
+   * the 4.5:1 this size needs, and it is also the colour of everything on this
+   * screen that can still be tapped.
+   */
+  notifyDoneText: {
+    color: theme.colors.text,
   },
   emptyAnimation: {
     width: 100,
@@ -45,3 +75,10 @@ export const LogoLoading = withUnistyles(LottieView);
 export const Title = Text;
 
 export const Description = Text;
+
+/** The check on the notify opt-in once it has been taken. */
+export const DoneCheck = withUnistyles(Check, (theme) => ({
+  color: theme.colors.primary,
+}));
+
+export const DoneLabel = Text;

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -96,8 +96,11 @@ export type PermissionStatus = "denied" | "granted";
 /** Which row of the dog share sheet the user picked. */
 export type ShareOption = "copy_link" | "link" | "story";
 
-/** The two things the empty swipe deck offers besides the preferences link. */
-export type EmptyDeckAction = "invite_friend" | "notify_new_dogs";
+/** What the user picked on the empty swipe deck. */
+export type EmptyDeckAction =
+  | "invite_friend"
+  | "notify_new_dogs"
+  | "preferences";
 
 /**
  * The push answer as the empty deck sees it. Wider than

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -397,7 +397,7 @@
     "small": "Small"
   },
   "swipeRequestFeedback": {
-    "emptyDescription": "But hang tight! We've just launched and still have small user base.\n\nWe're working hard to ensure a space filled with doggos very soon 🐶\n\nTry adjusting your preferences or check back later! 😉",
+    "emptyDescription": "We just launched and there are still few dogs nearby 🐶\n\nAdjust your preferences or check back later 😉",
     "emptyTitle": "We couldn't find any more dogs!",
     "inviteFriendButton": "Invite a friend",
     "inviteFriendMessage": "Pegada is where my dog makes friends. Bring yours along:\n{{link}}",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -397,7 +397,7 @@
     "small": "Pequeno"
   },
   "swipeRequestFeedback": {
-    "emptyDescription": "Mas calma! Acabamos de lançar e ainda temos poucos usuários.\n\nEstamos trabalhando para garantir um espaço cheio de doguinhos logo logo 🐶\n\nTente ajustar suas preferências ou volte mais tarde! 😉",
+    "emptyDescription": "Acabamos de lançar e ainda tem pouca gente por perto 🐶\n\nAjusta suas preferências ou volta mais tarde 😉",
     "emptyTitle": "Parece que os doguinhos acabaram!",
     "inviteFriendButton": "Convidar um amigo",
     "inviteFriendMessage": "O Pegada é onde meu cachorro faz amigos. Traz o seu também:\n{{link}}",


### PR DESCRIPTION
## Summary

On the empty swipe deck the preferences button that the body copy points at sat below the fold with no way to scroll to it, the notify opt in dropped to 1.7:1 contrast once taken, and the rewind control read like a pill sliced off by the screen edge. This fixes all three.

## Details

- Hypothesis: people who land on the empty deck and can't reach preferences from it leave without acting on anything the screen offers. Baseline is `Empty Deck Shown`, which already fires once per genuinely empty deck. Readout is `Empty Deck Action Tapped` per `Empty Deck Shown`.
- Nothing counted the preferences tap before this, so `action: "preferences"` joins `notify_new_dogs` and `invite_friend` on that event.
- The empty column scrolls. `NetworkBoundary`'s container is a `ScrollView` whose `contentContainerStyle` was `flex: 1`, which pins the content to exactly one screen and leaves nothing to scroll. `flexGrow: 1` still centres a short state and lets a tall one move. Bounce is off so it stays still when everything fits.
- Body copy goes from three paragraphs to two lines in pt-BR and en.
- The notify opt in stops being a button once it has been taken. A disabled button paints the whole control at half opacity, which is where the pale pink on white came from, and nothing on screen said why it wouldn't respond. It's a pink check and a label in the body text colour now.
- The rewind control sits inside the card, rounded on all four corners, arrow centred. It was 68 wide pinned to `right: 0` with only its left corners rounded and the arrow pushed to one side by a left padding, so half of it looked like it had run off the screen. Same corner of the deck, same slide in from the right.

## Testing steps

1. Open the app and swipe through every dog, or narrow the preferences until nothing is left.
2. On the screen that says there are no dogs left, check you can get to the button that opens preferences. Try it in both languages and in light and dark.
3. Tap the button that asks to be told when a new dog shows up. Come back to the screen. The confirmation should be easy to read and shouldn't look like a button that failed to respond.
4. Swipe one dog away. Look at the rewind control in the top right of the deck. It should sit inside the card with its arrow centred.

## Screenshots

Empty deck, pt-BR, light.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/before-empty-ptbr-light.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/after-empty-ptbr-light.png" width="300"> |

Scrolled to the bottom of the same screen. Before, there was nothing to scroll and the button never appeared.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/before-empty-ptbr-light-scrolled.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/after-empty-ptbr-light-scrolled.png" width="300"> |

Rewind control on the deck.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/before-rewind-light.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/after-rewind-light.png" width="300"> |

After, in the other three combinations.

| en light | en light scrolled | en dark | pt-BR dark |
| --- | --- | --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/after-empty-en-light.png" width="200"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/after-empty-en-light-scrolled.png" width="200"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/after-empty-en-dark.png" width="200"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-empty-deck/shots/after-empty-ptbr-dark.png" width="200"> |
