### PR TITLE
fix(web): serve the real Apple team in the app site association

### DIFF
--- a/apps/nextjs/src/lib/app-links.ts
+++ b/apps/nextjs/src/lib/app-links.ts
@@ -13,7 +13,10 @@
  * Android compares the certificate of the installed APK, and which key that
  * is depends on how the build reached the device.
  */
-export const APPLE_TEAM_ID = "23DRM684H8";
+// Read from the App Store provisioning profile entitlements
+// (`application-identifier = TWHC5L37B2.app.pegada`), which match the
+// distribution certificate and the App Store Connect API key in use.
+export const APPLE_TEAM_ID = "TWHC5L37B2";
 
 export const ANDROID_SHA256_CERT_FINGERPRINTS = [
   // Upload key. Signs the bundle we hand to Play, and the one Play strips off


### PR DESCRIPTION
## Summary

The app site association served at pegada.app carried an Apple team that does not sign the app, so iOS never handed pegada.app/dog links to the app. This serves the team that actually signs it.

## Details

- `APPLE_TEAM_ID` in the Next.js app links module goes from `23DRM684H8` to `TWHC5L37B2`. That value feeds `APPLE_APP_ID`, which is what the `.well-known/apple-app-site-association` route publishes for both `applinks` and `webcredentials`.
- Evidence for `TWHC5L37B2`: the App Store provisioning profile entitlements carry `application-identifier = TWHC5L37B2.app.pegada`, the distribution certificate belongs to the same team, and the App Store Connect API key in use is issued under it. All three point at the team "Gabriel Taveira (Individual)".
- iOS only opens a link in the app when the prefix in the association file matches the prefix the installed build was signed with, so the old value silently sent every shared dog link to Safari.
- After deploy the check is `curl https://www.pegada.app/.well-known/apple-app-site-association` and confirming the appIDs now read `TWHC5L37B2.app.pegada`.
- Metric: unblocks universal links, and the readout is the existing `Deep Link Opened` event in `packages/shared/analytics/events.ts` (`ANALYTICS_EVENTS.DEEP_LINK_OPENED`), which should start firing for shared dog links on iOS instead of staying flat.

## Testing steps

1. Open a shared dog link from a message on an iPhone that has the app installed.
2. The app opens on the dog profile instead of the website opening in the browser.
3. Sharing a dog from inside the app and tapping the resulting link does the same thing.

## Screenshots

Not applicable, JSON response only.
