### PR TITLE
fix(web): correct type and lockup metrics on the dog share surfaces

### DIFF
--- a/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
@@ -94,9 +94,21 @@ const fallbackContainerStyle = {
   background: `linear-gradient(135deg, ${COLORS.secondary} 0%, ${COLORS.background} 65%)`,
 } as const;
 
+/**
+ * The photo is rotated, which means the box it occupies is bigger than the box
+ * it is laid out in: a 3 degree turn on a 420x478 frame swings the corners out
+ * to 444x499. Sized and offset so that swung box lands inside the container's
+ * 64px padding instead of over it. At 440x502 with no offset the frame drew
+ * 53px from the left edge and 54px from the bottom, so the padding in the code
+ * was not the padding on the card.
+ */
+const PHOTO_WIDTH = 420;
+const PHOTO_HEIGHT = 478;
+
 const photoFrameStyle = {
-  width: 440,
-  height: 502,
+  width: PHOTO_WIDTH,
+  height: PHOTO_HEIGHT,
+  marginLeft: 13,
   borderRadius: 32,
   overflow: "hidden",
   display: "flex",
@@ -125,7 +137,20 @@ const brandRowStyle = {
   gap: 12,
 } as const;
 
-const logoMarkStyle = { width: 40, height: 42, display: "flex" } as const;
+/**
+ * Sized against the wordmark's caps rather than against its whole line box.
+ * The row centres both children on their layout boxes, and a text box runs
+ * from ascender to descender, so a mark centred that way floats above the
+ * letters it is meant to sit beside: measured 4px high, on a mark whose ink
+ * was 42px tall against a 22px cap height. Smaller, and nudged down by the
+ * difference.
+ */
+const logoMarkStyle = {
+  width: 32,
+  height: 34,
+  marginTop: 5,
+  display: "flex",
+} as const;
 
 const fallbackLogoMarkStyle = {
   width: 108,
@@ -137,6 +162,10 @@ const wordmarkStyle = {
   fontSize: 32,
   fontWeight: 800,
   fontFamily: "Gilroy",
+  // Gilroy ExtraBold sets loose at display sizes. Small negative values here
+  // and on the name below, in the same proportion the app's own story cards
+  // use, so the two read as the same typography.
+  letterSpacing: -0.4,
   color: COLORS.primary,
   display: "flex",
 } as const;
@@ -147,6 +176,7 @@ const nameStyle = {
   fontSize: 76,
   fontWeight: 800,
   fontFamily: "Gilroy",
+  letterSpacing: -1.5,
   color: COLORS.text,
   lineHeight: 1.05,
   display: "flex",
@@ -170,6 +200,10 @@ const fallbackTaglineStyle = { ...taglineStyle, fontSize: 30 } as const;
 const tagStyle = {
   display: "flex",
   marginTop: 12,
+  // A filled shape and a line of type do not line up on the same number: the
+  // fill has a hard edge where the type has a side bearing. Without this the
+  // button started 5px left of the name above it.
+  marginLeft: 3,
   padding: "20px 40px",
   borderRadius: 9999,
   background: COLORS.primary,
@@ -233,8 +267,8 @@ const Image = async ({ params }: Props) => {
         {/* oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image */}
         <img
           src={dogImage}
-          width={440}
-          height={502}
+          width={PHOTO_WIDTH}
+          height={PHOTO_HEIGHT}
           alt=""
           style={photoImgStyle}
         />

--- a/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/page.tsx
@@ -217,7 +217,14 @@ const DogProfile = async ({ params, searchParams }: DogProfileProps) => {
             )}
 
             <div className="absolute inset-x-0 bottom-0 flex flex-col gap-1 bg-gradient-to-t from-black/85 via-black/35 to-transparent px-5 pb-5 pt-16">
-              <h1 className="text-2xl font-extrabold leading-tight text-white md:text-3xl">
+              {/*
+               * The leading is restated at every size that changes the size.
+               * Tailwind's `text-*` utilities set a line height as well, and
+               * the responsive ones are emitted after `leading-*`, so a bare
+               * `leading-tight` here was overridden by `md:text-3xl` and the
+               * name rendered at a leading of 1.
+               */}
+              <h1 className="text-2xl font-extrabold leading-[1.15] text-white md:text-3xl md:leading-[1.1]">
                 {dog.name}
               </h1>
               {tagline ? (
@@ -233,7 +240,9 @@ const DogProfile = async ({ params, searchParams }: DogProfileProps) => {
         </div>
         {/* Desktop copy column. Hidden below `md`, where the sticky bar carries the ask instead. */}
         <div className="hidden fill-mode-both animate-in fade-in slide-in-from-bottom-2 delay-150 duration-700 motion-reduce:animate-none md:flex md:max-w-md md:flex-col md:gap-5">
-          <h2 className="text-4xl font-extrabold leading-tight text-text lg:text-5xl">
+          {/* Same reason as the `h1` above: `lg:text-5xl` was resetting the
+              leading to 1, and a long name makes this four lines. */}
+          <h2 className="text-4xl font-extrabold leading-[1.1] text-text lg:text-5xl lg:leading-[1.05]">
             {invite}
           </h2>
           <p className="text-lg font-light text-subtitle">{nextStep}</p>

--- a/apps/nextjs/src/lib/fonts.ts
+++ b/apps/nextjs/src/lib/fonts.ts
@@ -6,8 +6,15 @@ import localFont from "next/font/local";
  * the root layout, so only the pages that exist to look like the app they are
  * advertising pay for it: the dog share card and the story landing page.
  *
- * The weights below are the ones those pages set: body copy in medium, CTAs
- * and taglines in semibold, headlines in bold/extrabold.
+ * The weights below are the ones those pages set: secondary copy in light,
+ * body copy in medium, CTAs and taglines in semibold, headlines in
+ * bold/extrabold.
+ *
+ * Light is here because `/dog/[id]` sets `font-light` on the card bio, the
+ * "next step" line and the reassurance under the CTA. Without the face those
+ * three fell back to Medium, which is the weight of the tagline sitting right
+ * above the bio, so the two lines that were meant to differ were the same
+ * stroke with different opacity.
  *
  * The TTFs live in `packages/shared/themes/fonts`, outside this app. That path
  * survives `next build` (verified via `pnpm -F @pegada/nextjs build`), so there
@@ -17,6 +24,11 @@ export const gilroy = localFont({
   variable: "--font-gilroy",
   display: "swap",
   src: [
+    {
+      path: "../../../../packages/shared/themes/fonts/Gilroy-Light.ttf",
+      weight: "300",
+      style: "normal",
+    },
     {
       path: "../../../../packages/shared/themes/fonts/Gilroy-Medium.ttf",
       weight: "500",


### PR DESCRIPTION
## Summary

Six measured defects on the two web share surfaces, the `/dog/[id]` page and the OG card it hands to link previews. All of them are metrics that did not match what the code said: a line height that was overridden and resolved to 1, a font weight with no font behind it, and a photo frame drawing over the padding it was given. Style only, no copy and no behaviour changed.

Filed as #245 and #246. Items in those issues that need a copy or product decision are left there rather than guessed at here.

## Details

**The headline's leading was dead.** Both `<h1>` on the card and `<h2>` in the desktop column carried `leading-tight` followed by a responsive `text-*` utility. Tailwind's `text-*` sets a line height as well as a size, and the responsive one is emitted later, so it won: 48px of leading on 48px type, a ratio of 1.00. Two lines were tight and four lines collided, which is what any three word name produces. The leading is now restated at every size that changes the size, 1.1 at `text-4xl` and 1.05 at `lg:text-5xl`.

**`font-light` had no face.** `lib/fonts.ts` registered Gilroy at 500, 600, 700 and 800. Three elements ask for 300: the card bio, the "next step" line and the reassurance under the CTA. All three fell back to Medium, which is the weight of the tagline sitting directly above the bio, so the two lines meant to read as different things were the same stroke with different opacity. `Gilroy-Light.ttf` was already in `packages/shared/themes/fonts`; it is now registered at 300.

**The OG photo drew over its padding.** The frame is `rotate(-3deg)`, which swings a 440x502 box out to 466x524, and nothing accounted for it. Against a declared 64px padding it rendered 53px from the left edge, 56 from the top and 54 from the bottom. Resized to 420x478 with a 13px left offset so the swung box lands inside: 67, 69 and 66 now.

**The lockup did not line up.** The row centres the mark and the wordmark on their layout boxes, and a text box runs from ascender to descender, so the mark floated above the letters: measured 4px high, with 42px of ink against a 22px cap height. Now 32x34 with a 5px nudge, 1px off.

**No tracking on display type.** The 76px name and the 32px wordmark were both at 0. Small negative values, in the proportion the app's own story cards use.

**The button was 5px left of the name.** A filled shape and a line of type do not align on the same number. 3px back.

## Testing steps

1. Open a dog's share link on a laptop. The big headline on the right should have normal space between its lines.
2. Open the same link for a dog with a long name, three words or more. The headline should still have space between its lines, with nothing touching.
3. Look at the card on the left. The two lines under the dog's name, the breed line and the description, should look like different weights rather than the same text at two brightnesses.
4. Paste the link into WhatsApp or Slack and look at the preview card. The photo should have an even margin around it on the left and the bottom, and the paw should sit level with the word "Pegada" beside it.

## Screenshots

Desktop headline, long name, at 1280x800.

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/web-dog-headline-leading.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-web-dog-headline-leading.png) |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/web-dog-longname-desktop.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-web-dog-longname-desktop.png) |

Card caption at 390x844. The breed line asks for weight 500 and the description asks for 300.

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/web-dog-caption-weights.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-web-dog-caption-weights.png) |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/web-dog-pt-mobile.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-web-dog-pt-mobile.png) |

OG card padding. Blue guides at x 64 and y 64, the padding the container declares.

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/og-dog-frame-padding.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-og-dog-frame-padding.png) |

Lockup, and the card whole.

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/og-dog-brand-lockup.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-og-dog-brand-lockup.png) |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/og-dog-pt.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-og-dog-pt.png) |
| ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/og-dog-longname-pt.png) | ![](https://raw.githubusercontent.com/GSTJ/pegada/shots/story-card-v4-surfaces/shots/after-og-dog-longname-pt.png) |
