### PR TITLE
fix(api): hold every re-engagement push to the local evening window

### DIFF
--- a/packages/api/src/queue/handlers/push.test.ts
+++ b/packages/api/src/queue/handlers/push.test.ts
@@ -1,0 +1,289 @@
+import prisma from "@pegada/database";
+
+import { handleCheckPushReceipts, handleSendPushNotification } from "./push";
+
+// The mocks live inside the factory because jest hoists it above the import
+// of the module under test, which builds its Expo client at load time.
+jest.mock("expo-server-sdk", () => {
+  const send = jest.fn();
+  const getReceipts = jest.fn();
+
+  return {
+    Expo: class {
+      sendPushNotificationsAsync = send;
+      getPushNotificationReceiptsAsync = getReceipts;
+    },
+    __send: send,
+    __getReceipts: getReceipts,
+  };
+});
+
+jest.mock("../enqueue", () => ({ enqueue: jest.fn() }));
+
+jest.mock("../../errors/errors", () => ({ sendError: jest.fn() }));
+
+jest.mock("../../services/user-service", () => ({
+  UserService: { blacklistPushToken: jest.fn() },
+}));
+
+jest.mock("../../shared/observability", () => ({
+  observability: {
+    enabled: false,
+    disabledReason: "explicitly-disabled",
+    capture: jest.fn(),
+    captureError: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    register: jest.fn(),
+    flush: jest.fn(),
+    shutdown: jest.fn(),
+  },
+  getPostHogNode: jest.fn(() => null),
+}));
+
+const { __getReceipts: mockGetReceipts, __send: mockSend } = jest.requireMock(
+  "expo-server-sdk",
+) as { __getReceipts: jest.Mock; __send: jest.Mock };
+
+const { enqueue } = jest.requireMock("../enqueue") as { enqueue: jest.Mock };
+
+const { UserService } = jest.requireMock("../../services/user-service") as {
+  UserService: { blacklistPushToken: jest.Mock };
+};
+
+const { observability } = jest.requireMock("../../shared/observability") as {
+  observability: { capture: jest.Mock };
+};
+
+const PUSH_TOKEN = "ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]";
+const USER_ID = "user-under-test";
+
+const seedLog = () =>
+  prisma.notificationLog.create({
+    data: {
+      userId: USER_ID,
+      kind: "likes_waiting",
+      dedupeKey: `likes_waiting:${USER_ID}:${Math.random()}`,
+    },
+    select: { id: true },
+  });
+
+beforeEach(async () => {
+  await prisma.notificationLog.deleteMany({ where: { userId: USER_ID } });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("handleSendPushNotification", () => {
+  it("records the ticket Expo handed back", async () => {
+    const log = await seedLog();
+
+    mockSend.mockResolvedValue([{ status: "ok", id: "ticket-1" }]);
+
+    await handleSendPushNotification({
+      to: PUSH_TOKEN,
+      title: "oi",
+      body: "tem gente esperando",
+      userId: USER_ID,
+      pushKind: "likes_waiting",
+      notificationLogId: log.id,
+    });
+
+    expect(observability.capture).toHaveBeenCalledWith("Push Ticket Result", {
+      distinctId: USER_ID,
+      error_code: null,
+      kind: "likes_waiting",
+      status: "ok",
+    });
+
+    await expect(
+      prisma.notificationLog.findUniqueOrThrow({
+        where: { id: log.id },
+        select: { ticketError: true, ticketStatus: true },
+      }),
+    ).resolves.toEqual({ ticketError: null, ticketStatus: "ok" });
+
+    // A ticket with an id is a push to ask about later.
+    expect(enqueue).toHaveBeenCalledWith(
+      "check-push-receipts",
+      {
+        receipts: [
+          {
+            id: "ticket-1",
+            pushToken: PUSH_TOKEN,
+            userId: USER_ID,
+            pushKind: "likes_waiting",
+            notificationLogId: log.id,
+          },
+        ],
+      },
+      expect.anything(),
+    );
+  });
+
+  it("records a rejected ticket with its code", async () => {
+    const log = await seedLog();
+
+    mockSend.mockResolvedValue([
+      { status: "error", details: { error: "DeviceNotRegistered" } },
+    ]);
+
+    await handleSendPushNotification({
+      to: PUSH_TOKEN,
+      title: "oi",
+      userId: USER_ID,
+      pushKind: "match",
+      notificationLogId: log.id,
+    });
+
+    expect(observability.capture).toHaveBeenCalledWith("Push Ticket Result", {
+      distinctId: USER_ID,
+      error_code: "DeviceNotRegistered",
+      kind: "match",
+      status: "error",
+    });
+
+    await expect(
+      prisma.notificationLog.findUniqueOrThrow({
+        where: { id: log.id },
+        select: { ticketError: true, ticketStatus: true },
+      }),
+    ).resolves.toEqual({
+      ticketError: "DeviceNotRegistered",
+      ticketStatus: "error",
+    });
+
+    expect(UserService.blacklistPushToken).toHaveBeenCalledWith(PUSH_TOKEN);
+  });
+
+  it("keeps the attribution out of the message handed to Expo", async () => {
+    mockSend.mockResolvedValue([{ status: "ok", id: "ticket-2" }]);
+
+    await handleSendPushNotification({
+      to: PUSH_TOKEN,
+      title: "oi",
+      userId: USER_ID,
+      pushKind: "message",
+    });
+
+    const [[[message]]] = mockSend.mock.calls;
+
+    expect(message).not.toHaveProperty("userId");
+    expect(message).not.toHaveProperty("pushKind");
+    expect(message).not.toHaveProperty("notificationLogId");
+    expect(message).toMatchObject({ to: PUSH_TOKEN, title: "oi" });
+  });
+});
+
+describe("handleCheckPushReceipts", () => {
+  it("records what the device said and stamps the log", async () => {
+    const log = await seedLog();
+
+    mockGetReceipts.mockResolvedValue({ "ticket-1": { status: "ok" } });
+
+    await handleCheckPushReceipts({
+      receipts: [
+        {
+          id: "ticket-1",
+          pushToken: PUSH_TOKEN,
+          userId: USER_ID,
+          pushKind: "likes_waiting",
+          notificationLogId: log.id,
+        },
+      ],
+    });
+
+    expect(observability.capture).toHaveBeenCalledWith("Push Receipt Result", {
+      distinctId: USER_ID,
+      error_code: null,
+      kind: "likes_waiting",
+      status: "ok",
+    });
+
+    await expect(
+      prisma.notificationLog.findUniqueOrThrow({
+        where: { id: log.id },
+        select: { receiptError: true, receiptStatus: true },
+      }),
+    ).resolves.toEqual({ receiptError: null, receiptStatus: "ok" });
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("records a failed delivery and blacklists a dead device", async () => {
+    const log = await seedLog();
+
+    mockGetReceipts.mockResolvedValue({
+      "ticket-1": {
+        status: "error",
+        details: { error: "DeviceNotRegistered" },
+      },
+    });
+
+    await handleCheckPushReceipts({
+      receipts: [
+        {
+          id: "ticket-1",
+          pushToken: PUSH_TOKEN,
+          userId: USER_ID,
+          pushKind: "likes_waiting",
+          notificationLogId: log.id,
+        },
+      ],
+    });
+
+    expect(observability.capture).toHaveBeenCalledWith("Push Receipt Result", {
+      distinctId: USER_ID,
+      error_code: "DeviceNotRegistered",
+      kind: "likes_waiting",
+      status: "error",
+    });
+
+    await expect(
+      prisma.notificationLog.findUniqueOrThrow({
+        where: { id: log.id },
+        select: { receiptError: true, receiptStatus: true },
+      }),
+    ).resolves.toEqual({
+      receiptError: "DeviceNotRegistered",
+      receiptStatus: "error",
+    });
+
+    expect(UserService.blacklistPushToken).toHaveBeenCalledWith(PUSH_TOKEN);
+  });
+
+  it("says nothing about a receipt that has not settled, and asks again", async () => {
+    const log = await seedLog();
+
+    mockGetReceipts.mockResolvedValue({ "ticket-1": { status: "pending" } });
+
+    const reference = {
+      id: "ticket-1",
+      pushToken: PUSH_TOKEN,
+      userId: USER_ID,
+      pushKind: "likes_waiting" as const,
+      notificationLogId: log.id,
+    };
+
+    await handleCheckPushReceipts({ receipts: [reference] });
+
+    expect(observability.capture).not.toHaveBeenCalled();
+
+    await expect(
+      prisma.notificationLog.findUniqueOrThrow({
+        where: { id: log.id },
+        select: { receiptStatus: true },
+      }),
+    ).resolves.toEqual({ receiptStatus: null });
+
+    // The attribution goes back on the queue with it, otherwise the retry
+    // would land as an unattributed event.
+    expect(enqueue).toHaveBeenCalledWith(
+      "check-push-receipts",
+      { receipts: [reference] },
+      expect.anything(),
+    );
+  });
+});

--- a/packages/api/src/queue/handlers/push.ts
+++ b/packages/api/src/queue/handlers/push.ts
@@ -1,14 +1,21 @@
 import type {
   ICheckPushNotificationReceiptsJobData,
+  IPushReceiptReference,
   ISendNotificationJobData,
+  PushAttribution,
 } from "../topics";
+import type { PushDeliveryStatus } from "@pegada/shared/analytics/events";
 
 import type { ExpoPushMessage } from "expo-server-sdk";
 
 import { Expo } from "expo-server-sdk";
 
+import prisma from "@pegada/database";
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
+
 import { sendError } from "../../errors/errors";
 import { UserService } from "../../services/user-service";
+import { captureEvent } from "../../shared/analytics";
 import { config } from "../../shared/config";
 import { enqueue } from "../enqueue";
 import { TOPICS } from "../topics";
@@ -37,16 +44,90 @@ const handlePushError = async (errorMessage: string, pushToken: string) => {
   sendError(newError);
 };
 
+type DeliveryEvent =
+  | typeof ANALYTICS_EVENTS.PUSH_RECEIPT_RESULT
+  | typeof ANALYTICS_EVENTS.PUSH_TICKET_RESULT;
+
+type DeliveryOutcome = {
+  errorCode: string | null;
+  status: PushDeliveryStatus;
+};
+
+/** A ticket or a receipt, in the two fields both of them answer with. */
+type ExpoResult = { details?: { error?: string }; status: string };
+
+/** Neither confirmed nor rejected yet, so there is nothing to record. */
+const isInFlight = (result: ExpoResult) =>
+  result.status !== "ok" && !result.details?.error;
+
+/**
+ * Expo's answer, in the two fields the events break down by.
+ *
+ * An error with no code of its own still counts as an error: what matters for
+ * the ok rate is that the push did not make it, and `Unknown` is a more honest
+ * bucket than dropping the row.
+ */
+const outcomeOf = (result: ExpoResult): DeliveryOutcome =>
+  result.status === "error"
+    ? { errorCode: result.details?.error ?? "Unknown", status: "error" }
+    : { errorCode: null, status: "ok" };
+
+/**
+ * Write down what became of one push.
+ *
+ * Two halves, because they answer different questions. The analytics event is
+ * the readable one: an ok rate per kind in PostHog, which is the first number
+ * this stack has ever had for "was it delivered" as opposed to "was it
+ * enqueued". The `NotificationLog` stamp is the auditable one, for asking
+ * about a single send after the fact.
+ *
+ * Neither may fail the job. A push that went out and could not be recorded is
+ * a gap in a chart; throwing here would have the queue retry a send that has
+ * already happened, which the user would see twice.
+ */
+const recordDelivery = async (
+  event: DeliveryEvent,
+  { notificationLogId, pushKind, userId }: PushAttribution,
+  { errorCode, status }: DeliveryOutcome,
+) => {
+  if (userId) {
+    captureEvent(userId, event, {
+      error_code: errorCode,
+      kind: pushKind ?? null,
+      status,
+    });
+  }
+
+  if (!notificationLogId) return;
+
+  try {
+    await prisma.notificationLog.update({
+      where: { id: notificationLogId },
+      data:
+        event === ANALYTICS_EVENTS.PUSH_TICKET_RESULT
+          ? { ticketError: errorCode, ticketStatus: status }
+          : { receiptError: errorCode, receiptStatus: status },
+    });
+  } catch (error) {
+    sendError(error);
+  }
+};
+
 export const handleSendPushNotification = async (
   data: ISendNotificationJobData,
 ) => {
+  // Attribution is ours, not Expo's, so it comes back off before the message
+  // is built rather than being spread into it.
+  const { notificationLogId, pushKind, userId, ...push } = data;
+  const attribution: PushAttribution = { notificationLogId, pushKind, userId };
+
   const message: ExpoPushMessage = {
     sound: "default",
     priority: "high",
     channelId: "default",
     expiration: Math.floor(Date.now() / 1000) + RECEIPT_EXPIRATION_MIN,
     badge: 1,
-    ...data,
+    ...push,
   };
 
   const pushToken = data.to as string;
@@ -54,19 +135,26 @@ export const handleSendPushNotification = async (
   const tickets = await expo.sendPushNotificationsAsync([message]);
 
   // Error codes: https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
-  await Promise.all(
-    tickets.flatMap((ticket) =>
+  await Promise.all([
+    ...tickets.map((ticket) =>
+      recordDelivery(
+        ANALYTICS_EVENTS.PUSH_TICKET_RESULT,
+        attribution,
+        outcomeOf(ticket),
+      ),
+    ),
+    ...tickets.flatMap((ticket) =>
       ticket.status === "error" && ticket.details?.error
         ? [handlePushError(ticket.details.error, pushToken)]
         : [],
     ),
-  );
+  ]);
 
   // Tickets for notifications that could not be enqueued have no id.
   const receipts = tickets.flatMap((ticket) =>
     ticket.status === "error" || !ticket.id
       ? []
-      : [{ id: ticket.id, pushToken }],
+      : [{ id: ticket.id, pushToken, ...attribution }],
   );
 
   if (receipts.length > 0) {
@@ -89,24 +177,41 @@ export const handleCheckPushReceipts = async ({
     incomingReceiptsData.map(({ id }) => id),
   );
 
-  const tokenFor = (id: string) =>
-    incomingReceiptsData.find((receipt) => receipt.id === id)
-      ?.pushToken as string;
+  const referenceFor = (id: string) =>
+    incomingReceiptsData.find((receipt) => receipt.id === id);
 
   const entries = Object.entries(receipts);
 
   await Promise.all(
-    entries.flatMap(([id, receipt]) =>
-      receipt.status === "error" && receipt.details?.error
-        ? [handlePushError(receipt.details.error, tokenFor(id))]
-        : [],
-    ),
+    entries.flatMap(([id, receipt]) => {
+      if (isInFlight(receipt)) return [];
+
+      const reference = referenceFor(id);
+      const pushToken = reference?.pushToken;
+
+      return [
+        recordDelivery(
+          ANALYTICS_EVENTS.PUSH_RECEIPT_RESULT,
+          reference ?? {},
+          outcomeOf(receipt),
+        ),
+        ...(receipt.status === "error" && receipt.details?.error && pushToken
+          ? [handlePushError(receipt.details.error, pushToken)]
+          : []),
+      ];
+    }),
   );
 
   // Anything neither errored nor confirmed is still in flight: ask again later.
-  const nonProcessedReceipts: typeof incomingReceiptsData = entries
-    .filter(([, receipt]) => receipt.status !== "ok" && !receipt.details?.error)
-    .map(([id]) => ({ id, pushToken: tokenFor(id) }));
+  // The attribution rides along, otherwise a push that takes two rounds to
+  // settle loses the user and kind it belongs to.
+  const nonProcessedReceipts: IPushReceiptReference[] = entries
+    .filter(([, receipt]) => isInFlight(receipt))
+    .flatMap(([id]) => {
+      const reference = referenceFor(id);
+
+      return reference ? [reference] : [];
+    });
 
   if (nonProcessedReceipts.length === 0) return;
 

--- a/packages/api/src/queue/topics.ts
+++ b/packages/api/src/queue/topics.ts
@@ -1,3 +1,4 @@
+import type { PushKind } from "@pegada/shared/analytics/events";
 import type { Language } from "@pegada/shared/i18n/types/types";
 import type { Image } from "@prisma/client";
 
@@ -21,10 +22,41 @@ export type IMailJobData = {
 
 export type IProcessImageJobData = Partial<Image> & { id: string; url: string };
 
-export type ISendNotificationJobData = ExpoPushMessage;
+/**
+ * Who a push is for and what it is, carried alongside the Expo message and
+ * stripped back off before it is handed to Expo.
+ *
+ * All three are optional because they are attribution rather than delivery:
+ * a push with none of them still goes out, it just cannot be counted. Every
+ * caller in the codebase sets them, so an unattributed push in PostHog means
+ * a new send path that forgot to.
+ */
+export type PushAttribution = {
+  /**
+   * The `NotificationLog` row to stamp with the outcome. Only the scheduled
+   * nudges have one; transactional pushes are not logged.
+   */
+  notificationLogId?: string;
+  /** Breakdown property on the ticket and receipt events. */
+  pushKind?: PushKind;
+  /** Distinct id for those events, so delivery is readable per person. */
+  userId?: string;
+};
+
+export type ISendNotificationJobData = ExpoPushMessage & PushAttribution;
+
+/**
+ * Attribution rides along with each receipt id because a receipt is checked
+ * in a separate job, half an hour after the send, with none of the context
+ * that produced it.
+ */
+export type IPushReceiptReference = PushAttribution & {
+  id: string;
+  pushToken: string;
+};
 
 export type ICheckPushNotificationReceiptsJobData = {
-  receipts?: { id: string; pushToken: string }[];
+  receipts?: IPushReceiptReference[];
 };
 
 export type ICleanupUploadJobData = {

--- a/packages/api/src/services/match-service.ts
+++ b/packages/api/src/services/match-service.ts
@@ -102,6 +102,8 @@ class MatchService {
           data: {
             url: `match/${match.id}/${match.requesterId}`,
           },
+          userId: match.responder.user.id,
+          pushKind: "match" as const,
         }
       : null;
 

--- a/packages/api/src/services/message-service.ts
+++ b/packages/api/src/services/message-service.ts
@@ -120,6 +120,8 @@ class MessageService {
         data: {
           url: `chat/${matchId}/${newMessage.senderId}`,
         },
+        userId: otherDog.user.id,
+        pushKind: "message",
       });
     }
 

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -45,11 +45,17 @@ const PUSH_TOKEN = "ExponentPushToken[aaaaaaaaaaaaaaaaaaaaaa]";
 const LONGITUDE = -38.5;
 const LATITUDE = -12.97;
 
-/** 15:00 in UTC-3, comfortably inside the send window. */
-const NOW = new Date("2026-09-01T18:00:00.000Z");
+/** 18:00 in UTC-3, the first of the two hours a nudge may leave in. */
+const NOW = new Date("2026-09-01T21:00:00.000Z");
 
-/** 03:00 in UTC-3, inside quiet hours. */
+/** 03:00 in UTC-3, the middle of the night. */
 const NIGHT = new Date("2026-09-01T06:00:00.000Z");
+
+/**
+ * The instant of the production incident: 19:03 UTC, which is 16:03 in
+ * Sao Paulo. Inside the old "not quiet hours" window, outside the evening one.
+ */
+const AFTERNOON_BURST = new Date("2026-09-02T19:03:00.000Z");
 
 const hoursBefore = (reference: Date, hours: number) =>
   new Date(reference.getTime() - hours * 60 * 60 * 1000);
@@ -105,9 +111,9 @@ const seedSilentMatch = async (hours: number, reference = NOW) => {
 
 describe("localHourFromLongitude", () => {
   it("reads the hour from the longitude offset", () => {
-    expect(localHourFromLongitude(LONGITUDE, NOW)).toBe(15);
-    expect(localHourFromLongitude(0, NOW)).toBe(18);
-    expect(localHourFromLongitude(150, NOW)).toBe(4);
+    expect(localHourFromLongitude(LONGITUDE, NOW)).toBe(18);
+    expect(localHourFromLongitude(0, NOW)).toBe(21);
+    expect(localHourFromLongitude(150, NOW)).toBe(7);
   });
 
   it("has no hour without a longitude", () => {
@@ -117,22 +123,41 @@ describe("localHourFromLongitude", () => {
 });
 
 describe("isWithinSendWindow", () => {
-  it("sends during the day and stays quiet at night", () => {
+  it("opens for the two evening hours and nothing else", () => {
+    // 18:00 and 19:00 local.
     expect(isWithinSendWindow(LONGITUDE, NOW)).toBe(true);
-    // 23:00 local.
     expect(
-      isWithinSendWindow(LONGITUDE, new Date("2026-09-02T02:00:00.000Z")),
+      isWithinSendWindow(LONGITUDE, new Date("2026-09-01T22:00:00.000Z")),
+    ).toBe(true);
+    // 17:00 local, an hour early.
+    expect(
+      isWithinSendWindow(LONGITUDE, new Date("2026-09-01T20:00:00.000Z")),
     ).toBe(false);
-    // 06:00 local.
+    // 20:00 local, an hour late.
+    expect(
+      isWithinSendWindow(LONGITUDE, new Date("2026-09-01T23:00:00.000Z")),
+    ).toBe(false);
+    // 03:00 local.
     expect(isWithinSendWindow(LONGITUDE, NIGHT)).toBe(false);
   });
 
-  it("falls back to the early evening Sao Paulo slot without coordinates", () => {
+  it("holds a located user to the same window as everybody else", () => {
+    // The production incident. Sao Paulo, 16:03 local: the old rule let any
+    // located user through from 09:00 to 21:00, so this went out.
+    expect(isWithinSendWindow(-46.63, AFTERNOON_BURST)).toBe(false);
+    expect(isWithinSendWindow(null, AFTERNOON_BURST)).toBe(false);
+
+    // Three hours later, in the slot, both are due.
+    const evening = new Date("2026-09-02T22:00:00.000Z");
+
+    expect(isWithinSendWindow(-46.63, evening)).toBe(true);
+    expect(isWithinSendWindow(null, evening)).toBe(true);
+  });
+
+  it("uses America/Sao_Paulo when there are no coordinates", () => {
     // 18:00 in UTC-3, and 19:00 so one missed cron run does not drop the
     // whole cohort for the day.
-    expect(isWithinSendWindow(null, new Date("2026-09-01T21:00:00.000Z"))).toBe(
-      true,
-    );
+    expect(isWithinSendWindow(null, NOW)).toBe(true);
     expect(isWithinSendWindow(null, new Date("2026-09-01T22:00:00.000Z"))).toBe(
       true,
     );
@@ -140,8 +165,6 @@ describe("isWithinSendWindow", () => {
     expect(isWithinSendWindow(null, new Date("2026-09-01T23:00:00.000Z"))).toBe(
       false,
     );
-    // 15:00 in UTC-3, fine for a located user but not for this one.
-    expect(isWithinSendWindow(null, NOW)).toBe(false);
   });
 });
 
@@ -503,6 +526,26 @@ describe("selectLikesWaitingCandidates", () => {
     await expect(selectLikesWaitingCandidates(NOW)).resolves.toEqual([]);
   });
 
+  it("stays quiet for a week after the last one, even for a brand new like", async () => {
+    const { user } = await seedWaitingLike(30);
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: user.id,
+        kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+        dedupeKey: "announced-three-days-ago",
+        sentAt: daysAgo(3),
+      },
+    });
+
+    await expect(selectLikesWaitingCandidates(NOW)).resolves.toEqual([]);
+
+    // Eight days on, the floor has passed and the like is fair game again.
+    await prisma.notificationLog.updateMany({ data: { sentAt: daysAgo(8) } });
+
+    await expect(selectLikesWaitingCandidates(NOW)).resolves.toHaveLength(1);
+  });
+
   it("does not repeat itself once the oldest waiting like was announced", async () => {
     const { user, interest } = await seedWaitingLike(30);
 
@@ -576,10 +619,10 @@ describe("ReengagementService.run", () => {
 
     expect((await ReengagementService.run(NOW)).sent).toBe(2);
 
-    // Two hours later the match keys are claimed but the like key is not, and
-    // the daily cap is what has to stop it.
+    // An hour later, still in the window: the match keys are claimed but the
+    // like key is not, and the daily cap is what has to stop it.
     const summary = await ReengagementService.run(
-      new Date(NOW.getTime() + 2 * 60 * 60 * 1000),
+      new Date(NOW.getTime() + 60 * 60 * 1000),
     );
 
     expect(summary.sent).toBe(0);
@@ -658,13 +701,116 @@ describe("ReengagementService.run", () => {
     expect(summary.byKind[REENGAGEMENT_KINDS.LIKES_WAITING]).toBe(1);
   });
 
-  it("sends nothing during quiet hours", async () => {
+  it("does not send in the afternoon the production burst went out in", async () => {
+    await seedSilentMatch(25, AFTERNOON_BURST);
+
+    // Sao Paulo. The old rule let a located user through at any hour from
+    // 09:00 to 21:00 local, which is how 200 pushes left at 16:03.
+    await prisma.user.updateMany({
+      data: { latitude: -23.55, longitude: -46.63 },
+    });
+
+    const burst = await ReengagementService.run(AFTERNOON_BURST);
+
+    expect(burst.sent).toBe(0);
+    expect(burst.skippedOutsideWindow).toBe(2);
+    expect(
+      PushNotificationService.enqueuePushNotification,
+    ).not.toHaveBeenCalled();
+
+    // The same two candidates three hours later, now 19:00 local.
+    const evening = await ReengagementService.run(
+      new Date("2026-09-02T22:00:00.000Z"),
+    );
+
+    expect(evening.sent).toBe(2);
+  });
+
+  it("nudges about waiting likes once a week, not once a day", async () => {
+    const { user, dog: liked } = await generateFakeUserWithDog(
+      { gender: "FEMALE" },
+      reachableUser(),
+    );
+
+    /** Seven admirers, oldest like first, all of them waiting over a day. */
+    const likes: { id: string }[] = [];
+    for (const index of [0, 1, 2, 3, 4, 5, 6]) {
+      // oxlint-disable-next-line no-await-in-loop -- Fixture rows are created in order so their timestamps stay distinct.
+      const { dog: admirer } = await generateFakeUserWithDog(
+        { gender: "MALE", name: `Admirer ${index}` },
+        reachableUser({ pushToken: null }),
+      );
+
+      // oxlint-disable-next-line no-await-in-loop -- Same.
+      const like = await prisma.interest.create({
+        data: {
+          requesterId: admirer.id,
+          responderId: liked.id,
+          swipeType: "INTERESTED",
+          lastPositiveAt: hoursAgo(40 - index),
+        },
+      });
+
+      // oxlint-disable-next-line no-await-in-loop -- Same.
+      await prisma.interest.update({
+        where: { id: like.id },
+        data: { createdAt: hoursAgo(40 - index) },
+      });
+
+      likes.push(like);
+    }
+
+    const first = await ReengagementService.run(NOW);
+
+    expect(first.byKind[REENGAGEMENT_KINDS.LIKES_WAITING]).toBe(1);
+
+    /**
+     * The next evening slot, with the like that was announced taken off the
+     * board. A swipe back does exactly this, and it is what moves the anchor
+     * the dedupe key is built from: every one of these days offers a key that
+     * has never been claimed, so the weekly floor is the only thing left
+     * holding the nudge back.
+     */
+    const runOnDay = async (day: number) => {
+      await prisma.interest.update({
+        where: { id: likes[day - 1]?.id },
+        data: { deletedAt: NOW },
+      });
+
+      return ReengagementService.run(
+        new Date(NOW.getTime() + day * 24 * 60 * 60 * 1000),
+      );
+    };
+
+    for (const day of [1, 2, 3, 4, 5, 6]) {
+      // oxlint-disable-next-line no-await-in-loop -- Each day has to see the log the previous day wrote.
+      const summary = await runOnDay(day);
+
+      expect(summary.byKind[REENGAGEMENT_KINDS.LIKES_WAITING]).toBe(0);
+    }
+
+    await expect(
+      prisma.notificationLog.count({
+        where: { userId: user.id, kind: REENGAGEMENT_KINDS.LIKES_WAITING },
+      }),
+    ).resolves.toBe(1);
+
+    // A week on, the floor has passed and the likes still sitting there are
+    // worth one more nudge.
+    const nextWeek = await ReengagementService.run(
+      new Date(NOW.getTime() + 8 * 24 * 60 * 60 * 1000),
+    );
+
+    expect(nextWeek.byKind[REENGAGEMENT_KINDS.LIKES_WAITING]).toBe(1);
+  });
+
+  it("sends nothing outside the evening window", async () => {
     await seedSilentMatch(25, NIGHT);
 
     const summary = await ReengagementService.run(NIGHT);
 
     expect(summary.sent).toBe(0);
-    expect(summary.skippedQuietHours).toBe(2);
+    expect(summary.skippedOutsideWindow).toBe(2);
     expect(
       PushNotificationService.enqueuePushNotification,
     ).not.toHaveBeenCalled();

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -77,33 +77,67 @@ const NEW_DOGS_FALLBACK_WINDOW_DAYS = 30;
  */
 const UNLIMITED_DISTANCE_KM = 295;
 
-/** Local hours between which nothing is sent. */
-const QUIET_HOURS_START = 21;
-const QUIET_HOURS_END = 9;
+/**
+ * The rule, in full: a re-engagement push may only leave inside 18:00 and
+ * 19:00 of the recipient's own local hour, whatever the kind.
+ *
+ * Two hours rather than one because Vercel Cron is best effort and a single
+ * missed invocation would otherwise drop a whole cohort for the day. The
+ * dedupe key and the per-user cap are what stop the second hour resending.
+ *
+ * This used to be two rules: located users were allowed any hour from 09:00
+ * to 21:00 and only the users without coordinates were held to the evening.
+ * That is what put 200 pushes on the wire at 16:03 America/Sao_Paulo on
+ * 2026-09-02: every one of them a located Brazilian user, comfortably inside a
+ * twelve hour "not quiet hours" window that was never the intent. There is one
+ * window now and every kind goes through it.
+ */
+const SEND_WINDOW_HOURS = new Set([18, 19]);
 
 /**
  * America/Sao_Paulo, for users whose coordinates we do not have.
  *
- * Two hours rather than one because Vercel Cron is best effort: a single
- * missed invocation would drop this whole cohort for the day. The dedupe key
- * and the daily cap are what stop the second hour resending.
+ * A fixed offset is correct rather than convenient: Brazil dropped daylight
+ * saving in 2019, so the zone has been UTC-3 all year round ever since.
  */
 const FALLBACK_OFFSET_HOURS = -3;
-const FALLBACK_SEND_HOURS = new Set([18, 19]);
 
-/** One re-engagement push per user per rolling day. */
 /**
- * One re-engagement push per user per day.
+ * One re-engagement push per user per rolling day, whatever the kind.
  *
  * 23 hours rather than 24, and strictly greater than rather than inclusive,
  * because the job runs hourly and the cap is measured against the previous
  * send. At exactly 24 a user nudged at 19:00 is still inside the window at
  * 18:00 the next day, so their slot slides an hour later each time until it
- * falls out of the evening entirely and they end up on every other day. The
- * hour of slack absorbs that without ever allowing two sends in a calendar
- * day, since the earliest either can land is 09:00 local.
+ * falls out of the evening entirely and they end up on every other day.
  */
 const USER_COOLDOWN_HOURS = 23;
+
+/**
+ * How long one kind waits before it may nudge the same user again.
+ *
+ * `likes_waiting` is the outlier and the reason this map exists. Its dedupe
+ * key names one pending like, so a dormant user collecting a like a day was
+ * eligible again every day under a key that had never been claimed: same
+ * person, same "you have likes waiting", every evening. A week between two of
+ * them makes it a nudge rather than a drip, and it costs nothing when the
+ * likes really are new, because the copy never counted them.
+ *
+ * The other two are already self limiting (a match is nudged at 24h and 72h
+ * and never again, new dogs are keyed on an anchor that only the user can
+ * move), so they sit at the shared floor.
+ */
+const KIND_COOLDOWN_HOURS = {
+  [REENGAGEMENT_KINDS.UNANSWERED_MATCH]: USER_COOLDOWN_HOURS,
+  [REENGAGEMENT_KINDS.NEW_DOGS_NEARBY]: USER_COOLDOWN_HOURS,
+  [REENGAGEMENT_KINDS.LIKES_WAITING]: 7 * 24,
+} as const satisfies Record<ReengagementKind, number>;
+
+/** How far back the cooldown lookup has to read to answer every kind. */
+const MAX_COOLDOWN_HOURS = Math.max(...Object.values(KIND_COOLDOWN_HOURS));
+
+/** Set membership key for "this user has had this kind recently". */
+const kindKey = (userId: string, kind: string) => `${userId}:${kind}`;
 
 /** Bounds one invocation so a backlog cannot outrun the function budget. */
 const MAX_CANDIDATES_PER_QUERY = 500;
@@ -129,8 +163,12 @@ export type ReengagementRunSummary = {
   sent: number;
   byKind: Record<ReengagementKind, number>;
   candidates: number;
-  skippedQuietHours: number;
+  /** Users whose local hour was not 18:00 or 19:00 when the run started. */
+  skippedOutsideWindow: number;
+  /** Users inside {@link USER_COOLDOWN_HOURS} of their last push, any kind. */
   skippedCooldown: number;
+  /** Candidates dropped by their own kind's cooldown. */
+  skippedKindCooldown: number;
   skippedAlreadySent: number;
   skippedUnreachable: number;
 };
@@ -166,9 +204,14 @@ const hourInOffset = (now: Date, offsetHours: number) =>
  * Longitude over 15 is the solar offset, and it is deliberately the whole
  * timezone story here: a real tz lookup means shipping a coordinate-to-zone
  * dataset (tens of megabytes into a serverless bundle) to decide whether a
- * nudge goes out at 18:00 or 19:00. Political zones drift from solar time by
- * an hour or two at the edges, which the twelve hour send window absorbs, and
- * Brazil (where nearly all the users are) sits close to its solar offset.
+ * nudge goes out at 18:00 or 19:00.
+ *
+ * Political zones drift from solar time by up to an hour at the edges of a
+ * zone, so the two hour window really means "somewhere between 17:00 and
+ * 20:00 local" for a user near one. That is the price of not shipping the
+ * dataset, and it is a price worth paying: every one of those hours is still
+ * the evening. Brazil, where nearly all the users are, sits close enough to
+ * its solar offset that most of them land on the nose.
  *
  * `null` when there is no longitude, which is the caller's cue to fall back to
  * America/Sao_Paulo.
@@ -183,25 +226,20 @@ export const localHourFromLongitude = (
 };
 
 /**
- * Is now a decent moment to interrupt this user?
+ * Is now the moment this user is allowed to be interrupted?
  *
- * With coordinates: any local hour outside 21:00 to 09:00. Without: only the
- * early evening America/Sao_Paulo slot, because guessing a whole day of
- * waking hours for someone whose location we do not know is how a retention
- * push becomes a 3am push.
+ * One rule for everybody: the local hour has to be 18 or 19. The local hour
+ * comes from the user's longitude when there is one, and from
+ * America/Sao_Paulo when there is not. See {@link SEND_WINDOW_HOURS}.
  */
 export const isWithinSendWindow = (
   longitude: number | null | undefined,
   now: Date,
-): boolean => {
-  const localHour = localHourFromLongitude(longitude, now);
-
-  if (localHour === null) {
-    return FALLBACK_SEND_HOURS.has(hourInOffset(now, FALLBACK_OFFSET_HOURS));
-  }
-
-  return localHour >= QUIET_HOURS_END && localHour < QUIET_HOURS_START;
-};
+): boolean =>
+  SEND_WINDOW_HOURS.has(
+    localHourFromLongitude(longitude, now) ??
+      hourInOffset(now, FALLBACK_OFFSET_HOURS),
+  );
 
 type ReengagementCopyKey =
   | "server:notification.reengagement.unansweredMatch.title"
@@ -557,12 +595,21 @@ type LikesWaitingRow = {
  * and nothing back from you. That is the set worth interrupting someone over.
  *
  * The dedupe key is the oldest waiting like, so the nudge does not repeat
- * until that particular like is dealt with.
+ * until that particular like is dealt with. On its own that was not enough:
+ * a new like arriving is a new oldest-unannounced like, so a popular dormant
+ * dog produced one of these every evening. The weekly floor below is the cap
+ * that actually holds, and it is applied here as well as in the run so those
+ * users do not sit in the candidate limit for nothing.
  */
 export const selectLikesWaitingCandidates = async (
   now: Date,
 ): Promise<Candidate[]> => {
   const olderThan = new Date(now.getTime() - LIKES_WAITING_HOURS * HOUR_MS);
+
+  const cooldownFloor = new Date(
+    now.getTime() -
+      KIND_COOLDOWN_HOURS[REENGAGEMENT_KINDS.LIKES_WAITING] * HOUR_MS,
+  );
 
   const rows = await prisma.$queryRaw<LikesWaitingRow[]>`
     WITH "waiting" AS (
@@ -623,6 +670,14 @@ export const selectLikesWaitingCandidates = async (
       SELECT 1 FROM "NotificationLog"
       WHERE "NotificationLog"."dedupeKey" =
         ${`${REENGAGEMENT_KINDS.LIKES_WAITING}:`} || "waiting"."userId" || ':' || "waiting"."anchorId"
+    )
+    /* The weekly per-user floor for this kind, mirrored from the run so the
+       users it holds back never take a slot in the limit below. */
+    AND NOT EXISTS (
+      SELECT 1 FROM "NotificationLog"
+      WHERE "NotificationLog"."userId" = "waiting"."userId"
+      AND "NotificationLog"."kind" = ${REENGAGEMENT_KINDS.LIKES_WAITING}
+      AND "NotificationLog"."sentAt" > ${cooldownFloor}
     )
     ORDER BY "waiting"."newestLikeAt" DESC
     LIMIT ${MAX_CANDIDATES_PER_QUERY}
@@ -687,8 +742,9 @@ export class ReengagementService {
         [REENGAGEMENT_KINDS.LIKES_WAITING]: 0,
       },
       candidates: candidates.length,
-      skippedQuietHours: 0,
+      skippedOutsideWindow: 0,
       skippedCooldown: 0,
+      skippedKindCooldown: 0,
       skippedAlreadySent: 0,
       skippedUnreachable: 0,
     };
@@ -733,23 +789,51 @@ export class ReengagementService {
 
     const due = [...perUser.entries()].filter(([, { longitude }]) => {
       if (isWithinSendWindow(longitude, now)) return true;
-      summary.skippedQuietHours += 1;
+      summary.skippedOutsideWindow += 1;
       return false;
     });
 
     if (due.length === 0) return summary;
 
-    const cooledDown = await prisma.notificationLog.findMany({
+    // One read covers both caps: the widest kind window is a superset of the
+    // per-user one, so the rows are filtered in memory rather than queried
+    // once per kind.
+    const recentLogs = await prisma.notificationLog.findMany({
       where: {
         userId: { in: due.map(([userId]) => userId) },
-        sentAt: {
-          gt: new Date(now.getTime() - USER_COOLDOWN_HOURS * HOUR_MS),
-        },
+        sentAt: { gt: new Date(now.getTime() - MAX_COOLDOWN_HOURS * HOUR_MS) },
       },
-      select: { userId: true },
+      select: { userId: true, kind: true, sentAt: true },
     });
 
-    const recentlyNudged = new Set(cooledDown.map(({ userId }) => userId));
+    const recentlyNudged = new Set(
+      recentLogs
+        .filter(
+          ({ sentAt }) =>
+            sentAt.getTime() > now.getTime() - USER_COOLDOWN_HOURS * HOUR_MS,
+        )
+        .map(({ userId }) => userId),
+    );
+
+    // The selectors mirror their own kind's floor in SQL so a cooled down user
+    // never takes a slot in MAX_CANDIDATES_PER_QUERY. This is the same rule
+    // stated once more where the decision is actually made: it is what a new
+    // kind gets for free, and `skippedKindCooldown` reading anything but zero
+    // is the signal that a selector has stopped mirroring it.
+    const kindOnCooldown = new Set(
+      recentLogs
+        .filter(({ kind, sentAt }) => {
+          const hours = KIND_COOLDOWN_HOURS[kind as ReengagementKind];
+
+          // An unknown kind is a row this service did not write, so it holds
+          // nobody back beyond the per-user cap above.
+          return (
+            hours !== undefined &&
+            sentAt.getTime() > now.getTime() - hours * HOUR_MS
+          );
+        })
+        .map(({ userId, kind }) => kindKey(userId, kind)),
+    );
 
     for (const [userId, { queue }] of due) {
       if (summary.sent >= MAX_PUSHES_PER_RUN) break;
@@ -757,9 +841,15 @@ export class ReengagementService {
       if (recentlyNudged.has(userId)) {
         summary.skippedCooldown += 1;
       } else {
+        const allowed = queue.filter((candidate) => {
+          if (!kindOnCooldown.has(kindKey(userId, candidate.kind))) return true;
+          summary.skippedKindCooldown += 1;
+          return false;
+        });
+
         // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cooldown they enforce on each other.
         const sent = await ReengagementService.#sendFirstAvailable(
-          queue,
+          allowed,
           summary,
         );
 
@@ -814,14 +904,19 @@ export class ReengagementService {
    * push is the thing users uninstall over.
    */
   static async #send(candidate: Candidate): Promise<"sent" | "already-sent"> {
+    let notificationLogId: string;
+
     try {
-      await prisma.notificationLog.create({
+      const log = await prisma.notificationLog.create({
         data: {
           userId: candidate.userId,
           kind: candidate.kind,
           dedupeKey: candidate.dedupeKey,
         },
+        select: { id: true },
       });
+
+      notificationLogId = log.id;
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -838,6 +933,11 @@ export class ReengagementService {
       title: candidate.title,
       body: candidate.body,
       data: { url: candidate.url, kind: candidate.kind },
+      // Carried through the queue so the ticket and receipt this produces can
+      // be attributed back to this user, this kind, and this log row.
+      userId: candidate.userId,
+      pushKind: candidate.kind,
+      notificationLogId,
     });
 
     if (candidate.clearsNewDogsAlert) {

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -139,7 +139,15 @@ const MAX_COOLDOWN_HOURS = Math.max(...Object.values(KIND_COOLDOWN_HOURS));
 /** Set membership key for "this user has had this kind recently". */
 const kindKey = (userId: string, kind: string) => `${userId}:${kind}`;
 
-/** Bounds one invocation so a backlog cannot outrun the function budget. */
+/**
+ * Bounds one invocation so a backlog cannot outrun the function budget.
+ *
+ * Worth reading next to {@link SEND_WINDOW_HOURS}: a user is only eligible in
+ * two of the twenty four runs a day, and Brazil is one offset, so the whole
+ * base shares those two runs and the real daily ceiling is twice this number.
+ * The 200 the incident sent was this cap being hit, so a backlog does exist.
+ * Raise this before widening the window if the queue stops draining.
+ */
 const MAX_CANDIDATES_PER_QUERY = 500;
 const MAX_PUSHES_PER_RUN = 200;
 

--- a/packages/api/src/services/swipe-service.ts
+++ b/packages/api/src/services/swipe-service.ts
@@ -64,6 +64,8 @@ export class SwipeService {
         // Gives the like push the same shape as the match and chat pushes so a
         // tap resolves to a known destination instead of an unknown link.
         data: { url: "like" },
+        userId: dog.user.id,
+        pushKind: "like",
       });
     } catch (error) {
       sendError(error);

--- a/packages/database/migrations/20260902190000_add_notification_log_delivery/migration.sql
+++ b/packages/database/migrations/20260902190000_add_notification_log_delivery/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "NotificationLog"
+ADD COLUMN "ticketStatus" TEXT,
+ADD COLUMN "ticketError" TEXT,
+ADD COLUMN "receiptStatus" TEXT,
+ADD COLUMN "receiptError" TEXT;
+
+-- Serves the per-kind cooldown lookup in the re-engagement run, which asks for
+-- one user's sends of one kind inside a window.
+CREATE INDEX "NotificationLog_userId_kind_sentAt_idx"
+ON "NotificationLog"("userId", "kind", "sentAt");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -374,7 +374,18 @@ model NotificationLog {
   dedupeKey String   @unique
   sentAt    DateTime @default(now())
 
+  /// What Expo said when the push was handed over, and what the device said
+  /// about half an hour later. Both stay null until the queue handler answers,
+  /// and stay null forever for a push the handler never ran for, which is
+  /// itself the signal that the queue hop dropped it. `sentAt` only ever meant
+  /// "we tried"; these are the columns that mean "it arrived".
+  ticketStatus  String?
+  ticketError   String?
+  receiptStatus String?
+  receiptError  String?
+
   @@index([userId, sentAt])
+  @@index([userId, kind, sentAt])
 }
 
 /// One row per person who asked to be told when a feature we have not built

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -56,6 +56,8 @@ export const ANALYTICS_EVENTS = {
   PUSH_NOTIFICATION_OPENED: "Push Notification Opened",
   REENGAGEMENT_PUSH_SENT: "Reengagement Push Sent",
   PUSH_PERMISSION: "Push Permission",
+  PUSH_RECEIPT_RESULT: "Push Receipt Result",
+  PUSH_TICKET_RESULT: "Push Ticket Result",
   REFERRAL_CAPTURED: "Referral Captured",
   RESTORE_PURCHASES: "RestorePurchases",
   RESTORE_PURCHASES_SUCCESS: "Restore Purchases Success",
@@ -126,6 +128,23 @@ export type ReengagementPushKind =
   | "likes_waiting"
   | "new_dogs_nearby"
   | "unanswered_match";
+
+/**
+ * What a push was for, across every path that sends one: the three scheduled
+ * nudges plus the three transactional ones. One vocabulary so the delivery
+ * events below break down by the same property whoever sent the push.
+ */
+export type PushKind = ReengagementPushKind | "like" | "match" | "message";
+
+/**
+ * Expo's answer about one push, at whichever of the two checkpoints asked.
+ *
+ * A ticket is Expo accepting the message; a receipt, fetched about half an
+ * hour later, is Apple or Google saying what became of it. Only the second one
+ * means delivered, which is why both are recorded separately rather than
+ * collapsed into a single "sent".
+ */
+export type PushDeliveryStatus = "error" | "ok";
 
 /**
  * The moment that produced a review prompt. The whole point of the review
@@ -402,6 +421,31 @@ export type ServerEventProperties = {
     message_type: "text";
   };
   /**
+   * What the device said about a push, roughly half an hour after it left.
+   *
+   * This is the only event in the catalogue that means "delivered". Read as an
+   * ok rate per `kind` it is the denominator every push funnel was missing:
+   * before it existed, a push that Expo dropped and a push nobody opened were
+   * the same data.
+   */
+  [ANALYTICS_EVENTS.PUSH_RECEIPT_RESULT]: {
+    /** Expo's own code, such as `DeviceNotRegistered`. Null when ok. */
+    error_code: string | null;
+    /** Null only for a push enqueued before this property existed. */
+    kind: PushKind | null;
+    status: PushDeliveryStatus;
+  };
+  /**
+   * What Expo said when the push was handed over. An error here is a push that
+   * never reached a device at all, so it is the first place a silent failure
+   * shows up.
+   */
+  [ANALYTICS_EVENTS.PUSH_TICKET_RESULT]: {
+    error_code: string | null;
+    kind: PushKind | null;
+    status: PushDeliveryStatus;
+  };
+  /**
    * One row per re-engagement push handed to Expo. `dedupe_key` is the same key
    * the send claimed in `NotificationLog`, so a send and the open it produced
    * can be lined up without trusting timestamps.
@@ -562,6 +606,8 @@ export const MOBILE_EVENT_NAMES = [
 export const SERVER_EVENT_NAMES = [
   ANALYTICS_EVENTS.MATCH_CREATED,
   ANALYTICS_EVENTS.MESSAGE_SENT,
+  ANALYTICS_EVENTS.PUSH_RECEIPT_RESULT,
+  ANALYTICS_EVENTS.PUSH_TICKET_RESULT,
   ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT,
   ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED,
   ANALYTICS_EVENTS.SUBSCRIPTION_EVENT,


### PR DESCRIPTION
## Summary

The hourly re-engagement job sent 200 pushes at 16:03 Sao Paulo instead of the evening, and nothing on the server ever recorded whether any of them arrived. This holds every kind to one local evening window and adds the two delivery events that make the answer readable.

## Details

Root cause of the burst. The send window was two different rules. A user with coordinates was allowed any local hour from 09:00 to 21:00, and only a user without coordinates was held to the 18:00 to 19:00 Sao Paulo slot the design describes. At 19:03 UTC on 2 September the located Brazilian users read as 16:00 local, which passed, and the run went straight to its ceiling of 200 pushes. There is one rule now: the local hour has to be 18 or 19, taken from longitude when there is one and from Sao Paulo when there is not, and it applies to all three kinds. A unit test pinned to that exact instant covers it.

Caps. One push per user per 23 hours, whatever the kind, is written down as a constant and kept. The likes nudge gets a floor of one per user per 7 days on top, because its dedupe key names a single pending like, so a dormant dog collecting likes could qualify again the moment the old key stopped applying. The floor is applied both in the candidate query, so those users do not fill the per run limit, and in the run itself.

Observability. The queue handler now records Push Ticket Result when Expo takes the message and Push Receipt Result when the device answers, both with the user id as the distinct id and a kind that covers the scheduled nudges as well as the like, match and chat pushes. The same outcome is stamped on the notification log row, so one send can be looked up after the fact. Neither write can fail the job.

Hypothesis. Pushes that land in the evening and are capped per person get opened more than pushes that land mid afternoon and repeat, and the ticket and receipt events tell us which half of the funnel is losing people.

Baseline. 200 pushes sent in a 14 second burst at 16:03 local, all of them the likes nudge, 0 opens, and 0 measurable deliveries because no server event existed for Expo tickets or receipts.

Readout. In PostHog, the ok rate of Push Receipt Result broken down by kind gives delivery per nudge for the first time, and Reengagement Push Sent grouped by hour has to sit entirely inside 18:00 to 19:00 local. Opens per delivered push, rather than per push sent, is then the number to move.

One consequence worth stating. A user is now eligible in two of the twenty four runs a day instead of twelve, and Brazil is a single offset, so the base shares those two runs. The 200 the incident sent was the per run ceiling being hit, which means a backlog exists, and it will now drain more slowly. The cap is commented with that, and raising it is the lever to pull before the window is widened again.

No copy and no targeting changed.

## Testing steps

Nothing in the app looks different. The change is in the scheduled reminder that brings people back.

To confirm it by hand, pick an account that qualifies for a reminder and run the scheduled job in the middle of the afternoon: nothing goes out. Run it again between six and seven in the evening in that person's own time zone and the reminder arrives. Ask for a second reminder the next afternoon about a new like and it stays quiet for a week.

In the analytics dashboard, each reminder that leaves now produces a record of whether the phone accepted it, so the share that actually arrived can be read per reminder type.

## Screenshots

Not applicable. Server side only, with no visible change in the app.
