### PR TITLE
fix(mobile): stop the sign in banner from cutting the hero headline

### DIFF
--- a/apps/mobile/src/views/(auth)/SignIn/index.tsx
+++ b/apps/mobile/src/views/(auth)/SignIn/index.tsx
@@ -30,6 +30,7 @@ import {
   Container,
   Description,
   Highlight,
+  LOGO_MARGIN_BOTTOM,
   LogoStyled,
   Title,
   TopCard,
@@ -50,10 +51,55 @@ const requestTrackingPermissions = async () => {
   }
 };
 
+const LOGO_SIZE = 70;
+/** The logo's own height plus the gap it keeps under itself. */
+const LOGO_BLOCK = LOGO_SIZE + LOGO_MARGIN_BOTTOM;
+
+/**
+ * The hero's height is whatever the card below leaves, so a mounted banner or
+ * a taller keyboard takes it away. This decides what still fits in it: the
+ * logo goes first, the headline last, and neither is ever painted half.
+ *
+ * The two spacers around them are already the breathing room and they shrink
+ * to nothing before this has to drop anything, so the thresholds are the bare
+ * heights. Anything more and an iPhone 17 Pro with no banner, which has room
+ * for both, would lose its logo.
+ *
+ * `room` comes from the flex layout and does not depend on what this returns,
+ * and `heroHeight` is the headline's natural height, measured once and kept.
+ * Both are stable inputs, so dropping the logo cannot change the answer that
+ * dropped it.
+ */
+const heroFit = ({
+  room,
+  heroHeight,
+}: {
+  room: number | undefined;
+  heroHeight: number | undefined;
+}) => {
+  if (room === undefined || heroHeight === undefined) {
+    return { showLogo: true, showHero: true };
+  }
+
+  return {
+    showLogo: room >= heroHeight + LOGO_BLOCK,
+    showHero: room >= heroHeight,
+  };
+};
+
 const InsertEmail = () => {
   const insets = useSafeAreaInsets();
   const bottomInset = useCustomBottomInset();
   const { theme } = useUnistyles();
+
+  const [heroSpace, setHeroSpace] = useState<number | undefined>(undefined);
+  const [heroHeight, setHeroHeight] = useState<number | undefined>(undefined);
+  // Measured once. The headline is hidden by the very state this measures, so
+  // remeasuring it would feed the layout back its own answer.
+  const measureHero = (height: number) =>
+    setHeroHeight((current) => current ?? height);
+
+  const { showLogo, showHero } = heroFit({ room: heroSpace, heroHeight });
 
   // The email field autofocuses, so the keyboard is up on the first frame of a
   // cold launch and this screen is the one that has to survive it.
@@ -137,15 +183,34 @@ const InsertEmail = () => {
         <Container style={styles.container} edges={["left", "right"]}>
           <TopCard
             source={require("@/assets/images/background.webp")}
-            style={[styles.topCard, { paddingTop: 60 + insets.top }]}
+            style={[styles.topCard, { paddingTop: insets.top }]}
           >
-            <LogoStyled
-              width={70}
-              height={70}
-              fill={theme.colors.text}
-              style={styles.logoStyled}
-            />
-            <HeroText />
+            <View
+              style={styles.heroSpace}
+              onLayout={(event) =>
+                setHeroSpace(event.nativeEvent.layout.height)
+              }
+            >
+              <View style={styles.topSpacer} />
+              {showLogo ? (
+                <LogoStyled
+                  width={LOGO_SIZE}
+                  height={LOGO_SIZE}
+                  fill={theme.colors.text}
+                  style={styles.logoStyled}
+                />
+              ) : null}
+              {showHero ? (
+                <View
+                  onLayout={(event) =>
+                    measureHero(event.nativeEvent.layout.height)
+                  }
+                >
+                  <HeroText />
+                </View>
+              ) : null}
+              <View style={styles.bottomSpacer} />
+            </View>
           </TopCard>
           <View style={[styles.bottomCard, { paddingBottom: bottomInset }]}>
             <PendingDogProfileBanner />

--- a/apps/mobile/src/views/(auth)/SignIn/styles.ts
+++ b/apps/mobile/src/views/(auth)/SignIn/styles.ts
@@ -6,6 +6,9 @@ import { StyleSheet, withUnistyles } from "react-native-unistyles";
 import Logo from "@/assets/images/logo";
 import { Text } from "@/components/text";
 
+/** Exported so the view can price the logo before it decides to render it. */
+export const LOGO_MARGIN_BOTTOM = 25;
+
 export const styles = StyleSheet.create((theme) => ({
   container: {
     flexGrow: 1,
@@ -19,8 +22,16 @@ export const styles = StyleSheet.create((theme) => ({
     flexGrow: 1,
   },
   logoStyled: {
-    marginBottom: 25,
+    marginBottom: LOGO_MARGIN_BOTTOM,
   },
+  /**
+   * The hero owns whatever height the card below it leaves, and that height
+   * drops by the whole banner when a `/dog/<id>` link brings someone here
+   * signed out. It used to keep painting at full size into a box that no
+   * longer fit it, and the card, drawn after it, cut the headline through the
+   * letterforms. Clipped here instead, and the two spacers and the logo give
+   * their height up before the headline has to.
+   */
   topCard: {
     flexGrow: 1,
     flexShrink: 1,
@@ -28,10 +39,30 @@ export const styles = StyleSheet.create((theme) => ({
     backgroundColor: theme.colors.background,
     justifyContent: "center",
     alignItems: "center",
-    paddingTop: theme.spacing[10],
+    overflow: "hidden",
     paddingRight: theme.spacing[4],
-    paddingBottom: theme.spacing[10],
     paddingLeft: theme.spacing[4],
+  },
+  /** The box the hero has to fit into, measured rather than assumed: it is the
+   * card minus the notch inset, and the banner is what takes it away. */
+  heroSpace: {
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    alignSelf: "stretch",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  /** Was the caller's `paddingTop: 60 + insets.top`, which cannot shrink. The
+   * inset half stays a padding: it is the notch and it never gives. */
+  topSpacer: {
+    height: 60,
+    flexShrink: 1,
+  },
+  /** Was `paddingBottom`. */
+  bottomSpacer: {
+    height: theme.spacing[10],
+    flexShrink: 1,
   },
   bottomCard: {
     backgroundColor: theme.colors.background,


### PR DESCRIPTION
## Summary

Opening a `pegada.app/dog/<id>` link while signed out mounts a banner on the sign in screen, and the hero above it kept painting at full size into a box that no longer fit it. The card below cut "Encontre Dogs" through the letterforms.

## Details

- The hero is a flex child with `flexBasis: 0`, so its height is whatever the card below leaves. The banner takes about a hundred points of that. Its content never gave any of it back, so it overflowed and the card, drawn after it, painted over the overflow.
- The card's top and bottom paddings are two spacers with `flexShrink: 1` now. Padding cannot shrink, a spacer can, so the first thing that gives is empty space.
- Under that, the logo goes, then the headline. `heroFit` prices both against the measured height of the box. The headline's own height is measured once and kept, and the box height comes from the flex layout rather than from the content, so hiding the logo cannot change the answer that hid it.
- `overflow: hidden` on the card is the backstop. Nothing can bleed under the sheet below it again, whatever a future banner or a taller keyboard does to the space.
- On an iPhone SE the headline was already cut with no banner at all, on the plain launch screen. That is fixed by the same change.
- The safe area inset stays a padding. It is the notch and it does not give.

## Testing steps

1. Sign out.
2. Open a dog link someone shared with you from Safari or Messages while signed out.
3. The sign in screen comes up with a notice saying a dog profile is waiting. Check the headline above it is whole, in light and in dark.
4. Do the same on an iPhone SE, where the screen is shorter. The headline should either be whole or absent, never half.
5. Sign in and check the app takes you to that dog.

## Screenshots

iPhone 17 Pro, pt-BR, opened from a dog link while signed out.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-signin-banner/shots/before-ptbr-light.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-signin-banner/shots/after-ptbr-light.png" width="300"> |

Same thing in dark.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-signin-banner/shots/before-ptbr-dark.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-signin-banner/shots/after-ptbr-dark.png" width="300"> |

iPhone SE on the plain launch screen, no banner. "Near You" was off the bottom entirely.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-signin-banner/shots/before-se-en-light-nobanner.png" width="300"> | <img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-signin-banner/shots/after-se-en-light-nobanner.png" width="300"> |

iPhone SE with the banner, where there is no room for a headline at all. The hero hides and only the background image is left.

<img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/fix-qa-signin-banner/shots/after-se-en-light.png" width="300">

