### PR TITLE
feat(api): image moderation through the AI SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,19 +44,18 @@ PUBLIC_IMAGES_BASE_URL=
 
 NODE_ENV=
 
-BUGSNAG_API_KEY=
-
-REDIS_HOST=
-REDIS_PORT=
-REDIS_PASSWORD=
-REDIS_USERNAME=
-
 EXPO_ACCESS_TOKEN=
+
+# Image moderation. `off` skips the provider call, `shadow` records a verdict
+# and publishes anyway, `enforce` lets a verdict reject a photo. The model is
+# `<provider>/<model-id>`; whichever provider it names needs its key set.
+IMAGE_MODERATION_MODE=
+IMAGE_MODERATION_MODEL=
+GOOGLE_GENERATIVE_AI_API_KEY=
+OPENAI_API_KEY=
 
 MAIL_USER=
 MAIL_NAME=
-
-SENDGRID_API_KEY=
 
 # PostHog, server (magic-observability/node for @pegada/api,
 # magic-observability/next for the site's onRequestError hook). Optional for

--- a/.env.test
+++ b/.env.test
@@ -13,7 +13,6 @@ EXPO_PUBLIC_ENV="development"
 
 # Server
 PORT=3010
-QUEUE_DEV_PORT=3009
 
 DATABASE_URL='postgresql://tony:hawk@localhost:3355/pegava'
 DIRECT_URL='postgresql://tony:hawk@localhost:3355/pegava'
@@ -25,13 +24,6 @@ AWS_SECRET_ACCESS_KEY=''
 AWS_S3_BUCKET_NAME='pegada-dev'
 AWS_REGION='sa-east-1'
 
-BUGSNAG_API_KEY=""
-
-REDIS_HOST="localhost"
-REDIS_PORT="6380"
-REDIS_PASSWORD=""
-REDIS_USERNAME="default"
-
 UPSTASH_REDIS_REST_URL="http://localhost:8078/"
 UPSTASH_REDIS_REST_TOKEN=example_token
 
@@ -39,8 +31,6 @@ EXPO_ACCESS_TOKEN=""
 
 MAIL_USER=no-reply@pegada.app
 MAIL_NAME=Pegada
-
-SENDGRID_API_KEY=""
 
 MIN_APP_VERSION="1.1.4"
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -109,7 +109,7 @@
     "superjson": "^2.2.6",
     "typesafe-actions": "^5.1.0",
     "uuid": "^11.1.1",
-    "zod": "3.23.8"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -65,8 +65,6 @@ const nextConfig = {
   // can't statically analyse — resolve them at runtime instead.
   serverExternalPackages: [
     "sharp",
-    "@tensorflow/tfjs",
-    "nsfwjs",
     "expo-server-sdk",
     "@vercel/queue",
     "cloudflare",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -39,7 +39,6 @@
     "posthog-node": "^5.39.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "redis": "^4.7.0",
     "tailwind-merge": "^2.4.0",
     "tailwindcss": "3.4.7",
     "tailwindcss-animate": "^1.0.7",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,16 +18,18 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@ai-sdk/google": "4.0.47",
+    "@ai-sdk/openai": "4.0.44",
     "@aws-sdk/client-s3": "^3.1045.0",
     "@aws-sdk/s3-request-presigner": "^3.1045.0",
     "@pegada/database": "workspace:*",
     "@pegada/shared": "workspace:*",
     "@prisma/client": "^5.17.0",
     "@smithy/node-http-handler": "^4.7.3",
-    "@tensorflow/tfjs": "^4.22.0",
     "@trpc/server": "11.0.0-rc.477",
     "@types/jest": "^29.5.12",
     "@vercel/queue": "^0.3.1",
+    "ai": "7.0.69",
     "blurhash": "^2.0.5",
     "cloudflare": "^6.5.0",
     "date-fns": "^3.6.0",
@@ -38,14 +40,13 @@
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.3",
     "magic-observability": "1.0.0",
-    "nsfwjs": "^4.3.0",
     "posthog-node": "^5.39.4",
     "semver": "^7.8.5",
     "sharp": "^0.35.3",
     "superjson": "^2.2.6",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
-    "zod": "3.23.8"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/packages/api/src/queue/enqueue.ts
+++ b/packages/api/src/queue/enqueue.ts
@@ -12,14 +12,14 @@ type EnqueueOptions = {
    * {@link ENQUEUE_MAX_ATTEMPTS}. Opt-in per call, because it is only the
    * right trade for jobs that are cheap, fast, and worth more to the user
    * than the request latency they cost — `mail` during login is the case it
-   * exists for. Never set it on `process-image` (sharp/tfjs, 120s budget) or
-   * on anything that relies on `delaySeconds`.
+   * exists for. Never set it on `process-image` (sharp plus a moderation call
+   * out to a model, 120s budget) or on anything that relies on `delaySeconds`.
    */
   fallbackInline?: boolean;
 };
 
-// Handlers are imported lazily so heavyweight consumers (sharp, tfjs) stay
-// out of the module graph of regular API routes.
+// Handlers are imported lazily so heavyweight consumers (sharp, the AI SDK)
+// stay out of the module graph of regular API routes.
 const INLINE_HANDLERS: {
   [T in Topic]: () => Promise<(payload: TopicPayloads[T]) => Promise<unknown>>;
 } = {

--- a/packages/api/src/queue/handlers/process-image.test.ts
+++ b/packages/api/src/queue/handlers/process-image.test.ts
@@ -1,19 +1,41 @@
 jest.mock("../../services/image-processing-service", () => ({
   ImageProcessingService: {
-    checkForProfanity: jest.fn().mockResolvedValue("APPROVED"),
+    moderateImage: jest
+      .fn()
+      .mockResolvedValue({ status: "APPROVED", result: null, mode: "off" }),
     createBlurhash: jest.fn().mockResolvedValue("blur"),
   },
 }));
 
 jest.mock("../../services/image-service", () => ({
-  ImageService: { updateImage: jest.fn().mockResolvedValue({}) },
+  ImageService: {
+    updateImage: jest.fn().mockResolvedValue({}),
+    getImageOwner: jest.fn().mockResolvedValue({
+      dogId: "dog-id",
+      dog: {
+        name: "Rex",
+        user: { id: "user-id", pushToken: "ExponentPushToken[abc]" },
+      },
+    }),
+  },
 }));
+
+jest.mock("../../services/push-notification-service", () => ({
+  PushNotificationService: {
+    enqueuePushNotification: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock("../../shared/analytics", () => ({ captureEvent: jest.fn() }));
 
 jest.mock("../../errors/errors", () => ({ sendError: jest.fn() }));
 
 import { ReadableStream } from "node:stream/web";
 
+import { ImageProcessingService } from "../../services/image-processing-service";
 import { ImageService } from "../../services/image-service";
+import { PushNotificationService } from "../../services/push-notification-service";
+import { captureEvent } from "../../shared/analytics";
 import { config } from "../../shared/config";
 import {
   downloadImage,
@@ -25,9 +47,39 @@ const BUCKET_URL = `https://${config.AWS_S3_BUCKET_NAME}.s3.${config.AWS_REGION}
 
 const fetchMock = jest.fn();
 
+const moderateImage = jest.mocked(ImageProcessingService.moderateImage);
+const updateImage = jest.mocked(ImageService.updateImage);
+const enqueuePushNotification = jest.mocked(
+  PushNotificationService.enqueuePushNotification,
+);
+
+const REJECTION = {
+  verdict: "reject" as const,
+  score: 0.93,
+  reason: "gore",
+  containsDog: false,
+  model: "google/gemini-2.5-flash-lite",
+  latencyMs: 512,
+  costUsdEstimate: 0.000038,
+  inputTokens: 300,
+  outputTokens: 20,
+};
+
 beforeEach(() => {
   fetchMock.mockResolvedValue(new Response(new Uint8Array(8)));
   global.fetch = fetchMock as unknown as typeof fetch;
+  moderateImage.mockResolvedValue({
+    status: "APPROVED",
+    result: null,
+    mode: "off",
+  });
+  jest.mocked(ImageService.getImageOwner).mockResolvedValue({
+    dogId: "dog-id",
+    dog: {
+      name: "Rex",
+      user: { id: "user-id", pushToken: "ExponentPushToken[abc]" },
+    },
+  } as never);
 });
 
 describe("handleProcessImage", () => {
@@ -95,6 +147,117 @@ describe("handleProcessImage", () => {
       "configured storage origin",
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes no verdict columns when no call was made", async () => {
+    await handleProcessImage({ id: "image-id", url: `${BUCKET_URL}/dogs/1` });
+
+    expect(updateImage.mock.calls[0]?.[0]).not.toHaveProperty(
+      "moderationVerdict",
+    );
+    expect(captureEvent).not.toHaveBeenCalled();
+    expect(enqueuePushNotification).not.toHaveBeenCalled();
+  });
+
+  it("records a shadow rejection, publishes the photo and pushes nobody", async () => {
+    moderateImage.mockResolvedValue({
+      status: "APPROVED",
+      result: REJECTION,
+      mode: "shadow",
+    });
+
+    await handleProcessImage({ id: "image-id", url: `${BUCKET_URL}/dogs/2` });
+
+    expect(updateImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "APPROVED",
+        moderationVerdict: "reject",
+        moderationScore: 0.93,
+        moderationReason: "gore",
+        moderationModel: "google/gemini-2.5-flash-lite",
+        moderatedAt: expect.any(Date),
+      }),
+    );
+    expect(captureEvent).toHaveBeenCalledWith(
+      "user-id",
+      "Image Moderation Result",
+      expect.objectContaining({
+        verdict: "reject",
+        mode: "shadow",
+        model: "google/gemini-2.5-flash-lite",
+        latency_ms: 512,
+        cost_usd_estimate: 0.000038,
+        reason: "gore",
+        contains_dog: false,
+        image_id: "image-id",
+        dog_id: "dog-id",
+      }),
+    );
+    expect(enqueuePushNotification).not.toHaveBeenCalled();
+  });
+
+  it("holds the photo back in enforce and tells the owner", async () => {
+    moderateImage.mockResolvedValue({
+      status: "REJECTED",
+      result: REJECTION,
+      mode: "enforce",
+    });
+
+    await handleProcessImage({ id: "image-id", url: `${BUCKET_URL}/dogs/3` });
+
+    expect(updateImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "REJECTED",
+        moderationVerdict: "reject",
+      }),
+    );
+    // A rejected image is never shown, so nothing pays to blur it.
+    expect(ImageProcessingService.createBlurhash).not.toHaveBeenCalled();
+    expect(enqueuePushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "ExponentPushToken[abc]",
+        userId: "user-id",
+        pushKind: "photo_rejected",
+        data: { url: "profile" },
+      }),
+    );
+    const [push] = enqueuePushNotification.mock.calls[0] ?? [];
+    expect(push?.title).toContain("Rex");
+    expect(push?.body).toBeTruthy();
+  });
+
+  it("skips the push when the owner has no device to send it to", async () => {
+    moderateImage.mockResolvedValue({
+      status: "REJECTED",
+      result: REJECTION,
+      mode: "enforce",
+    });
+    jest.mocked(ImageService.getImageOwner).mockResolvedValue({
+      dogId: "dog-id",
+      dog: { name: "Rex", user: { id: "user-id", pushToken: null } },
+    } as never);
+
+    await handleProcessImage({ id: "image-id", url: `${BUCKET_URL}/dogs/4` });
+
+    expect(captureEvent).toHaveBeenCalled();
+    expect(enqueuePushNotification).not.toHaveBeenCalled();
+  });
+
+  it("still saves the image when the owner lookup fails", async () => {
+    moderateImage.mockResolvedValue({
+      status: "APPROVED",
+      result: { ...REJECTION, verdict: "error", reason: "provider_error" },
+      mode: "enforce",
+    });
+    jest
+      .mocked(ImageService.getImageOwner)
+      .mockRejectedValue(new Error("database is away"));
+
+    await expect(
+      handleProcessImage({ id: "image-id", url: `${BUCKET_URL}/dogs/5` }),
+    ).resolves.toBeDefined();
+
+    expect(updateImage).toHaveBeenCalled();
   });
 
   it("follows a redirect that stays on the configured storage origin", async () => {

--- a/packages/api/src/queue/handlers/process-image.ts
+++ b/packages/api/src/queue/handlers/process-image.ts
@@ -1,11 +1,17 @@
+import type { ImageModerationOutcome } from "../../services/image-processing-service";
 import type { IProcessImageJobData } from "../topics";
 
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { MAX_IMAGE_BYTES } from "@pegada/shared/constants/constants";
+import { Language } from "@pegada/shared/i18n/types/types";
 import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
 
 import { sendError } from "../../errors/errors";
 import { ImageProcessingService } from "../../services/image-processing-service";
 import { ImageService } from "../../services/image-service";
+import { PushNotificationService } from "../../services/push-notification-service";
+import { TranslationService } from "../../services/translation-service";
+import { captureEvent } from "../../shared/analytics";
 import { assertAllowedImageUrl } from "../../shared/image-url";
 
 export { MAX_IMAGE_BYTES };
@@ -82,6 +88,88 @@ export const downloadImage = async (url: string): Promise<ArrayBuffer> => {
   return readBoundedBody(response);
 };
 
+/**
+ * The columns a verdict writes, or nothing at all when no call was made.
+ *
+ * Left untouched rather than nulled when moderation is off, so turning the
+ * feature off does not erase the history that decided whether to turn it on.
+ */
+const moderationColumns = (outcome: ImageModerationOutcome) => {
+  if (!outcome.result) return {};
+
+  return {
+    moderationVerdict: outcome.result.verdict,
+    moderationScore: outcome.result.score,
+    moderationReason: outcome.result.reason,
+    moderationModel: outcome.result.model,
+    moderatedAt: new Date(),
+  };
+};
+
+/**
+ * Report the verdict and, in `enforce`, tell the owner their photo was held
+ * back.
+ *
+ * Everything here is best effort: the image row is already written by the time
+ * this runs, and a failed analytics write or an undeliverable push must not
+ * turn a processed image into a retried job that moderates the same photo
+ * again at full price.
+ */
+const reportModeration = async (
+  image: IProcessImageJobData,
+  outcome: ImageModerationOutcome,
+) => {
+  if (!outcome.result) return;
+
+  try {
+    const owner = await ImageService.getImageOwner(image.id);
+    const user = owner?.dog.user;
+
+    captureEvent(
+      // Falls back to the image id so a verdict on an image whose dog was
+      // deleted mid-job is still counted, just not attributed to a person.
+      user?.id ?? image.id,
+      ANALYTICS_EVENTS.IMAGE_MODERATION_RESULT,
+      {
+        contains_dog: outcome.result.containsDog,
+        cost_usd_estimate: outcome.result.costUsdEstimate,
+        dog_id: owner?.dogId ?? image.dogId ?? null,
+        image_id: image.id,
+        latency_ms: outcome.result.latencyMs,
+        mode: outcome.mode,
+        model: outcome.result.model,
+        reason: outcome.result.reason,
+        verdict: outcome.result.verdict,
+      },
+    );
+
+    if (outcome.status !== IMAGE_STATUS.REJECTED) return;
+    if (!owner || !user?.pushToken) return;
+
+    await PushNotificationService.enqueuePushNotification({
+      to: user.pushToken,
+      // The queue has no request to read a language from and `User` has no
+      // language column, so this follows the re-engagement pushes and goes out
+      // in pt-BR, which is where essentially all of the users are.
+      title: TranslationService.translate(
+        "server:notification.photoRejected.title",
+        { lng: Language.PtBr, replace: { name: owner.dog.name } },
+      ),
+      body: TranslationService.translate(
+        "server:notification.photoRejected.body",
+        { lng: Language.PtBr },
+      ),
+      // The profile tab is where the photo grid is, so the tap lands on the
+      // one screen where another photo can be added.
+      data: { url: "profile" },
+      userId: user.id,
+      pushKind: "photo_rejected",
+    });
+  } catch (error) {
+    sendError(error, { image_id: image.id });
+  }
+};
+
 export const handleProcessImage = async (image: IProcessImageJobData) => {
   // The URL is validated on the way in and rebuilt from our own storage base
   // before it is persisted, so this should never fire. It is here because the
@@ -89,14 +177,14 @@ export const handleProcessImage = async (image: IProcessImageJobData) => {
   // started life in a request body.
   const arrayBuffer = await downloadImage(image.url);
 
-  const status = await ImageProcessingService.checkForProfanity({
+  const moderation = await ImageProcessingService.moderateImage({
     arrayBuffer,
   });
 
   let blurhash: string | undefined;
 
   // Blurhashes for rejected images are not needed
-  if (status === IMAGE_STATUS.APPROVED) {
+  if (moderation.status === IMAGE_STATUS.APPROVED) {
     // It's OK if this fails, we should still save the image.
     try {
       blurhash = await ImageProcessingService.createBlurhash({
@@ -107,9 +195,14 @@ export const handleProcessImage = async (image: IProcessImageJobData) => {
     }
   }
 
-  return ImageService.updateImage({
+  const updated = await ImageService.updateImage({
     ...image,
     blurhash,
-    status,
+    status: moderation.status,
+    ...moderationColumns(moderation),
   });
+
+  await reportModeration(image, moderation);
+
+  return updated;
 };

--- a/packages/api/src/queue/handlers/process-image.ts
+++ b/packages/api/src/queue/handlers/process-image.ts
@@ -179,6 +179,7 @@ export const handleProcessImage = async (image: IProcessImageJobData) => {
 
   const moderation = await ImageProcessingService.moderateImage({
     arrayBuffer,
+    imageId: image.id,
   });
 
   let blurhash: string | undefined;

--- a/packages/api/src/services/image-moderation-service.test.ts
+++ b/packages/api/src/services/image-moderation-service.test.ts
@@ -1,0 +1,297 @@
+/**
+ * The moderation service is the one place in the API that spends money per
+ * request and the one place a bug can hide someone's photo, so the cases below
+ * are the two properties that matter: it never throws, and it only ever says
+ * `reject` because the model said so.
+ */
+const config = {
+  IMAGE_MODERATION_MODE: "shadow" as string,
+  IMAGE_MODERATION_MODEL: "google/gemini-2.5-flash-lite",
+  GOOGLE_GENERATIVE_AI_API_KEY: "google-key" as string | undefined,
+  OPENAI_API_KEY: "openai-key" as string | undefined,
+};
+
+jest.mock("../shared/config", () => ({
+  config,
+  isMagicEmail: () => false,
+}));
+
+const sendError = jest.fn();
+jest.mock("../errors/errors", () => ({
+  sendError: (...args: unknown[]) => sendError(...args),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
+const generateText = jest.fn();
+jest.mock("ai", () => ({
+  generateText: (...args: unknown[]) => generateText(...args),
+  Output: { object: (options: unknown) => ({ marker: "output", options }) },
+}));
+
+const createGoogleModel = jest.fn(
+  (modelId: string) => `google-model:${modelId}`,
+);
+const createGoogleGenerativeAI = jest.fn(
+  (..._options: unknown[]) => createGoogleModel,
+);
+jest.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: (...args: unknown[]) =>
+    createGoogleGenerativeAI(...args),
+}));
+
+const createOpenAiModel = jest.fn(
+  (modelId: string) => `openai-model:${modelId}`,
+);
+const createOpenAI = jest.fn((..._options: unknown[]) => createOpenAiModel);
+jest.mock("@ai-sdk/openai", () => ({
+  createOpenAI: (...args: unknown[]) => createOpenAI(...args),
+}));
+
+import sharp from "sharp";
+
+import {
+  estimateCostUsd,
+  ImageModerationService,
+  parseModelSetting,
+} from "./image-moderation-service";
+
+/** A real JPEG, so the sharp downscale in front of the call is exercised too. */
+const makePhoto = (size = 1024) =>
+  sharp({
+    create: {
+      width: size,
+      height: size,
+      channels: 3,
+      background: { r: 120, g: 90, b: 60 },
+    },
+  })
+    .jpeg()
+    .toBuffer();
+
+const answer = (
+  output: Record<string, unknown>,
+  usage: Record<string, number> = { inputTokens: 300, outputTokens: 20 },
+) => ({ output, usage });
+
+const APPROVAL = {
+  verdict: "approve",
+  score: 0.02,
+  reason: "none",
+  containsDog: true,
+};
+
+const REJECTION = {
+  verdict: "reject",
+  score: 0.94,
+  reason: "sexual",
+  containsDog: false,
+};
+
+let photo: Buffer;
+
+beforeAll(async () => {
+  photo = await makePhoto();
+});
+
+beforeEach(() => {
+  config.IMAGE_MODERATION_MODEL = "google/gemini-2.5-flash-lite";
+  config.GOOGLE_GENERATIVE_AI_API_KEY = "google-key";
+  config.OPENAI_API_KEY = "openai-key";
+  sendError.mockClear();
+  generateText.mockResolvedValue(answer(APPROVAL));
+});
+
+describe("ImageModerationService.moderate", () => {
+  it("passes an approval straight through, with the model and its cost", async () => {
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "approve",
+      score: 0.02,
+      reason: "none",
+      containsDog: true,
+      model: "google/gemini-2.5-flash-lite",
+      inputTokens: 300,
+      outputTokens: 20,
+    });
+    // 300 in at $0.10/M plus 20 out at $0.40/M.
+    expect(result.costUsdEstimate).toBeCloseTo(0.000038, 9);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(sendError).not.toHaveBeenCalled();
+  });
+
+  it("reports a rejection with the category the model gave", async () => {
+    generateText.mockResolvedValue(answer(REJECTION));
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "reject",
+      reason: "sexual",
+      score: 0.94,
+      containsDog: false,
+    });
+  });
+
+  it("sends a downscaled JPEG rather than whatever the phone shot", async () => {
+    await ImageModerationService.moderate(photo);
+
+    const [call] = generateText.mock.calls as [
+      [
+        {
+          messages: {
+            content: { data?: Buffer; mediaType?: string; type: string }[];
+          }[];
+          maxRetries: number;
+          abortSignal: AbortSignal;
+        },
+      ],
+    ];
+    const [options] = call;
+    const file = options.messages[0]?.content.find(
+      (part) => part.type === "file",
+    );
+    const data = file?.data as Buffer;
+
+    expect(file?.mediaType).toBe("image/jpeg");
+    expect(options.maxRetries).toBe(1);
+    expect(options.abortSignal).toBeInstanceOf(AbortSignal);
+
+    const metadata = await sharp(data).metadata();
+    expect(metadata.format).toBe("jpeg");
+    expect(Math.max(metadata.width ?? 0, metadata.height ?? 0)).toBe(768);
+    expect(data.byteLength).toBeLessThan(photo.byteLength);
+  });
+
+  it("fails open when the provider throws, and reports the failure", async () => {
+    generateText.mockRejectedValue(new Error("503 from the provider"));
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "error",
+      reason: "provider_error",
+      score: null,
+      containsDog: null,
+      costUsdEstimate: null,
+    });
+    expect(sendError).toHaveBeenCalled();
+  });
+
+  it("fails open on a timeout, which reaches it as a provider error", async () => {
+    generateText.mockRejectedValue(
+      Object.assign(new Error("aborted"), { name: "AbortError" }),
+    );
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result.verdict).toBe("error");
+    expect(result.reason).toBe("provider_error");
+  });
+
+  it("fails open without calling anyone when the key is missing", async () => {
+    config.GOOGLE_GENERATIVE_AI_API_KEY = undefined;
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "error",
+      reason: "missing_api_key",
+      model: "google/gemini-2.5-flash-lite",
+    });
+    expect(generateText).not.toHaveBeenCalled();
+    // A key that was never configured is a deployment fact, not an incident.
+    expect(sendError).not.toHaveBeenCalled();
+  });
+
+  it("fails open on a model string no provider claims", async () => {
+    config.IMAGE_MODERATION_MODEL = "anthropic/claude";
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "error",
+      reason: "unsupported_model",
+    });
+    expect(generateText).not.toHaveBeenCalled();
+    expect(sendError).toHaveBeenCalled();
+  });
+
+  it("switches provider on the environment variable alone", async () => {
+    config.IMAGE_MODERATION_MODEL = "openai/gpt-5-nano";
+    generateText.mockResolvedValue(
+      answer(APPROVAL, { inputTokens: 1000, outputTokens: 100 }),
+    );
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(createOpenAI).toHaveBeenCalledWith({ apiKey: "openai-key" });
+    expect(createOpenAiModel).toHaveBeenCalledWith("gpt-5-nano");
+    expect(createGoogleGenerativeAI).not.toHaveBeenCalled();
+    expect(result.model).toBe("openai/gpt-5-nano");
+    // 1000 in at $0.05/M plus 100 out at $0.40/M.
+    expect(result.costUsdEstimate).toBeCloseTo(0.00009, 9);
+  });
+
+  it("leaves the cost null when the provider reports no usage", async () => {
+    generateText.mockResolvedValue({ output: APPROVAL, usage: undefined });
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result.verdict).toBe("approve");
+    expect(result.inputTokens).toBeNull();
+    expect(result.costUsdEstimate).toBeNull();
+  });
+});
+
+describe("estimateCostUsd", () => {
+  it("prices a known model off its published rate", () => {
+    expect(
+      estimateCostUsd({
+        modelId: "gemini-2.5-flash-lite",
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+      }),
+    ).toBeCloseTo(0.5, 9);
+  });
+
+  it("gives no number for a model it has no rate for", () => {
+    expect(
+      estimateCostUsd({
+        modelId: "gemini-9-ultra",
+        inputTokens: 100,
+        outputTokens: 10,
+      }),
+    ).toBeNull();
+  });
+
+  it("counts a missing half as zero rather than dropping the estimate", () => {
+    expect(
+      estimateCostUsd({
+        modelId: "gpt-4.1-nano",
+        inputTokens: 1_000_000,
+        outputTokens: null,
+      }),
+    ).toBeCloseTo(0.1, 9);
+  });
+});
+
+describe("parseModelSetting", () => {
+  it.each([
+    ["google/gemini-2.5-flash-lite", "google", "gemini-2.5-flash-lite"],
+    ["openai/gpt-5-nano", "openai", "gpt-5-nano"],
+    ["google/models/one/two", "google", "models/one/two"],
+  ])("splits %s on the first slash", (setting, provider, modelId) => {
+    expect(parseModelSetting(setting)).toEqual({ provider, modelId });
+  });
+
+  it.each([
+    "gemini-2.5-flash-lite",
+    "/gpt-5-nano",
+    "google/",
+    "cohere/command",
+  ])("refuses %s", (setting) => {
+    expect(parseModelSetting(setting)).toBeNull();
+  });
+});

--- a/packages/api/src/services/image-moderation-service.ts
+++ b/packages/api/src/services/image-moderation-service.ts
@@ -1,0 +1,273 @@
+import type { ImageModerationVerdict } from "@pegada/shared/analytics/events";
+import type { LanguageModel } from "ai";
+
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText, Output } from "ai";
+import sharp from "sharp";
+import { z } from "zod";
+
+import { sendError } from "../errors/errors";
+import { config } from "../shared/config";
+
+/** What the model is allowed to answer, and what the caller acts on. */
+export const MODERATION_VERDICTS = ["approve", "reject"] as const;
+
+/**
+ * Why an image was rejected, in the model's own vocabulary. `none` rides along
+ * with an approval so the schema has one shape rather than two, and `other` is
+ * the escape hatch that stops the model inventing a category.
+ */
+export const MODERATION_REASONS = [
+  "drug_paraphernalia",
+  "gore",
+  "hateful_symbol",
+  "none",
+  "nudity",
+  "other",
+  "sexual",
+  "violence",
+] as const;
+
+const moderationSchema = z.object({
+  verdict: z.enum(MODERATION_VERDICTS),
+  /** How sure the model is that the photo breaks the rules, not how sure it is. */
+  score: z.number().min(0).max(1),
+  reason: z.enum(MODERATION_REASONS),
+  containsDog: z.boolean(),
+});
+
+/**
+ * The outcome of one moderation call.
+ *
+ * `error` is a third verdict rather than a thrown exception because every
+ * caller treats a provider outage the same way: publish the photo. Folding it
+ * into the result type means the analytics event records the outage too,
+ * instead of it vanishing into a catch block.
+ */
+export type ModerationResult = {
+  verdict: ImageModerationVerdict;
+  /** 0..1 confidence that the image violates the rules. Null on `error`. */
+  score: number | null;
+  /** Short category, or the failure cause when the verdict is `error`. */
+  reason: string | null;
+  containsDog: boolean | null;
+  /** The `<provider>/<model-id>` string the call was made with. */
+  model: string;
+  latencyMs: number;
+  costUsdEstimate: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+};
+
+/**
+ * Adding a provider is one entry here plus one optional key in `config.ts`.
+ *
+ * The key is read through a function rather than captured at module load so a
+ * test can change the environment between cases, and so a missing key is a
+ * result rather than a throw from a provider constructor.
+ */
+const PROVIDERS = {
+  google: {
+    getApiKey: () => config.GOOGLE_GENERATIVE_AI_API_KEY,
+    createModel: (apiKey: string, modelId: string): LanguageModel =>
+      createGoogleGenerativeAI({ apiKey })(modelId),
+  },
+  openai: {
+    getApiKey: () => config.OPENAI_API_KEY,
+    createModel: (apiKey: string, modelId: string): LanguageModel =>
+      createOpenAI({ apiKey })(modelId),
+  },
+} as const;
+
+type ProviderName = keyof typeof PROVIDERS;
+
+const isProviderName = (value: string): value is ProviderName =>
+  Object.hasOwn(PROVIDERS, value);
+
+/**
+ * Published list prices in USD per million tokens, for the handful of models
+ * cheap enough to run on every upload. An unlisted model gives a null estimate
+ * rather than a wrong one: a cost chart that is quietly stale is worse than a
+ * cost chart with a gap.
+ */
+const RATES_USD_PER_MILLION_TOKENS: Record<
+  string,
+  { input: number; output: number }
+> = {
+  "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
+  "gpt-4.1-nano": { input: 0.1, output: 0.4 },
+  "gpt-5-nano": { input: 0.05, output: 0.4 },
+};
+
+/**
+ * Gemini bills an image as one 258-token tile while it fits in 768x768, and
+ * every other model charges less for a smaller picture too. Profile photos
+ * arrive at phone-camera resolution, so this is the difference between a
+ * fixed cost per image and one that scales with whatever the phone shot.
+ */
+const MAX_DIMENSION = 768;
+const OUTBOUND_MEDIA_TYPE = "image/jpeg";
+const TIMEOUT_MS = 15_000;
+
+const SYSTEM_PROMPT = [
+  "You moderate profile photos for a dog friendship app, where people post",
+  "pictures of their dogs to find walking companions and playdates.",
+  "",
+  "Reject a photo ONLY when it contains one of these:",
+  "- explicit sexual content or nudity",
+  "- graphic violence or gore, including injured or dead animals",
+  "- hateful symbols",
+  "- drug paraphernalia",
+  "",
+  "Approve everything else. Photos of dogs, people with dogs, people on their",
+  "own, children, homes, streets, parks, beaches, food, cars, screenshots and",
+  "blurry or badly framed pictures are all approved. A photo is not rejected",
+  "for being low quality, off topic, or for having no dog in it.",
+  "",
+  "Answer separately whether a dog is visible in the photo. That answer is for",
+  "measurement only and must not change the verdict.",
+  "",
+  "score is your confidence from 0 to 1 that the photo breaks one of the four",
+  "rules above, so an ordinary photo scores near 0 whatever the verdict says.",
+  "Use reason 'none' when you approve.",
+].join("\n");
+
+const USER_PROMPT = "Moderate this profile photo.";
+
+/**
+ * Downscale to fit the tile budget and re-encode as JPEG, which every provider
+ * accepts. `withoutEnlargement` keeps a small photo small rather than paying to
+ * upscale it.
+ */
+const prepareImage = (image: ArrayBuffer | Buffer): Promise<Buffer> =>
+  sharp(image)
+    .rotate()
+    .resize({
+      width: MAX_DIMENSION,
+      height: MAX_DIMENSION,
+      fit: "inside",
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 80 })
+    .toBuffer();
+
+/** Null unless both the rate and the token counts are known. */
+export const estimateCostUsd = ({
+  modelId,
+  inputTokens,
+  outputTokens,
+}: {
+  modelId: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+}): number | null => {
+  const rate = RATES_USD_PER_MILLION_TOKENS[modelId];
+  if (!rate) return null;
+  if (inputTokens === null && outputTokens === null) return null;
+
+  const input = ((inputTokens ?? 0) * rate.input) / 1_000_000;
+  const output = ((outputTokens ?? 0) * rate.output) / 1_000_000;
+
+  return input + output;
+};
+
+/** `<provider>/<model-id>`, where the model id may itself contain slashes. */
+export const parseModelSetting = (setting: string) => {
+  const separator = setting.indexOf("/");
+  if (separator <= 0) return null;
+
+  const provider = setting.slice(0, separator);
+  const modelId = setting.slice(separator + 1);
+  if (!modelId || !isProviderName(provider)) return null;
+
+  return { provider, modelId };
+};
+
+const finiteOrNull = (value: number | undefined) =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
+
+export class ImageModerationService {
+  /**
+   * Ask the configured model whether one photo is publishable.
+   *
+   * Never throws. A bad configuration, a timeout, a provider outage and a
+   * response that does not match the schema all come back as verdict `error`,
+   * because the alternative is a queue job that retries forever and a photo
+   * that never leaves PENDING.
+   */
+  static async moderate(
+    image: ArrayBuffer | Buffer,
+    mediaType = OUTBOUND_MEDIA_TYPE,
+  ): Promise<ModerationResult> {
+    const setting = config.IMAGE_MODERATION_MODEL;
+    const startedAt = Date.now();
+
+    const failure = (reason: string): ModerationResult => ({
+      verdict: "error",
+      score: null,
+      reason,
+      containsDog: null,
+      model: setting,
+      latencyMs: Date.now() - startedAt,
+      costUsdEstimate: null,
+      inputTokens: null,
+      outputTokens: null,
+    });
+
+    const parsed = parseModelSetting(setting);
+    if (!parsed) {
+      sendError(new Error(`Unsupported image moderation model: ${setting}`));
+      return failure("unsupported_model");
+    }
+
+    const provider = PROVIDERS[parsed.provider];
+    const apiKey = provider.getApiKey();
+    if (!apiKey) return failure("missing_api_key");
+
+    try {
+      const data = await prepareImage(image);
+
+      const result = await generateText({
+        model: provider.createModel(apiKey, parsed.modelId),
+        output: Output.object({ schema: moderationSchema }),
+        system: SYSTEM_PROMPT,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: USER_PROMPT },
+              { type: "file", mediaType, data },
+            ],
+          },
+        ],
+        // One retry, then give up: this runs inside an image job with its own
+        // retry, and a slow moderation call is a photo the owner is waiting on.
+        maxRetries: 1,
+        abortSignal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+
+      const inputTokens = finiteOrNull(result.usage?.inputTokens);
+      const outputTokens = finiteOrNull(result.usage?.outputTokens);
+
+      return {
+        verdict: result.output.verdict,
+        score: result.output.score,
+        reason: result.output.reason,
+        containsDog: result.output.containsDog,
+        model: setting,
+        latencyMs: Date.now() - startedAt,
+        costUsdEstimate: estimateCostUsd({
+          modelId: parsed.modelId,
+          inputTokens,
+          outputTokens,
+        }),
+        inputTokens,
+        outputTokens,
+      };
+    } catch (error) {
+      sendError(error, { image_moderation_model: setting });
+      return failure("provider_error");
+    }
+  }
+}

--- a/packages/api/src/services/image-moderation-service.ts
+++ b/packages/api/src/services/image-moderation-service.ts
@@ -198,7 +198,6 @@ export class ImageModerationService {
    */
   static async moderate(
     image: ArrayBuffer | Buffer,
-    mediaType = OUTBOUND_MEDIA_TYPE,
   ): Promise<ModerationResult> {
     const setting = config.IMAGE_MODERATION_MODEL;
     const startedAt = Date.now();
@@ -237,7 +236,9 @@ export class ImageModerationService {
             role: "user",
             content: [
               { type: "text", text: USER_PROMPT },
-              { type: "file", mediaType, data },
+              // Always the type `prepareImage` re-encodes to, whatever the
+              // phone uploaded.
+              { type: "file", mediaType: OUTBOUND_MEDIA_TYPE, data },
             ],
           },
         ],

--- a/packages/api/src/services/image-processing-service.test.ts
+++ b/packages/api/src/services/image-processing-service.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The gate in front of the provider. Two switches have to agree before a photo
+ * costs anything, and only one of the three modes is allowed to reject, so
+ * these are the cases that decide whether a rollout is reversible.
+ */
+const config = { IMAGE_MODERATION_MODE: "off" as string };
+
+jest.mock("../shared/config", () => ({
+  config,
+  isMagicEmail: () => false,
+}));
+
+const isFeatureEnabled = jest.fn();
+jest.mock("./flag-service", () => ({
+  FEATURES: {
+    PROFANITY_CHECK: "profanity_check",
+    IMAGE_BLURHASH: "image_blurhash",
+  },
+  FlagService: {
+    isFeatureEnabled: (...args: unknown[]) => isFeatureEnabled(...args),
+  },
+}));
+
+const moderate = jest.fn();
+jest.mock("./image-moderation-service", () => ({
+  ImageModerationService: {
+    moderate: (...args: unknown[]) => moderate(...args),
+  },
+}));
+
+import { ImageProcessingService } from "./image-processing-service";
+
+const arrayBuffer = new ArrayBuffer(8);
+
+const verdict = (value: "approve" | "error" | "reject") => ({
+  verdict: value,
+  score: value === "reject" ? 0.9 : 0.01,
+  reason: value === "reject" ? "gore" : "none",
+  containsDog: true,
+  model: "google/gemini-2.5-flash-lite",
+  latencyMs: 420,
+  costUsdEstimate: 0.00004,
+  inputTokens: 300,
+  outputTokens: 20,
+});
+
+beforeEach(() => {
+  isFeatureEnabled.mockResolvedValue(true);
+  moderate.mockResolvedValue(verdict("approve"));
+});
+
+describe("ImageProcessingService.moderateImage", () => {
+  it("calls nobody while the mode is off, whatever the flag says", async () => {
+    config.IMAGE_MODERATION_MODE = "off";
+
+    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+
+    expect(outcome).toEqual({ status: "APPROVED", result: null, mode: "off" });
+    expect(moderate).not.toHaveBeenCalled();
+    expect(isFeatureEnabled).not.toHaveBeenCalled();
+  });
+
+  it("calls nobody while the flag is off, whatever the mode says", async () => {
+    config.IMAGE_MODERATION_MODE = "enforce";
+    isFeatureEnabled.mockResolvedValue(false);
+
+    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+
+    expect(outcome).toEqual({
+      status: "APPROVED",
+      result: null,
+      mode: "enforce",
+    });
+    expect(moderate).not.toHaveBeenCalled();
+  });
+
+  it("defaults the flag to off, so an unreachable PostHog spends nothing", async () => {
+    config.IMAGE_MODERATION_MODE = "shadow";
+
+    await ImageProcessingService.moderateImage({ arrayBuffer });
+
+    expect(isFeatureEnabled).toHaveBeenCalledWith({
+      feature: "profanity_check",
+      defaultValue: false,
+    });
+  });
+
+  it("keeps a rejection out of the status in shadow, but keeps the verdict", async () => {
+    config.IMAGE_MODERATION_MODE = "shadow";
+    moderate.mockResolvedValue(verdict("reject"));
+
+    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+
+    expect(outcome.status).toBe("APPROVED");
+    expect(outcome.result).toMatchObject({ verdict: "reject", reason: "gore" });
+    expect(outcome.mode).toBe("shadow");
+  });
+
+  it("rejects in enforce, which is the only mode that can", async () => {
+    config.IMAGE_MODERATION_MODE = "enforce";
+    moderate.mockResolvedValue(verdict("reject"));
+
+    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+
+    expect(outcome.status).toBe("REJECTED");
+    expect(outcome.result?.verdict).toBe("reject");
+  });
+
+  it("publishes on a provider error even in enforce", async () => {
+    config.IMAGE_MODERATION_MODE = "enforce";
+    moderate.mockResolvedValue(verdict("error"));
+
+    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+
+    expect(outcome.status).toBe("APPROVED");
+    expect(outcome.result?.verdict).toBe("error");
+  });
+
+  it("publishes an approval in enforce", async () => {
+    config.IMAGE_MODERATION_MODE = "enforce";
+
+    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+
+    expect(outcome.status).toBe("APPROVED");
+    expect(moderate).toHaveBeenCalledWith(arrayBuffer);
+  });
+});

--- a/packages/api/src/services/image-processing-service.test.ts
+++ b/packages/api/src/services/image-processing-service.test.ts
@@ -28,9 +28,18 @@ jest.mock("./image-moderation-service", () => ({
   },
 }));
 
+const getStoredModerationVerdict = jest.fn();
+jest.mock("./image-service", () => ({
+  ImageService: {
+    getStoredModerationVerdict: (...args: unknown[]) =>
+      getStoredModerationVerdict(...args),
+  },
+}));
+
 import { ImageProcessingService } from "./image-processing-service";
 
 const arrayBuffer = new ArrayBuffer(8);
+const imageId = "image-id";
 
 const verdict = (value: "approve" | "error" | "reject") => ({
   verdict: value,
@@ -47,13 +56,17 @@ const verdict = (value: "approve" | "error" | "reject") => ({
 beforeEach(() => {
   isFeatureEnabled.mockResolvedValue(true);
   moderate.mockResolvedValue(verdict("approve"));
+  getStoredModerationVerdict.mockResolvedValue({ moderationVerdict: null });
 });
 
 describe("ImageProcessingService.moderateImage", () => {
   it("calls nobody while the mode is off, whatever the flag says", async () => {
     config.IMAGE_MODERATION_MODE = "off";
 
-    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
 
     expect(outcome).toEqual({ status: "APPROVED", result: null, mode: "off" });
     expect(moderate).not.toHaveBeenCalled();
@@ -64,7 +77,10 @@ describe("ImageProcessingService.moderateImage", () => {
     config.IMAGE_MODERATION_MODE = "enforce";
     isFeatureEnabled.mockResolvedValue(false);
 
-    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
 
     expect(outcome).toEqual({
       status: "APPROVED",
@@ -77,7 +93,7 @@ describe("ImageProcessingService.moderateImage", () => {
   it("defaults the flag to off, so an unreachable PostHog spends nothing", async () => {
     config.IMAGE_MODERATION_MODE = "shadow";
 
-    await ImageProcessingService.moderateImage({ arrayBuffer });
+    await ImageProcessingService.moderateImage({ arrayBuffer, imageId });
 
     expect(isFeatureEnabled).toHaveBeenCalledWith({
       feature: "profanity_check",
@@ -89,7 +105,10 @@ describe("ImageProcessingService.moderateImage", () => {
     config.IMAGE_MODERATION_MODE = "shadow";
     moderate.mockResolvedValue(verdict("reject"));
 
-    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
 
     expect(outcome.status).toBe("APPROVED");
     expect(outcome.result).toMatchObject({ verdict: "reject", reason: "gore" });
@@ -100,7 +119,10 @@ describe("ImageProcessingService.moderateImage", () => {
     config.IMAGE_MODERATION_MODE = "enforce";
     moderate.mockResolvedValue(verdict("reject"));
 
-    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
 
     expect(outcome.status).toBe("REJECTED");
     expect(outcome.result?.verdict).toBe("reject");
@@ -110,7 +132,10 @@ describe("ImageProcessingService.moderateImage", () => {
     config.IMAGE_MODERATION_MODE = "enforce";
     moderate.mockResolvedValue(verdict("error"));
 
-    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
 
     expect(outcome.status).toBe("APPROVED");
     expect(outcome.result?.verdict).toBe("error");
@@ -119,9 +144,40 @@ describe("ImageProcessingService.moderateImage", () => {
   it("publishes an approval in enforce", async () => {
     config.IMAGE_MODERATION_MODE = "enforce";
 
-    const outcome = await ImageProcessingService.moderateImage({ arrayBuffer });
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
 
     expect(outcome.status).toBe("APPROVED");
     expect(moderate).toHaveBeenCalledWith(arrayBuffer);
+  });
+
+  it("reuses a verdict the row already carries instead of paying twice", async () => {
+    config.IMAGE_MODERATION_MODE = "enforce";
+    getStoredModerationVerdict.mockResolvedValue({
+      moderationVerdict: "reject",
+    });
+
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
+
+    // The status still comes out REJECTED, so a redelivered job cannot quietly
+    // republish a photo that was already held back.
+    expect(outcome.status).toBe("REJECTED");
+    // Null keeps the caller from rewriting the columns, recounting the event or
+    // sending the owner a second push.
+    expect(outcome.result).toBeNull();
+    expect(moderate).not.toHaveBeenCalled();
+  });
+
+  it("does not look up a stored verdict when it would not call anyone", async () => {
+    config.IMAGE_MODERATION_MODE = "off";
+
+    await ImageProcessingService.moderateImage({ arrayBuffer, imageId });
+
+    expect(getStoredModerationVerdict).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/services/image-processing-service.ts
+++ b/packages/api/src/services/image-processing-service.ts
@@ -9,14 +9,26 @@ import sharp from "sharp";
 import { config } from "../shared/config";
 import { FEATURES, FlagService } from "./flag-service";
 import { ImageModerationService } from "./image-moderation-service";
+import { ImageService } from "./image-service";
 
 export type ImageModerationOutcome = {
   /** What to write to `Image.status`. */
   status: ImageStatus;
-  /** Null when no call was made, which is the only case worth not charting. */
+  /**
+   * The verdict this run produced, or null when no call was made. Null covers
+   * both a photo nobody moderated and a redelivered job reusing a verdict that
+   * is already on the row, which is exactly the set of cases that must not be
+   * written, charted or pushed about a second time.
+   */
   result: ModerationResult | null;
   mode: ImageModerationMode;
 };
+
+/** Only `enforce` can turn a rejection into a status. */
+const statusFor = (mode: ImageModerationMode, verdict: string) =>
+  mode === "enforce" && verdict === "reject"
+    ? IMAGE_STATUS.REJECTED
+    : IMAGE_STATUS.APPROVED;
 
 export class ImageProcessingService {
   /**
@@ -28,13 +40,15 @@ export class ImageProcessingService {
    * PostHog flag, which is the runtime kill switch. Either one off means no
    * call, no cost, and the same APPROVED the old path produced.
    *
-   * Only `enforce` can reject. An `error` verdict approves in every mode: a
-   * provider outage must not be able to hold back everyone's photos at once.
+   * An `error` verdict approves in every mode: a provider outage must not be
+   * able to hold back everyone's photos at once.
    */
   static moderateImage = async ({
     arrayBuffer,
+    imageId,
   }: {
     arrayBuffer: ArrayBuffer;
+    imageId: string;
   }): Promise<ImageModerationOutcome> => {
     const mode = config.IMAGE_MODERATION_MODE;
     const skipped: ImageModerationOutcome = {
@@ -52,14 +66,24 @@ export class ImageProcessingService {
 
     if (!isModerationEnabled) return skipped;
 
+    // The queue delivers at least once, and the job can also be retried after
+    // the write that follows this call fails. A row that already carries a
+    // verdict has already been paid for, so the redelivery re-derives the
+    // status from it instead of buying a second opinion. The read only happens
+    // on jobs that would otherwise call a provider, so the `off` path is still
+    // a single query.
+    const stored = await ImageService.getStoredModerationVerdict(imageId);
+    if (stored?.moderationVerdict) {
+      return {
+        status: statusFor(mode, stored.moderationVerdict),
+        result: null,
+        mode,
+      };
+    }
+
     const result = await ImageModerationService.moderate(arrayBuffer);
 
-    const status =
-      mode === "enforce" && result.verdict === "reject"
-        ? IMAGE_STATUS.REJECTED
-        : IMAGE_STATUS.APPROVED;
-
-    return { status, result, mode };
+    return { status: statusFor(mode, result.verdict), result, mode };
   };
 
   static async createBlurhash({ arrayBuffer }: { arrayBuffer: ArrayBuffer }) {

--- a/packages/api/src/services/image-processing-service.ts
+++ b/packages/api/src/services/image-processing-service.ts
@@ -1,61 +1,65 @@
+import type { ModerationResult } from "./image-moderation-service";
+import type { ImageModerationMode } from "@pegada/shared/analytics/events";
+import type { ImageStatus } from "@prisma/client";
+
 import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
 import { encode as encodeBlurhash } from "blurhash";
 import sharp from "sharp";
 
+import { config } from "../shared/config";
 import { FEATURES, FlagService } from "./flag-service";
+import { ImageModerationService } from "./image-moderation-service";
+
+export type ImageModerationOutcome = {
+  /** What to write to `Image.status`. */
+  status: ImageStatus;
+  /** Null when no call was made, which is the only case worth not charting. */
+  result: ModerationResult | null;
+  mode: ImageModerationMode;
+};
 
 export class ImageProcessingService {
-  static checkForProfanity = async ({
+  /**
+   * Decide whether a freshly uploaded photo can be published.
+   *
+   * Two independent switches have to agree before a provider is called: the
+   * `IMAGE_MODERATION_MODE` environment variable, which is a deploy-time
+   * decision about how far the feature is turned up, and the `profanity_check`
+   * PostHog flag, which is the runtime kill switch. Either one off means no
+   * call, no cost, and the same APPROVED the old path produced.
+   *
+   * Only `enforce` can reject. An `error` verdict approves in every mode: a
+   * provider outage must not be able to hold back everyone's photos at once.
+   */
+  static moderateImage = async ({
     arrayBuffer,
-    threshold = 0.7,
   }: {
     arrayBuffer: ArrayBuffer;
-    threshold?: number;
-  }) => {
-    const isProfanityCheckEnabled = await FlagService.isFeatureEnabled({
+  }): Promise<ImageModerationOutcome> => {
+    const mode = config.IMAGE_MODERATION_MODE;
+    const skipped: ImageModerationOutcome = {
+      status: IMAGE_STATUS.APPROVED,
+      result: null,
+      mode,
+    };
+
+    if (mode === "off") return skipped;
+
+    const isModerationEnabled = await FlagService.isFeatureEnabled({
       feature: FEATURES.PROFANITY_CHECK,
       defaultValue: false,
     });
 
-    // In case this isn't working as intended or consuming too much bandwidth
-    if (!isProfanityCheckEnabled) {
-      return IMAGE_STATUS.APPROVED;
-    }
+    if (!isModerationEnabled) return skipped;
 
-    // Pure-JS tfjs instead of tfjs-node: the consumer runs in a Vercel
-    // function where native bindings can't load. Lazy imports keep the
-    // model out of every other route's cold start.
-    const [tf, nsfwjs] = await Promise.all([
-      import("@tensorflow/tfjs"),
-      import("nsfwjs"),
-    ]);
+    const result = await ImageModerationService.moderate(arrayBuffer);
 
-    const { data, info } = await sharp(arrayBuffer)
-      .resize({ height: 300, withoutEnlargement: true })
-      .removeAlpha()
-      .raw()
-      .toBuffer({ resolveWithObject: true });
+    const status =
+      mode === "enforce" && result.verdict === "reject"
+        ? IMAGE_STATUS.REJECTED
+        : IMAGE_STATUS.APPROVED;
 
-    const imageTensor = tf.tensor3d(
-      new Int32Array(data),
-      [info.height, info.width, 3],
-      "int32",
-    );
-
-    try {
-      const model = await nsfwjs.load("MobileNetV2");
-      const predictions = await model.classify(imageTensor as never);
-
-      const isNotSafe = predictions.some(
-        (prediction) =>
-          prediction.className !== "Neutral" &&
-          prediction.probability > threshold,
-      );
-
-      return isNotSafe ? IMAGE_STATUS.REJECTED : IMAGE_STATUS.APPROVED;
-    } finally {
-      imageTensor.dispose();
-    }
+    return { status, result, mode };
   };
 
   static async createBlurhash({ arrayBuffer }: { arrayBuffer: ArrayBuffer }) {

--- a/packages/api/src/services/image-service.ts
+++ b/packages/api/src/services/image-service.ts
@@ -201,6 +201,19 @@ export class ImageService {
   }
 
   /**
+   * The verdict already on an image, if there is one.
+   *
+   * Read before the image job calls a provider so a redelivered job reuses what
+   * was already paid for.
+   */
+  static getStoredModerationVerdict(id: string) {
+    return prisma.image.findUnique({
+      where: { id },
+      select: { moderationVerdict: true },
+    });
+  }
+
+  /**
    * The dog and the person behind one image, for the image job.
    *
    * The job payload carries the image row as it was enqueued and nothing about

--- a/packages/api/src/services/image-service.ts
+++ b/packages/api/src/services/image-service.ts
@@ -200,6 +200,29 @@ export class ImageService {
     });
   }
 
+  /**
+   * The dog and the person behind one image, for the image job.
+   *
+   * The job payload carries the image row as it was enqueued and nothing about
+   * who owns it, and both things that happen after a verdict need the owner:
+   * the analytics event is attributed to them, and the rejection push goes to
+   * their device.
+   */
+  static getImageOwner(id: string) {
+    return prisma.image.findUnique({
+      where: { id },
+      select: {
+        dogId: true,
+        dog: {
+          select: {
+            name: true,
+            user: { select: { id: true, pushToken: true } },
+          },
+        },
+      },
+    });
+  }
+
   static updateImage({ id, ...data }: Partial<Image> & { id: string }) {
     return prisma.image.update({
       where: { id },

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -82,6 +82,31 @@ const configSchema = z.object({
   EXPO_ACCESS_TOKEN: z.string().optional(),
 
   /**
+   * IMAGE MODERATION
+   *
+   * `off` skips the provider call entirely. `shadow` calls it, records the
+   * verdict and publishes the photo anyway, which is how the false positive
+   * rate gets measured before anyone's photo is held back. `enforce` is the
+   * only mode where a verdict can reject an image.
+   *
+   * Default `off` so a fresh clone, the test suite and any environment that
+   * has not been given a provider key behave exactly as they did before.
+   */
+  IMAGE_MODERATION_MODE: z.enum(["off", "shadow", "enforce"]).default("off"),
+  /**
+   * `<provider>/<model-id>`, resolved in `image-moderation-service.ts`.
+   * Swapping providers is an environment change rather than a deploy.
+   */
+  IMAGE_MODERATION_MODEL: z.string().default("google/gemini-2.5-flash-lite"),
+  /**
+   * Provider keys, both optional: whichever one the configured model needs
+   * has to be set, and a missing key is reported as a moderation error rather
+   * than a boot failure, so an unset key never takes the API down.
+   */
+  GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
+  OPENAI_API_KEY: z.string().optional(),
+
+  /**
    * CRON
    *
    * Vercel Cron sends `Authorization: Bearer ${CRON_SECRET}` on every

--- a/packages/database/migrations/20260902200000_add_image_moderation_verdict/migration.sql
+++ b/packages/database/migrations/20260902200000_add_image_moderation_verdict/migration.sql
@@ -1,0 +1,10 @@
+-- Records what the moderation model said, alongside rather than inside
+-- "status": in shadow mode "status" stays APPROVED while these columns hold the
+-- verdict enforcement would have acted on. All nullable, so every existing row
+-- keeps meaning "not moderated" without a backfill.
+ALTER TABLE "Image"
+ADD COLUMN "moderationVerdict" TEXT,
+ADD COLUMN "moderationScore" DOUBLE PRECISION,
+ADD COLUMN "moderationReason" TEXT,
+ADD COLUMN "moderationModel" TEXT,
+ADD COLUMN "moderatedAt" TIMESTAMP(3);

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^8.4.1",
-    "zod": "3.23.8"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@paralleldrive/cuid2": "^2.2.2",

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -57,16 +57,16 @@ model User {
   dogs             Dog[]
   featureInterests FeatureInterest[]
   // Location
-  city             String?
-  state            String?
-  country          String?
-  latitude         Float?
-  longitude        Float?
-  code             String?
-  codeExpiresAt    DateTime?
+  city          String?
+  state         String?
+  country       String?
+  latitude      Float?
+  longitude     Float?
+  code          String?
+  codeExpiresAt DateTime?
 
   // Push notifications
-  pushToken               String?
+  pushToken String?
   newDogsAlertRequestedAt DateTime?
 
   // Metadata
@@ -80,7 +80,7 @@ model User {
   lastActiveAt DateTime?
 
   // Plan
-  plan         PlanType  @default(FREE)
+  plan PlanType @default(FREE)
   // Latest paid-through date reported by the store. `plan` stays the
   // entitlement source of truth; this is only for churn reporting.
   premiumUntil DateTime?
@@ -269,10 +269,10 @@ model UploadGrant {
   id String @id @default(cuid())
 
   userId       String
-  temporaryUrl String  @unique
+  temporaryUrl String @unique
   permanentUrl String?
 
-  expiresAt  DateTime
+  expiresAt DateTime
   consumedAt DateTime?
   cleanedAt  DateTime?
   createdAt  DateTime  @default(now())
@@ -328,9 +328,9 @@ model Interest {
   matchId String? @unique(map: "interest_matchid_key")
   match   Match?  @relation(fields: [matchId], references: [id])
 
-  @@unique([requesterId, responderId], map: "interest_requester_responder_key")
   @@index([responderId], map: "interest_responderid_idx")
   @@index([requesterId], map: "interest_requesterid_idx")
+  @@unique([requesterId, responderId], map: "interest_requester_responder_key")
   @@index([requesterId, lastPositiveAt])
   @@index([updatedAt])
   @@index([deletedAt])

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -57,16 +57,16 @@ model User {
   dogs             Dog[]
   featureInterests FeatureInterest[]
   // Location
-  city          String?
-  state         String?
-  country       String?
-  latitude      Float?
-  longitude     Float?
-  code          String?
-  codeExpiresAt DateTime?
+  city             String?
+  state            String?
+  country          String?
+  latitude         Float?
+  longitude        Float?
+  code             String?
+  codeExpiresAt    DateTime?
 
   // Push notifications
-  pushToken String?
+  pushToken               String?
   newDogsAlertRequestedAt DateTime?
 
   // Metadata
@@ -80,7 +80,7 @@ model User {
   lastActiveAt DateTime?
 
   // Plan
-  plan PlanType @default(FREE)
+  plan         PlanType  @default(FREE)
   // Latest paid-through date reported by the store. `plan` stays the
   // entitlement source of truth; this is only for churn reporting.
   premiumUntil DateTime?
@@ -240,6 +240,22 @@ model Image {
 
   position Int
 
+  /// What the moderation model said about this image, kept apart from `status`
+  /// on purpose. In shadow mode `status` is APPROVED while these columns record
+  /// what enforcement would have done, which is the only way to measure the
+  /// false positive rate before a single photo is held back. Null means the
+  /// image predates moderation or was uploaded while the mode was `off`.
+  moderationVerdict String?
+  /// 0..1 confidence that the image violates the guidelines.
+  moderationScore   Float?
+  /// Short category such as `sexual` or `gore`, or the failure cause when the
+  /// verdict is `error`.
+  moderationReason  String?
+  /// The `<provider>/<model-id>` the verdict came from, so a change of model
+  /// does not silently mix two populations in the same chart.
+  moderationModel   String?
+  moderatedAt       DateTime?
+
   @@index([dogId], map: "image_dogid_idx")
   // The swipe deck's shadow-ban gate runs `EXISTS (dogId = ? AND status =
   // 'APPROVED')` and `NOT EXISTS (dogId = ? AND status = 'REJECTED')` once per
@@ -253,10 +269,10 @@ model UploadGrant {
   id String @id @default(cuid())
 
   userId       String
-  temporaryUrl String @unique
+  temporaryUrl String  @unique
   permanentUrl String?
 
-  expiresAt DateTime
+  expiresAt  DateTime
   consumedAt DateTime?
   cleanedAt  DateTime?
   createdAt  DateTime  @default(now())
@@ -312,9 +328,9 @@ model Interest {
   matchId String? @unique(map: "interest_matchid_key")
   match   Match?  @relation(fields: [matchId], references: [id])
 
+  @@unique([requesterId, responderId], map: "interest_requester_responder_key")
   @@index([responderId], map: "interest_responderid_idx")
   @@index([requesterId], map: "interest_requesterid_idx")
-  @@unique([requesterId, responderId], map: "interest_requester_responder_key")
   @@index([requesterId, lastPositiveAt])
   @@index([updatedAt])
   @@index([deletedAt])

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -37,6 +37,7 @@ export const ANALYTICS_EVENTS = {
   FAKE_DOOR_SHOWN: "Fake Door Shown",
   FAKE_DOOR_TAPPED: "Fake Door Tapped",
   FEEDBACK: "Feedback",
+  IMAGE_MODERATION_RESULT: "Image Moderation Result",
   INVALID_OTP_TYPED: "User Typed Invalid OTP code",
   LIKE_LIMIT_REACHED: "Like Limit Reached",
   LOCATION_PERMISSION: "Location Permission",
@@ -134,10 +135,15 @@ export type ReengagementPushKind =
 
 /**
  * What a push was for, across every path that sends one: the three scheduled
- * nudges plus the three transactional ones. One vocabulary so the delivery
- * events below break down by the same property whoever sent the push.
+ * nudges plus the transactional ones. One vocabulary so the delivery events
+ * below break down by the same property whoever sent the push.
  */
-export type PushKind = ReengagementPushKind | "like" | "match" | "message";
+export type PushKind =
+  | ReengagementPushKind
+  | "like"
+  | "match"
+  | "message"
+  | "photo_rejected";
 
 /**
  * Expo's answer about one push, at whichever of the two checkpoints asked.
@@ -205,6 +211,21 @@ export type FakeDoorFeature = "ai_story_video" | "referral_reward";
  * be added without splitting the funnel across event names.
  */
 export type FakeDoorSource = "share_sheet";
+
+/**
+ * How far image moderation is turned up, mirroring `IMAGE_MODERATION_MODE` in
+ * `packages/api/src/shared/config.ts`. Restated here rather than imported for
+ * the same reason the RevenueCat unions further down are: `@pegada/shared` is a
+ * dependency of `@pegada/api`, so importing back the other way would be a cycle.
+ */
+export type ImageModerationMode = "enforce" | "off" | "shadow";
+
+/**
+ * What the model said. `error` is a verdict rather than a missing event: the
+ * photo is published either way, and an outage that is not counted is an outage
+ * nobody notices.
+ */
+export type ImageModerationVerdict = "approve" | "error" | "reject";
 
 /**
  * Event name to property shape, for events sent from the app.
@@ -414,6 +435,29 @@ export type SubscriptionCancelReason =
  * apart by the properties each carries.
  */
 export type ServerEventProperties = {
+  /**
+   * One row per photo the moderation model looked at.
+   *
+   * `mode` is the property the whole rollout hangs on: the same verdict means
+   * "would have rejected" in shadow and "did reject" in enforce, and without it
+   * the two populations sit in one series and neither can be read. `verdict`
+   * includes `error`, so a provider outage shows up as a shape change in the
+   * distribution rather than as a gap.
+   */
+  [ANALYTICS_EVENTS.IMAGE_MODERATION_RESULT]: {
+    /** Null when the model did not answer, which is every `error`. */
+    contains_dog: boolean | null;
+    cost_usd_estimate: number | null;
+    dog_id: string | null;
+    image_id: string;
+    latency_ms: number;
+    mode: ImageModerationMode;
+    /** The `<provider>/<model-id>` the verdict came from. */
+    model: string;
+    /** Short category on a rejection, or the failure cause on an error. */
+    reason: string | null;
+    verdict: ImageModerationVerdict;
+  };
   [ANALYTICS_EVENTS.MATCH_CREATED]: {
     match_id: string;
     other_user_id: string;
@@ -607,6 +651,7 @@ export const MOBILE_EVENT_NAMES = [
 ] as const;
 
 export const SERVER_EVENT_NAMES = [
+  ANALYTICS_EVENTS.IMAGE_MODERATION_RESULT,
   ANALYTICS_EVENTS.MATCH_CREATED,
   ANALYTICS_EVENTS.MESSAGE_SENT,
   ANALYTICS_EVENTS.PUSH_RECEIPT_RESULT,

--- a/packages/shared/i18n/locales/en/server.json
+++ b/packages/shared/i18n/locales/en/server.json
@@ -17,6 +17,10 @@
       "title": "🐶 {{name}} received a like! 🩷",
       "body": "Search for the misterious admirer 🕵️‍♂️"
     },
+    "photoRejected": {
+      "title": "A photo of {{name}} was not approved",
+      "body": "It does not follow our community guidelines. You can add another one to the profile"
+    },
     "reengagement": {
       "unansweredMatch": {
         "title": "🐶 {{name}} is still waiting",

--- a/packages/shared/i18n/locales/pt-BR/server.json
+++ b/packages/shared/i18n/locales/pt-BR/server.json
@@ -17,6 +17,10 @@
       "title": "🐶 {{name}} recebeu um like! 🩷",
       "body": "Vem procurar o pretendente misterioso 🕵️‍♂️"
     },
+    "photoRejected": {
+      "title": "Uma foto do {{name}} não foi aprovada",
+      "body": "Ela não segue as nossas diretrizes da comunidade. Você pode adicionar outra no perfil"
+    },
     "reengagement": {
       "unansweredMatch": {
         "title": "🐶 {{name}} ainda está esperando",

--- a/packages/shared/i18n/locales/pt-BR/server.json
+++ b/packages/shared/i18n/locales/pt-BR/server.json
@@ -18,8 +18,8 @@
       "body": "Vem procurar o pretendente misterioso 🕵️‍♂️"
     },
     "photoRejected": {
-      "title": "Uma foto do {{name}} não foi aprovada",
-      "body": "Ela não segue as nossas diretrizes da comunidade. Você pode adicionar outra no perfil"
+      "title": "Uma foto de {{name}} não foi aprovada",
+      "body": "Ela não segue nossas diretrizes da comunidade. Você pode adicionar outra no perfil"
     },
     "reengagement": {
       "unansweredMatch": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,7 @@
     "@total-typescript/ts-reset": "^0.5.1",
     "i18next": "^23.12.2",
     "magic-tsconfig": "^1.2.0",
-    "zod": "3.23.8"
+    "zod": "3.25.76"
   },
   "peerDependencies": {
     "i18next": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,9 +491,6 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
-      redis:
-        specifier: ^4.7.0
-        version: 4.7.0
       tailwind-merge:
         specifier: ^2.4.0
         version: 2.4.0
@@ -525,6 +522,12 @@ importers:
 
   packages/api:
     dependencies:
+      '@ai-sdk/google':
+        specifier: 4.0.47
+        version: 4.0.47(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: 4.0.44
+        version: 4.0.44(zod@3.25.76)
       '@aws-sdk/client-s3':
         specifier: ^3.1045.0
         version: 3.1049.0
@@ -543,9 +546,6 @@ importers:
       '@smithy/node-http-handler':
         specifier: ^4.7.3
         version: 4.7.3
-      '@tensorflow/tfjs':
-        specifier: ^4.22.0
-        version: 4.22.0(seedrandom@3.0.5)
       '@trpc/server':
         specifier: 11.0.0-rc.477
         version: 11.0.0-rc.477
@@ -555,6 +555,9 @@ importers:
       '@vercel/queue':
         specifier: ^0.3.1
         version: 0.3.1
+      ai:
+        specifier: 7.0.69
+        version: 7.0.69(zod@3.25.76)
       blurhash:
         specifier: ^2.0.5
         version: 2.0.5
@@ -585,9 +588,6 @@ importers:
       magic-observability:
         specifier: 1.0.0
         version: 1.0.0(@posthog/react@1.10.3(@types/react@19.2.17)(posthog-js@1.407.2)(react@19.2.0))(posthog-js@1.407.2)(posthog-node@5.39.4(rxjs@7.8.1))(posthog-react-native@4.54.4(dd0719650ac7408b8594bb3923b10638))(react@19.2.0)
-      nsfwjs:
-        specifier: ^4.3.0
-        version: 4.3.0(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(buffer@6.0.3)
       posthog-node:
         specifier: ^5.39.4
         version: 5.39.4(rxjs@7.8.1)
@@ -607,8 +607,8 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.43)(@types/node@22.1.0)(typescript@5.4.5)
       zod:
-        specifier: 3.23.8
-        version: 3.23.8
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       '@faker-js/faker':
         specifier: ^8.4.1
@@ -638,8 +638,8 @@ importers:
         specifier: ^8.4.1
         version: 8.4.1
       zod:
-        specifier: 3.23.8
-        version: 3.23.8
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
@@ -664,7 +664,7 @@ importers:
         version: 3.6.0
       zod-i18n-map:
         specifier: ^2.27.0
-        version: 2.27.0(i18next@23.12.2)(zod@3.23.8)
+        version: 2.27.0(i18next@23.12.2)(zod@3.25.76)
     devDependencies:
       '@total-typescript/ts-reset':
         specifier: ^0.5.1
@@ -676,10 +676,44 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       zod:
-        specifier: 3.23.8
-        version: 3.23.8
+        specifier: 3.25.76
+        version: 3.25.76
 
 packages:
+
+  '@ai-sdk/gateway@4.0.55':
+    resolution: {integrity: sha512-7WP/nlDz2BkXFlZzwF3w5JgCvktyHC++LP4PZ4mQpbvxrq+M7OdNslevlkuddHhJ+62BZu4oiL/afXlsWOSJZQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@4.0.47':
+    resolution: {integrity: sha512-Aj/VRSDpNmxjC0mU1qWNI9BydRoRI3INVHv1KZcFj3lI7rdxmXuenhUfXw8KnfZlREWX3J3rM9JNF1khuxGfnw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.44':
+    resolution: {integrity: sha512-x3XjhKu5r7DKELWwE5WzCAKePkAqZXlgvat4eIiSm37MaQHk+n3qeJxmVcfqJWlQ2kkAld8+f7G3E3yjG+4ShQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.28':
+    resolution: {integrity: sha512-TnHUyd/rCYQqHg5RuiOaz/hUql6U+kbUaBW0Rp+0N5UhnAInA9CzzV0HXvuAAPwppDsK6fAx9Rd+tRawpJ/3pg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
+    engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2923,35 +2957,6 @@ packages:
   '@react-navigation/routers@7.5.5':
     resolution: {integrity: sha512-9/hhMte12Kgu+pMnLfA4EWJ0OQmIEAMVMX06FPH2yGkEQSQ3JhhCN/GkcRikzQhtEi97VYYQA15umptBUShcOQ==}
 
-  '@redis/bloom@1.2.0':
-    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/client@1.6.0':
-    resolution: {integrity: sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==}
-    engines: {node: '>=14'}
-
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@redux-saga/core@1.3.0':
     resolution: {integrity: sha512-L+i+qIGuyWn7CIg7k1MteHGfttKPmxwZR5E7OsGikCL2LzYA0RERlaUY00Y3P3ZV2EYgrsYlBrGs6cJP5OKKqA==}
 
@@ -3047,6 +3052,9 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -3231,42 +3239,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
-  '@tensorflow/tfjs-backend-cpu@4.22.0':
-    resolution: {integrity: sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==}
-    engines: {yarn: '>= 1.3.2'}
-    peerDependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-
-  '@tensorflow/tfjs-backend-webgl@4.22.0':
-    resolution: {integrity: sha512-H535XtZWnWgNwSzv538czjVlbJebDl5QTMOth4RXr2p/kJ1qSIXE0vZvEtO+5EC9b00SvhplECny2yDewQb/Yg==}
-    engines: {yarn: '>= 1.3.2'}
-    peerDependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-
-  '@tensorflow/tfjs-converter@4.22.0':
-    resolution: {integrity: sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==}
-    peerDependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-
-  '@tensorflow/tfjs-core@4.22.0':
-    resolution: {integrity: sha512-LEkOyzbknKFoWUwfkr59vSB68DMJ4cjwwHgicXN0DUi3a0Vh1Er3JQqCI1Hl86GGZQvY8ezVrtDIvqR1ZFW55A==}
-    engines: {yarn: '>= 1.3.2'}
-
-  '@tensorflow/tfjs-data@4.22.0':
-    resolution: {integrity: sha512-dYmF3LihQIGvtgJrt382hSRH4S0QuAp2w1hXJI2+kOaEqo5HnUPG0k5KA6va+S1yUhx7UBToUKCBHeLHFQRV4w==}
-    peerDependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-      seedrandom: ^3.0.5
-
-  '@tensorflow/tfjs-layers@4.22.0':
-    resolution: {integrity: sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA==}
-    peerDependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-
-  '@tensorflow/tfjs@4.22.0':
-    resolution: {integrity: sha512-0TrIrXs6/b7FLhLVNmfh8Sah6JgjBPH4mZ8JGb7NU6WW+cx00qK5BcAZxw7NCzxj6N8MRAIfHq+oNbPUNG5VAg==}
-    hasBin: true
-
   '@total-typescript/ts-reset@0.5.1':
     resolution: {integrity: sha512-AqlrT8YA1o7Ff5wPfMOL0pvL+1X+sw60NN6CcOCqs658emD6RfiXhF7Gu9QcfKBH7ELY2nInLhKSCWVoNL70MQ==}
 
@@ -3401,9 +3373,6 @@ packages:
   '@types/lodash@4.17.7':
     resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
 
-  '@types/long@4.0.2':
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -3422,12 +3391,6 @@ packages:
   '@types/node@22.1.0':
     resolution: {integrity: sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==}
 
-  '@types/offscreencanvas@2019.3.0':
-    resolution: {integrity: sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==}
-
-  '@types/offscreencanvas@2019.7.3':
-    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -3441,9 +3404,6 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
-
-  '@types/seedrandom@2.4.34':
-    resolution: {integrity: sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -3532,6 +3492,10 @@ packages:
       ws:
         optional: true
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vercel/oidc@3.8.0':
     resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
     engines: {node: '>= 20'}
@@ -3540,8 +3504,8 @@ packages:
     resolution: {integrity: sha512-6pjdXyNfdCQnj1nyeB1rPtll/XUhmciyeZJD0rpIUUwmcIfR+utDl6+iFvlHvsBdqAVT8UC6ydObT0v+xldfUQ==}
     engines: {node: '>=20.0.0'}
 
-  '@webgpu/types@0.1.38':
-    resolution: {integrity: sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==}
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
@@ -3581,6 +3545,12 @@ packages:
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
+
+  ai@7.0.69:
+    resolution: {integrity: sha512-gudEqQYt/FuRpQkckLHPYKOh5M5v5ayPmzQAk5xyZOaWkUM0ArNGdXQiBGEuZA7GCwYOjzmWxB44ZW0CyRhHfQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -3857,9 +3827,6 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -3969,9 +3936,6 @@ packages:
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
-  cliui@7.0.4:
-    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
-
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3990,10 +3954,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  cluster-key-slot@1.1.2:
-    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
-    engines: {node: '>=0.10.0'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -4081,9 +4041,6 @@ packages:
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
-
-  core-js@3.29.1:
-    resolution: {integrity: sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==}
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
@@ -4486,6 +4443,10 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -4943,10 +4904,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  generic-pool@3.9.0:
-    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
-    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -5483,6 +5440,9 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -5678,9 +5638,6 @@ packages:
   logkitty@0.7.1:
     resolution: {integrity: sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==}
     hasBin: true
-
-  long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -6228,15 +6185,6 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
-  node-fetch@2.6.13:
-    resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -6272,12 +6220,6 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  nsfwjs@4.3.0:
-    resolution: {integrity: sha512-WTKDte0vp1X97N1h34P79G/hG+sVT3+TnDz9di1WseIJR93v11E4viNX7Vg9WsO6HYoR772Nzq2iM8jo3XBZ+g==}
-    peerDependencies:
-      '@tensorflow/tfjs': ^4.0.0
-      buffer: ^6.0.3
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -6968,9 +6910,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  redis@4.7.0:
-    resolution: {integrity: sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==}
-
   reduce-reducers@1.0.4:
     resolution: {integrity: sha512-Mb2WZ2bJF597exiqX7owBzrqJ74DHLK3yOQjCyPAaNifRncE8OD0wFIuoMhXxTnHK07+8zZ2SJEKy/qtiyR7vw==}
 
@@ -7103,9 +7042,6 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
-
-  seedrandom@3.0.5:
-    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -7561,6 +7497,10 @@ packages:
   undici-types@6.13.0:
     resolution: {integrity: sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -7852,9 +7792,6 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -7864,10 +7801,6 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
-  yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -7875,10 +7808,6 @@ packages:
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
-
-  yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
@@ -7911,6 +7840,47 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@4.0.55(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+
+  '@ai-sdk/google@4.0.47(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.28(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/openai@4.0.44(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.28(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@5.0.27(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@5.0.28(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@4.0.7':
+    dependencies:
+      json-schema: 0.4.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -10639,32 +10609,6 @@ snapshots:
     dependencies:
       nanoid: 3.3.18
 
-  '@redis/bloom@1.2.0(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/client@1.6.0':
-    dependencies:
-      cluster-key-slot: 1.1.2
-      generic-pool: 3.9.0
-      yallist: 4.0.0
-
-  '@redis/graph@1.1.1(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/json@1.0.7(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/search@1.2.0(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
-  '@redis/time-series@1.1.0(@redis/client@1.6.0)':
-    dependencies:
-      '@redis/client': 1.6.0
-
   '@redux-saga/core@1.3.0':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -10779,6 +10723,8 @@ snapshots:
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
@@ -10935,67 +10881,6 @@ snapshots:
       '@tanstack/query-core': 5.51.21
       react: 19.2.0
 
-  '@tensorflow/tfjs-backend-cpu@4.22.0(@tensorflow/tfjs-core@4.22.0)':
-    dependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-      '@types/seedrandom': 2.4.34
-      seedrandom: 3.0.5
-
-  '@tensorflow/tfjs-backend-webgl@4.22.0(@tensorflow/tfjs-core@4.22.0)':
-    dependencies:
-      '@tensorflow/tfjs-backend-cpu': 4.22.0(@tensorflow/tfjs-core@4.22.0)
-      '@tensorflow/tfjs-core': 4.22.0
-      '@types/offscreencanvas': 2019.3.0
-      '@types/seedrandom': 2.4.34
-      seedrandom: 3.0.5
-
-  '@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0)':
-    dependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-
-  '@tensorflow/tfjs-core@4.22.0':
-    dependencies:
-      '@types/long': 4.0.2
-      '@types/offscreencanvas': 2019.7.3
-      '@types/seedrandom': 2.4.34
-      '@webgpu/types': 0.1.38
-      long: 4.0.0
-      node-fetch: 2.6.13
-      seedrandom: 3.0.5
-    transitivePeerDependencies:
-      - encoding
-
-  '@tensorflow/tfjs-data@4.22.0(@tensorflow/tfjs-core@4.22.0)(seedrandom@3.0.5)':
-    dependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-      '@types/node-fetch': 2.6.11
-      node-fetch: 2.6.13
-      seedrandom: 3.0.5
-      string_decoder: 1.3.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@tensorflow/tfjs-layers@4.22.0(@tensorflow/tfjs-core@4.22.0)':
-    dependencies:
-      '@tensorflow/tfjs-core': 4.22.0
-
-  '@tensorflow/tfjs@4.22.0(seedrandom@3.0.5)':
-    dependencies:
-      '@tensorflow/tfjs-backend-cpu': 4.22.0(@tensorflow/tfjs-core@4.22.0)
-      '@tensorflow/tfjs-backend-webgl': 4.22.0(@tensorflow/tfjs-core@4.22.0)
-      '@tensorflow/tfjs-converter': 4.22.0(@tensorflow/tfjs-core@4.22.0)
-      '@tensorflow/tfjs-core': 4.22.0
-      '@tensorflow/tfjs-data': 4.22.0(@tensorflow/tfjs-core@4.22.0)(seedrandom@3.0.5)
-      '@tensorflow/tfjs-layers': 4.22.0(@tensorflow/tfjs-core@4.22.0)
-      argparse: 1.0.10
-      chalk: 4.1.2
-      core-js: 3.29.1
-      regenerator-runtime: 0.13.11
-      yargs: 16.2.0
-    transitivePeerDependencies:
-      - encoding
-      - seedrandom
-
   '@total-typescript/ts-reset@0.5.1': {}
 
   '@trpc/client@11.0.0-rc.477(@trpc/server@11.0.0-rc.477)':
@@ -11130,8 +11015,6 @@ snapshots:
 
   '@types/lodash@4.17.7': {}
 
-  '@types/long@4.0.2': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.2
@@ -11153,10 +11036,6 @@ snapshots:
     dependencies:
       undici-types: 6.13.0
 
-  '@types/offscreencanvas@2019.3.0': {}
-
-  '@types/offscreencanvas@2019.7.3': {}
-
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -11175,8 +11054,6 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
-
-  '@types/seedrandom@2.4.34': {}
 
   '@types/semver@7.7.1': {}
 
@@ -11238,6 +11115,8 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.42
       ws: 8.21.1
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vercel/oidc@3.8.0':
     dependencies:
       '@vercel/cli-config': 0.2.0
@@ -11251,7 +11130,7 @@ snapshots:
       mixpart: 0.0.6
       picocolors: 1.1.1
 
-  '@webgpu/types@0.1.38': {}
+  '@workflow/serde@4.1.0': {}
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -11282,6 +11161,13 @@ snapshots:
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
+
+  ai@7.0.69(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.55(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@3.25.76)
+      zod: 3.25.76
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -11600,11 +11486,6 @@ snapshots:
       ieee754: 1.2.1
     optional: true
 
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -11720,12 +11601,6 @@ snapshots:
       wrap-ansi: 6.2.0
     optional: true
 
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -11749,8 +11624,6 @@ snapshots:
   clsx@2.0.0: {}
 
   clsx@2.1.1: {}
-
-  cluster-key-slot@1.1.2: {}
 
   co@4.6.0: {}
 
@@ -11839,8 +11712,6 @@ snapshots:
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.7
-
-  core-js@3.29.1: {}
 
   core-js@3.49.0: {}
 
@@ -12266,6 +12137,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventsource-parser@3.1.1: {}
 
   execa@5.1.1:
     dependencies:
@@ -12817,8 +12690,6 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  generic-pool@3.9.0: {}
-
   gensync@1.0.0-beta.2: {}
 
   geolib@3.3.14: {}
@@ -13053,7 +12924,8 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.12
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
   ignore@5.3.1: {}
 
@@ -13572,6 +13444,8 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@1.0.2:
@@ -13742,8 +13616,6 @@ snapshots:
       dayjs: 1.11.21
       yargs: 15.4.1
     optional: true
-
-  long@4.0.0: {}
 
   longest-streak@3.1.0: {}
 
@@ -14640,10 +14512,6 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
-  node-fetch@2.6.13:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -14669,11 +14537,6 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  nsfwjs@4.3.0(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(buffer@6.0.3):
-    dependencies:
-      '@tensorflow/tfjs': 4.22.0(seedrandom@3.0.5)
-      buffer: 6.0.3
 
   nth-check@2.1.1:
     dependencies:
@@ -15394,15 +15257,6 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
-  redis@4.7.0:
-    dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.0)
-      '@redis/client': 1.6.0
-      '@redis/graph': 1.1.1(@redis/client@1.6.0)
-      '@redis/json': 1.0.7(@redis/client@1.6.0)
-      '@redis/search': 1.2.0(@redis/client@1.6.0)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.0)
-
   reduce-reducers@1.0.4: {}
 
   redux-saga@1.3.0(patch_hash=8c7f7d64fa347d148c073162a8afd0e421c019bb94193fd3f29bccc3024e9a66):
@@ -15539,8 +15393,6 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
-
-  seedrandom@3.0.5: {}
 
   semver@6.3.1: {}
 
@@ -15725,6 +15577,7 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -16010,6 +15863,8 @@ snapshots:
 
   undici-types@6.13.0: {}
 
+  undici@7.29.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -16277,8 +16132,6 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@4.0.0: {}
-
   yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
@@ -16286,8 +16139,6 @@ snapshots:
       camelcase: 5.3.1
       decamelize: 1.2.0
     optional: true
-
-  yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
 
@@ -16306,16 +16157,6 @@ snapshots:
       yargs-parser: 18.1.3
     optional: true
 
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-
   yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
@@ -16330,10 +16171,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-i18n-map@2.27.0(i18next@23.12.2)(zod@3.23.8):
+  zod-i18n-map@2.27.0(i18next@23.12.2)(zod@3.25.76):
     dependencies:
       i18next: 23.12.2
-      zod: 3.23.8
+      zod: 3.25.76
 
   zod@3.23.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,8 +356,8 @@ importers:
         specifier: ^11.1.1
         version: 11.1.1
       zod:
-        specifier: 3.23.8
-        version: 3.23.8
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -7826,9 +7826,6 @@ packages:
     peerDependencies:
       i18next: '>=21.3.0'
       zod: '>=3.17.0'
-
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -16175,8 +16172,6 @@ snapshots:
     dependencies:
       i18next: 23.12.2
       zod: 3.25.76
-
-  zod@3.23.8: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Profile photos are now moderated by a vision model through the AI SDK instead of the bundled nsfwjs model, and the verdict is recorded on the image row.
The feature ships turned off, so nothing changes until `IMAGE_MODERATION_MODE` is set.

## Details

- `ImageModerationService` sends a photo to a model and returns a verdict, a score, a category, whether a dog is visible, the latency and a cost estimate. It never throws: a timeout, an outage, a missing key or an unusable answer all come back as verdict `error`.
- The provider is an environment variable, `IMAGE_MODERATION_MODEL`, in the form `<provider>/<model-id>`. Google and OpenAI are wired up, and adding a third is one entry in one table.
- `IMAGE_MODERATION_MODE` has three settings. `off` calls nobody. `shadow` calls the model, stores the verdict and publishes the photo anyway. `enforce` is the only setting where a verdict can hold a photo back. The existing `profanity_check` PostHog flag is still the runtime kill switch, and either switch being off means no call and no cost.
- An `error` verdict approves the photo in every mode, so a provider outage cannot hold back everyone's uploads at once.
- Photos are downscaled to fit 768x768 before they are sent, which keeps the image at one billing tile.
- Five nullable columns on `Image` hold the verdict, kept apart from `status` so shadow mode can record what enforcement would have done without doing it.
- In `enforce`, a held back photo sends its owner a push saying it was not approved and that they can add another. No app changes.
- The nsfwjs and TensorFlow.js path is gone, along with their entries in `serverExternalPackages`. The unused `redis` dependency and the dead `REDIS_*`, `QUEUE_DEV_PORT`, `SENDGRID_API_KEY` and `BUGSNAG_API_KEY` variables went with it, after checking nothing reads them.
- Hypothesis: shadow mode measures the false positive rate before enforcing.
- Baseline: none. The nsfwjs verdicts were never recorded, so there is no history to compare against.
- Readout: the PostHog event `Image Moderation Result`, broken down by verdict, plus p50 and p95 of `latency_ms`, alongside a manual review of every rejected image for 7 days.
- Vercel environment variables to add: `IMAGE_MODERATION_MODE=shadow`, `GOOGLE_GENERATIVE_AI_API_KEY`, and optionally `IMAGE_MODERATION_MODEL` to change model or provider without a deploy.
- Cost at 768px is roughly $0.04 to $0.14 per 1000 photos, depending on the model.
- Metric it moves: retention and safety, through fewer bad photos reaching the deck, measured by the readout above.

## Testing steps

1. Nothing should change for anyone yet, because moderation is off until it is switched on in the environment.
2. Once shadow mode is on, add a photo to a dog profile. The photo should appear as it always has, with no delay you would notice.
3. In PostHog, a new event called Image Moderation Result should show up for that photo, saying whether the model would have approved it.
4. Leave it in shadow mode for a week and look at how many photos the model would have rejected. If the ones it flags really do break the guidelines, switch it to enforce.
5. In enforce mode, add a photo that breaks the guidelines. It should not appear on the profile, and the owner should get a notification saying it was not approved and that they can add another.

## Screenshots

Not applicable, server only.
