### PR TITLE
fix(shared): put the Portuguese interface in sentence case

### DIFF
--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -1,6 +1,6 @@
 {
   "likeLimit": {
-    "dailyLikeLimit": "Limite de Curtidas Diário",
+    "dailyLikeLimit": "Limite de curtidas diário",
     "description": "Você curtiu <b>{{count}} cachorros</b> em <b>24h</b>. Espere ou vire <b>premium</b> para continuar deslizando.",
     "remaining": "restantes",
     "timeHours": "{{time}}h",
@@ -29,7 +29,7 @@
   },
   "askForLocation": {
     "activateLocation": "Ativar localização",
-    "enableLocation": "Ativar Localização",
+    "enableLocation": "Ativar localização",
     "activate": "Ativar",
     "locationUsage": "Sua localização será utilizada para mostrar doguinhos perto de você.",
     "permissionPrompt": "Você precisa permitir o acesso à localização para usar o Pegada."
@@ -67,7 +67,7 @@
   },
   "completeProfile": {
     "additionalInfo": "Assim como você poderá selecionar suas preferências para dogs, os outros doguinhos também podem.\n\nEssas informações servem para que possamos te mostrar para os melhores matches!",
-    "birthDate": "Data de Nascimento",
+    "birthDate": "Data de nascimento",
     "breed": "Raça",
     "color": "Cor",
     "female": "Fêmea",
@@ -81,10 +81,10 @@
     "bio": "Bio",
     "clickAndHold": "* Clique e segure na foto para alterar a ordem.",
     "createProfile": "Criar perfil",
-    "dogName": "Nome do Doguinho",
+    "dogName": "Nome do doguinho",
     "howToCallDog": "Como podemos chamar seu doguinho?",
     "minimumOnePhoto": "Pelo menos uma foto deve incluir você (dono/a)",
-    "profilePictures": "Fotinhas do Dog",
+    "profilePictures": "Fotinhas do dog",
     "tellSomethingCool": "Conte alguma coisa legal sobre vocês.",
     "title": "Crie seu perfil"
   },
@@ -98,7 +98,7 @@
   "dogProfile": {
     "profileInfoError": "⚠️ Oops. Tente novamente mais tarde.",
     "cancel": "Cancelar",
-    "dogProfile": "Perfil do Doguinho",
+    "dogProfile": "Perfil do doguinho",
     "report": "Denunciar",
     "reportBody": "Eu gostaria de denunciar a conta número {{id}}, pertencente a {{name}} por:\n",
     "reportMessage": "Ao denunciar um perfil, você estará nos ajudando a manter a comunidade segura. Deseja continuar?",
@@ -160,16 +160,16 @@
   "editProfile": {
     "bio": "Bio",
     "bioPlaceholder": "Conte alguma coisa legal sobre vocês.",
-    "birthDate": "Data de Nascimento",
+    "birthDate": "Data de nascimento",
     "color": "Cor",
-    "dogName": "Nome do Doguinho",
+    "dogName": "Nome do doguinho",
     "dogNamePlaceholder": "Como podemos chamar seu doguinho?",
     "female": "Fêmea",
     "gender": "Sexo",
     "male": "Macho",
     "profileError": "Não foi possível salvar as informações do perfil",
     "profileUpdated": "Seu perfil foi atualizado!",
-    "saveProfile": "Salvar Perfil",
+    "saveProfile": "Salvar perfil",
     "size": "Tamanho",
     "title": "Editar perfil",
     "weight": "Peso (kg)"
@@ -187,7 +187,7 @@
   "forceUpdate": {
     "button": "Atualizar",
     "description": "Uma nova versão do Pegada está disponível. Por favor, atualize para continuar usando o app.",
-    "title": "Atualização Obrigatória"
+    "title": "Atualização obrigatória"
   },
   "formErrors": {
     "bioTooLong": "A bio deve conter no máximo {{length}} caracteres",
@@ -203,11 +203,11 @@
   },
   "imagePicker": {
     "cancel": "Cancelar",
-    "chooseFromLibrary": "Escolher da Galeria",
+    "chooseFromLibrary": "Escolher da galeria",
     "message": "Tirar uma foto ou escolher da galeria",
     "permissionsRequiredMessage": "Por favor, conceda as permissões necessárias para acessar a câmera e a galeria de fotos.",
     "permissionsRequiredTitle": "Desculpe, precisamos dessa permissão para que isso funcione!",
-    "takePhoto": "Tirar Foto",
+    "takePhoto": "Tirar foto",
     "title": "O que você prefere?",
     "uploadFailed": "Não foi possível enviar a imagem. Tente novamente.",
     "uploadFailedDev": "Falha no upload: {{reason}}"
@@ -216,7 +216,7 @@
     "accountCode": "Vamos enviar um código de 6 dígitos para autorizar sua conta. Se ainda não tem uma, vamos criá-la.",
     "continue": "Continuar",
     "emailPlaceholder": "oi@email.com",
-    "findDogsNearYou": "<view><title>Encontre </title><highlight>Dogs</highlight></view><view><title>perto de </title><highlight>Você</highlight><view/>",
+    "findDogsNearYou": "<view><title>Encontre </title><highlight>dogs</highlight></view><view><title>perto de </title><highlight>você</highlight><view/>",
     "insertEmail": "Insira seu <1>email</1>",
     "loginError": "Ocorreu um erro ao fazer login.",
     "pendingDogProfileBanner": {
@@ -228,7 +228,7 @@
   "locationMap": {
     "adjustYourPosition": "Ajuste sua posição",
     "areYouHere": "Você está aqui?",
-    "confirmLocation": "Confirmar Localização",
+    "confirmLocation": "Confirmar localização",
     "title": "Localização",
     "updateLocationError": "Ocorreu um erro ao atualizar sua localização."
   },
@@ -237,21 +237,21 @@
     "itsAMatchDescription": "Você deu match com esse doguinho!"
   },
   "matches": {
-    "matchedDogs": "Doguinhos Que Deram Match 🐶",
+    "matchedDogs": "Doguinhos que deram Match 🐶",
     "messages": "Mensagens",
     "sendFirstMessage": "Envie a primeira mensagem!"
   },
   "messages": {
     "empty": {
-      "clearSearch": "Limpar Busca",
+      "clearSearch": "Limpar busca",
       "description": " Aqui você irá ver e enviar mensagens para seus Matches.",
-      "searchForDogs": "Procurar Doguinhos",
+      "searchForDogs": "Procurar doguinhos",
       "title": "Não encontramos Matches, procure por novos doguinhos!"
     }
   },
   "newMatch": {
-    "keepSwiping": "Continue Deslizando",
-    "sendMessage": "Enviar Mensagem",
+    "keepSwiping": "Continue deslizando",
+    "sendMessage": "Enviar mensagem",
     "youGotA": "Você deu um",
     "youLikedEachOther": "Você e {{name}} se curtiram!"
   },
@@ -271,7 +271,7 @@
     "color": "Cor",
     "maxDistance": "Distância máxima",
     "preferencesUpdated": "Suas preferências foram atualizadas!",
-    "savePreferences": "Salvar Preferências",
+    "savePreferences": "Salvar preferências",
     "size": "Tamanho",
     "title": "Preferências",
     "updateError": "Ocorreu um erro ao atualizar suas preferências.",
@@ -313,7 +313,7 @@
     "theme": "Tema",
     "updateLocation": "Atualizar localização",
     "plan": {
-      "currentPlan": "Plano Atual",
+      "currentPlan": "Plano atual",
       "errorLoading": "Erro ao carregar o plano",
       "clickToRetry": "Tente novamente",
       "upgradeToPremium": "Atualize para Premium",
@@ -321,7 +321,7 @@
     }
   },
   "plans": {
-    "FREE": "Grátuito",
+    "FREE": "Gratuito",
     "PREMIUM": "Premium",
     "day": "dia",
     "week": "semana",
@@ -333,17 +333,17 @@
     "yearly": "Anual",
     "save": "Economize {{percent}}%",
     "benefits": {
-      "priorityQueue": "Prioridade na Fila",
+      "priorityQueue": "Prioridade na fila",
       "getSeenFirst": "Seja visto primeiro pelos populares!",
-      "unlimitedLikes": "Curtidas Ilimitadas",
+      "unlimitedLikes": "Curtidas ilimitadas",
       "noDailyLimits": "Sem limites para o amor",
-      "rewind": "Voltar na Lista de Doguinhos",
+      "rewind": "Voltar na lista de doguinhos",
       "madeAMistake": "Cometeu um erro? Sem problemas",
-      "noAds": "Sem Anúncios",
+      "noAds": "Sem anúncios",
       "noAdsDescription": "Aproveite o app sem distrações"
     },
     "restorePurchases": {
-      "restore": "Restaurar Compras"
+      "restore": "Restaurar compras"
     },
     "errors": {
       "fetchingOfferingsDevice": "Ocorreu um erro ao buscar as ofertas. Tente em um dispositivo real.",
@@ -390,7 +390,7 @@
     "titleMale": "Compartilhe o {{name}}"
   },
   "sizes": {
-    "extraSmall": "Extra Pequeno",
+    "extraSmall": "Extra pequeno",
     "giant": "Gigante",
     "large": "Grande",
     "medium": "Médio",
@@ -403,7 +403,7 @@
     "inviteFriendMessage": "O Pegada é onde meu cachorro faz amigos. Traz o seu também:\n{{link}}",
     "notifyNewDogsButton": "Avisar quando chegar dog novo",
     "notifyNewDogsDone": "Vamos te avisar",
-    "preferencesButton": "Ver Preferências"
+    "preferencesButton": "Ver preferências"
   },
   "themes": {
     "automatic": "Automático",

--- a/packages/shared/i18n/locales/pt-BR/web.json
+++ b/packages/shared/i18n/locales/pt-BR/web.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "title": "Pegada - Aplicativo de Relacionamento para Cachorros",
+    "title": "Pegada - Aplicativo de relacionamento para cachorros",
     "description": "Pegada é um aplicativo de relacionamento para cachorros. Com ele, você pode encontrar outros cachorros para passear, brincar e até mesmo namorar. O aplicativo é gratuito e está disponível para Android e iOS.",
     "ogImageAlt": "Um iPhone com o Pegada aberto, mostrando o perfil de uma golden retriever chamada Maui, ao lado dos dizeres “Friends For Your Doggie” e “Pawfect Matches”."
   },
   "home": {
-    "title": "Amigos Pro Seu Dog",
+    "title": "Amigos pro seu dog",
     "description": "Aqui do lado tem cachorro da mesma raça e com o mesmo jeito do seu.",
     "cta": {
       "googlePlay": "Google Play",
@@ -111,7 +111,7 @@
       "description": "Deixa o e-mail que a gente te escreve quando tiver novidade do story.",
       "label": "Seu e-mail",
       "placeholder": "voce@email.com",
-      "privacy": "Política de Privacidade",
+      "privacy": "Política de privacidade",
       "honeypot": "Site",
       "submit": "Anotar",
       "submitting": "Anotando",
@@ -142,19 +142,19 @@
   },
   "privacyPolicy": {
     "metadata": {
-      "title": "Pegada | Política de Privacidade"
+      "title": "Pegada | Política de privacidade"
     },
     "content": "### Política de Privacidade do Aplicativo\n\nA política de privacidade descreve como coletamos, usamos, protegemos e compartilhamos as informações sobre você e seu pet. Por favor, leia cuidadosamente esta política antes de usar nosso aplicativo.\n\n#### Coleta de Informações\n\nColetamos informações de duas maneiras:\n\n- **Informações que você fornece:** Isso inclui as informações do perfil do seu pet, como nome, raça, idade e fotos. Também podemos coletar suas informações de contato para facilitar a comunicação.\n- **Informações de uso e do dispositivo:** Coletamos automaticamente informações sobre como você usa o aplicativo e sobre o dispositivo que você usa para acessar o nosso serviço. Isso pode incluir seu endereço IP, tipo de dispositivo e atividade no aplicativo.\n\n#### Uso das Informações\n\nUsamos as informações coletadas para:\n\n- Facilitar as correspondências entre os pets.\n- Melhorar nosso aplicativo e personalizar sua experiência.\n- Comunicar-se com você.\n- Proteger a segurança dos nossos usuários e prevenir fraudes.\n\n#### Compartilhamento de Informações\n\nNão vendemos nem compartilhamos suas informações pessoais com terceiros para fins de marketing sem o seu consentimento explícito. Podemos compartilhar informações com prestadores de serviços que nos ajudam a operar e melhorar nosso aplicativo. Esses prestadores de serviços têm acesso apenas às informações necessárias para realizar suas funções e estão obrigados a proteger suas informações.\n\n#### Segurança\n\nAdotamos medidas de segurança razoáveis para proteger suas informações, mas nenhum sistema é completamente seguro. Embora façamos o nosso melhor para proteger suas informações, não podemos garantir a sua segurança absoluta.\n\n#### Alterações à Política de Privacidade\n\nPodemos alterar esta política de privacidade de tempos em tempos. Se fizermos alterações, notificaremos você por meio de uma atualização no aplicativo ou por e-mail.\n\n#### Contato\n\nSe tiver alguma dúvida sobre esta política de privacidade, entre em contato conosco pelo e-mail: [suporte@pegada.app](mailto:suporte@pegada.app)\n\nAo utilizar o nosso aplicativo, você concorda com a coleta, uso e compartilhamento de suas informações conforme descrito nesta política de privacidade.\n\nÚltima atualização: 2 de julho de 2023."
   },
   "termsOfUse": {
     "metadata": {
-      "title": "Pegada | Termos de Uso"
+      "title": "Pegada | Termos de uso"
     },
     "content": "### Termos de Uso do Aplicativo \"Pegada\"\n\n1. **Definições:** \"Pegada\" refere-se ao aplicativo de relacionamento destinado para cães, incluindo todas as funcionalidades, serviços e interfaces associados. \"Usuário\" refere-se a qualquer pessoa que registre e use o aplicativo.\n\n2. **Aceitação dos Termos:** Ao acessar e usar o Pegada, você concorda, sem restrição ou reserva, com estes Termos de Uso. Se não concordar com qualquer parte destes termos, não deve usar o Pegada.\n\n3. **Elegibilidade:** O Pegada não possui restrições de idade para registro; no entanto, recomendamos que menores de idade obtenham o consentimento de seus responsáveis legais antes de usar o aplicativo.\n\n4. **Uso Responsável e Conteúdo do Usuário:**\n   a. Os usuários devem fornecer informações verdadeiras e precisas ao criar perfis para seus pets.\n   b. É proibido qualquer tipo de conteúdo ofensivo, discriminatório, difamatório ou que promova atividades ilegais.\n   c. O Pegada reserva-se o direito de moderar, remover ou recusar qualquer conteúdo postado pelos usuários que possa ser considerado inapropriado.\n\n5. **Segurança Infantil e Proibição de Abuso e Exploração Sexual Infantil (CSAE):** O Pegada tem tolerância zero com o abuso e a exploração sexual infantil. É estritamente proibido qualquer conteúdo, conduta ou material que sexualize, explore ou coloque em risco menores de idade, incluindo material de abuso sexual infantil (CSAM). Os usuários podem denunciar conteúdo ou comportamento que viole esta política a qualquer momento dentro do aplicativo ou entrando em contato com nossa equipe de suporte. Ao tomar conhecimento de tal conteúdo, o Pegada irá removê-lo, tomar medidas contra as contas responsáveis e reportá-lo ao National Center for Missing & Exploited Children (NCMEC) e às autoridades brasileiras competentes, conforme exigido pela legislação aplicável. Nosso ponto de contato para segurança infantil pode ser acessado em contato@gabrieltaveira.dev.\n\n6. **Privacidade e Comunicação:** Após um \"match\", os usuários podem trocar mensagens dentro da plataforma. Linguagem ofensiva, assédio ou comportamento inadequado não serão tolerados e podem resultar em ação disciplinar, incluindo a suspensão ou encerramento da conta.\n\n7. **Preferências de Match:** Os usuários têm a liberdade de definir preferências para encontrar matches para seus pets. Embora o Pegada se esforce para sugerir matches relevantes, não garantimos que todos os matches atendam às preferências definidas.\n\n8. **Limitação de Responsabilidade:** O Pegada não será responsável por qualquer lesão, perda ou dano que possa resultar de encontros organizados através do aplicativo. Todos os usuários são incentivados a exercer discernimento e precaução ao se encontrarem com outros usuários.\n\n9. **Indenização:** Você concorda em indenizar e isentar o Pegada, seus diretores, funcionários e agentes, de quaisquer reivindicações, responsabilidades, danos, perdas e despesas, incluindo, sem limitação, honorários advocatícios e custos, resultantes de ou de alguma forma relacionados ao seu uso do aplicativo.\n\n10. **Modificações:** Reservamo-nos o direito de revisar e atualizar estes Termos de Uso periodicamente, sem aviso prévio. A continuação do uso do aplicativo após tais modificações constituirá a sua aceitação dos termos revisados.\n\n11. **Legislação Aplicável e Jurisdição:** Estes Termos de Uso serão regidos e interpretados de acordo com as leis do Brasil. Qualquer litígio relacionado ao Pegada será resolvido nos tribunais competentes do Brasil.\n\n12. **Contato:** Para perguntas, dúvidas ou feedback sobre estes Termos de Uso, entre em contato com a equipe de suporte do Pegada.\n\nAo criar uma conta e usar o Pegada, você concorda com todos os termos e condições acima estabelecidos."
   },
   "deleteAccount": {
     "metadata": {
-      "title": "Pegada | Solicitar Exclusão de Conta"
+      "title": "Pegada | Solicitar exclusão de conta"
     },
     "content": "### Solicitar Exclusão de Conta\n\nPara solicitar a exclusão da conta e dos dados fora do aplicativo, envie um e-mail para [support@pegada.app](mailto:support@pegada.app) e sua solicitação será processada em breve."
   },


### PR DESCRIPTION
## Summary

The Portuguese interface was written in English title case, so labels like "Plano Atual" and "Restaurar Compras" capitalised every word. Portuguese capitalises the first word and proper nouns only, and this puts every one of those labels back to that.

## Details

- Only the Portuguese files changed. English is untouched, and so are the keys and the placeholders inside the strings.
- Product and brand names keep their capital: Pegada, Premium, Match, App Store, Google Play.
- The story card copy is left alone. It is written in lower case on purpose as part of that design.
- One typo went along for the ride: the free plan was spelled "Grátuito" and is now "Gratuito".
- No test asserts on any of these strings, so nothing in the mobile test suite needed updating. The two Portuguese strings the tests do read, "Configurações" and "Copiar", were already correct and stay as they are.
- The long legal texts on the privacy and terms pages keep their existing headings. Rewriting a legal document is a separate call from relabelling the interface.
- Hypothesis: an interface that reads as native Portuguese rather than as a translation raises trust, which shows up in satisfaction rather than in a single event.
- Baseline: none.
- Readout: none beyond review. There is no event that isolates the effect of casing, and inventing one would not be honest about what this change does.

| Before | After |
| --- | --- |
| Limite de Curtidas Diário | Limite de curtidas diário |
| Ativar Localização | Ativar localização |
| Data de Nascimento | Data de nascimento |
| Nome do Doguinho | Nome do doguinho |
| Fotinhas do Dog | Fotinhas do dog |
| Perfil do Doguinho | Perfil do doguinho |
| Salvar Perfil | Salvar perfil |
| Atualização Obrigatória | Atualização obrigatória |
| Escolher da Galeria | Escolher da galeria |
| Tirar Foto | Tirar foto |
| Encontre Dogs perto de Você | Encontre dogs perto de você |
| Confirmar Localização | Confirmar localização |
| Doguinhos Que Deram Match 🐶 | Doguinhos que deram Match 🐶 |
| Limpar Busca | Limpar busca |
| Procurar Doguinhos | Procurar doguinhos |
| Continue Deslizando | Continue deslizando |
| Enviar Mensagem | Enviar mensagem |
| Salvar Preferências | Salvar preferências |
| Grátuito | Gratuito |
| Prioridade na Fila | Prioridade na fila |
| Curtidas Ilimitadas | Curtidas ilimitadas |
| Voltar na Lista de Doguinhos | Voltar na lista de doguinhos |
| Sem Anúncios | Sem anúncios |
| Restaurar Compras | Restaurar compras |
| Plano Atual | Plano atual |
| Extra Pequeno | Extra pequeno |
| Ver Preferências | Ver preferências |
| Pegada - Aplicativo de Relacionamento para Cachorros | Pegada - Aplicativo de relacionamento para cachorros |
| Amigos Pro Seu Dog | Amigos pro seu dog |
| Política de Privacidade | Política de privacidade |
| Pegada \| Política de Privacidade | Pegada \| Política de privacidade |
| Pegada \| Termos de Uso | Pegada \| Termos de uso |
| Pegada \| Solicitar Exclusão de Conta | Pegada \| Solicitar exclusão de conta |

## Testing steps

1. Put the phone in Portuguese and open the app. The opening screen reads "Encontre dogs perto de você".
2. Go to the profile tab. The settings list reads "Plano atual", "Preferências de match" and "Editar perfil".
3. Open the plan row and go through to the upgrade screen. The top left reads "Restaurar compras" and the benefits read "Prioridade na fila", "Curtidas ilimitadas", "Voltar na lista de doguinhos" and "Sem anúncios".
4. Open the site in Portuguese. The page title in the browser tab and the headline both read in sentence case.

## Screenshots

Opening screen:

![Opening screen in Portuguese](https://raw.githubusercontent.com/GSTJ/pegada/shots/ptbr-sentence-case/shots/01-signin.png)

Profile:

![Profile screen in Portuguese](https://raw.githubusercontent.com/GSTJ/pegada/shots/ptbr-sentence-case/shots/02-profile.png)

Upgrade screen:

![Upgrade screen in Portuguese](https://raw.githubusercontent.com/GSTJ/pegada/shots/ptbr-sentence-case/shots/03-paywall.png)
