### PR TITLE
fix(web): keep the well-known files on the apex when it stops redirecting

### DIFF
--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -90,6 +90,39 @@ const nextConfig = {
       destination: "/store",
       permanent: false,
     },
+    /**
+     * www is the canonical host, so the apex has to send visitors there. It
+     * cannot send Apple and Google there: `swcd`, the daemon that installs
+     * an app's associated domains, fetches
+     * `https://<domain>/.well-known/apple-app-site-association` and treats
+     * anything other than a direct 200 as a failure, and Android's domain
+     * verifier does the same for `assetlinks.json`. Neither follows a
+     * redirect. `apps/mobile/app.config.ts` declares
+     * `applinks:pegada.app` alongside `applinks:www.pegada.app` and lists
+     * both as Android verified hosts, so a blanket apex redirect silently
+     * drops the apex half of every universal link: the OS never installs
+     * the association and a shared `pegada.app/dog/<id>` opens in the
+     * browser instead of the app, with no error anywhere to say why.
+     *
+     * The negative lookahead is what keeps the two well-known files
+     * answering 200 on the apex while every other apex path still hops to
+     * www. Query strings ride along on their own, Next preserves them
+     * whenever the destination declares none.
+     *
+     * Inert until the "Redirect to www.pegada.app" setting is removed from
+     * the `pegada.app` domain in the Vercel project. That redirect is a
+     * whole-domain one applied at the platform's routing layer, ahead of
+     * this deployment, and it has no path exclusions, so today it answers
+     * 308 for `/.well-known/*` too and nothing here is ever reached.
+     * Landing this first means clearing that setting is the only step left
+     * and the apex never goes a deploy without a canonical redirect.
+     */
+    {
+      source: "/:path((?!\\.well-known).*)",
+      has: [{ type: "host", value: "pegada.app" }],
+      destination: "https://www.pegada.app/:path",
+      permanent: true,
+    },
   ],
 };
 

--- a/apps/nextjs/tests/apex-redirect.test.mjs
+++ b/apps/nextjs/tests/apex-redirect.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+
+import nextConfig from "../next.config.mjs";
+
+/**
+ * The defect: `pegada.app` sends every path to `www.pegada.app` with a 308.
+ * Apple's `swcd` fetches
+ * `https://pegada.app/.well-known/apple-app-site-association` when the app
+ * is installed and does not follow redirects, and Android's domain verifier
+ * treats `assetlinks.json` the same way, so the apex association never
+ * installs. `apps/mobile/app.config.ts` declares `applinks:pegada.app`, so
+ * that is half the universal links quietly opening in a browser.
+ *
+ * What is asserted here is the matching, not the wording: the source is
+ * compiled with the same library Next compiles `redirects` sources with, so
+ * a rewrite of that pattern that starts swallowing `/.well-known` fails
+ * here rather than on a store install. If Next moves this module the import
+ * throws, and the fix is to point it at the new path, not to weaken the
+ * assertions.
+ */
+const { pathToRegexp, compile } = createRequire(import.meta.url)(
+  "next/dist/compiled/path-to-regexp",
+);
+
+const redirects = await nextConfig.redirects();
+
+const apexRedirect = redirects.find((redirect) =>
+  redirect.has?.some(
+    (condition) =>
+      condition.type === "host" && condition.value === "pegada.app",
+  ),
+);
+
+test("the apex has a redirect to the canonical www host", () => {
+  assert.ok(
+    apexRedirect,
+    "no redirect is conditioned on the pegada.app host, so the apex would serve the site on a second canonical origin",
+  );
+  // 308, which is what search engines and the App Store listing expect from
+  // a host that has moved for good.
+  assert.equal(apexRedirect.permanent, true);
+});
+
+test("the well-known files stay on the apex", () => {
+  const matches = pathToRegexp(apexRedirect.source);
+
+  for (const path of [
+    "/.well-known/apple-app-site-association",
+    "/.well-known/assetlinks.json",
+  ]) {
+    assert.equal(
+      matches.test(path),
+      false,
+      `${path} would be redirected, and neither Apple nor Android follows a redirect when installing an app link association`,
+    );
+  }
+});
+
+test("every other apex path still goes to www", () => {
+  const matches = pathToRegexp(apexRedirect.source);
+
+  for (const path of [
+    "/",
+    "/dog/abc",
+    "/pt-br/dog/abc",
+    "/store",
+    "/privacy-policy",
+  ]) {
+    assert.equal(matches.test(path), true, `${path} would stay on the apex`);
+  }
+});
+
+test("the path is carried over to the destination", () => {
+  // Next splits the origin off an absolute destination before compiling the
+  // rest, because a bare `compile` reads the `https:` scheme as a parameter
+  // with no name and throws. Same split here, same result.
+  const destination = new URL(apexRedirect.destination);
+  assert.equal(destination.origin, "https://www.pegada.app");
+
+  // `validate: false` is what Next passes in `prepareDestination`. Without
+  // it the default single-segment pattern rejects the slashes in a path
+  // like `dog/abc`, which the server itself substitutes happily.
+  const buildPath = compile(destination.pathname, { validate: false });
+
+  assert.equal(buildPath({ path: "dog/abc" }), "/dog/abc");
+  assert.equal(buildPath({ path: "" }), "/");
+});


### PR DESCRIPTION
## Summary

The apex host answers a 308 for every path, so Apple and Google never install the app link association for `pegada.app` and half of every shared link opens in a browser. This puts the canonical redirect in code with the two well-known files left out of it.

## Details

- `apps/nextjs/next.config.mjs` gains a host conditioned 308 from `pegada.app` to `www.pegada.app`. The path is carried over and the query string rides along, so `?ref=` survives the hop.
- The source pattern excludes `/.well-known/*`, so `apple-app-site-association` and `assetlinks.json` answer 200 with their JSON on the apex while every other apex path still lands on www.
- Why it matters: `swcd` fetches the association file once per install and does not follow redirects, and Android's domain verifier treats `assetlinks.json` the same way. `apps/mobile/app.config.ts` declares `applinks:pegada.app` next to `applinks:www.pegada.app` and lists both as verified Android hosts, so today the apex half fails with no error anywhere to say why.
- This is inert until the domain redirect is removed in Vercel. That one is applied at the platform routing layer, ahead of the deployment, and it has no path exclusions, so nothing in this file is reached while it is on. Dashboard step: Vercel project, Settings, Domains, `pegada.app`, remove the "Redirect to www.pegada.app" setting. Landing the code first means clearing that setting is the only step left and the apex never spends a deploy without a canonical redirect.
- The new test compiles the redirect source with the same matcher Next compiles it with, so a later edit to that pattern that starts swallowing `/.well-known` fails in CI instead of on a store install.
- Metric: this is on the share to install path. A dog link shared out of the app opens the app itself rather than Safari, which is what the share funnel is measured on.

## Testing steps

1. Open `https://pegada.app/.well-known/apple-app-site-association` in a browser. The JSON shows up directly and the address bar stays on the apex, with no hop to www.
2. Open `https://pegada.app/.well-known/assetlinks.json`. Same thing, the JSON straight away and no redirect.
3. Open any other apex address, for example a shared dog link that starts with `pegada.app`. It lands on the same page on www, and anything after the question mark is still there.
4. Steps 1 and 2 only behave this way once the domain redirect on the apex is removed in Vercel. Until then the apex keeps bouncing everything to www.

## Screenshots

Not applicable, JSON responses only.
