### PR TITLE
fix(ci): count active users from client events only in the daily readout

### DIFF
--- a/scripts/metrics/daily.mjs
+++ b/scripts/metrics/daily.mjs
@@ -19,6 +19,7 @@ import { upsertMarkedComment } from "./github.mjs";
 import { queryHogql } from "./posthog.mjs";
 import {
   BREAKDOWNS,
+  buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
   buildTotalsQuery,
@@ -61,16 +62,21 @@ export async function runDailyMetrics({
   const run = (name, query) =>
     queryHogql({ apiKey, fetchImpl, host, name, projectId, query });
 
-  const [activeUsers, totals, ...breakdownRows] = await Promise.all([
-    run("pegada daily metrics: active users", buildActiveUsersQuery(windows)),
-    run("pegada daily metrics: event totals", buildTotalsQuery(windows)),
-    ...BREAKDOWNS.map((breakdown) =>
+  const [activeUsers, activeUsersByVersion, totals, ...breakdownRows] =
+    await Promise.all([
+      run("pegada daily metrics: active users", buildActiveUsersQuery(windows)),
       run(
-        `pegada daily metrics: ${breakdown.id}`,
-        buildBreakdownQuery(windows, breakdown),
+        "pegada daily metrics: active users by app version",
+        buildActiveUsersByVersionQuery(windows),
       ),
-    ),
-  ]);
+      run("pegada daily metrics: event totals", buildTotalsQuery(windows)),
+      ...BREAKDOWNS.map((breakdown) =>
+        run(
+          `pegada daily metrics: ${breakdown.id}`,
+          buildBreakdownQuery(windows, breakdown),
+        ),
+      ),
+    ]);
 
   const breakdowns = Object.fromEntries(
     BREAKDOWNS.map((breakdown, position) => [
@@ -81,6 +87,7 @@ export async function runDailyMetrics({
 
   const body = buildReport({
     activeUsers,
+    activeUsersByVersion,
     breakdowns,
     generatedAt: now,
     totals,

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -49,6 +49,16 @@ function fakeWorld({ existingComment = null } = {}) {
           ],
         });
       }
+      if (name.endsWith("active users by app version")) {
+        return json({
+          columns: ["bucket", "period", "people"],
+          results: [
+            ["1.4.0", "current", 900],
+            ["1.3.2", "current", 320],
+            ["1.4.0", "previous", 210],
+          ],
+        });
+      }
       if (name.endsWith("event totals")) {
         return json({
           columns: ["event", "period", "total", "people"],
@@ -95,6 +105,10 @@ test("a dry run renders the comment and never touches GitHub", async () => {
     result.body,
     /\| Swipes \| 5,400 \| 5,000 \| \+400 \(\+8\.0%\) \|/,
   );
+  assert.match(
+    result.body,
+    /\| 1\.4\.0 \| 900 \| 210 \| \+690 \(\+328\.6%\) \|/,
+  );
   assert.equal(
     fetchImpl.calls.every((call) => isPostHog(call.url)),
     true,
@@ -104,7 +118,7 @@ test("a dry run renders the comment and never touches GitHub", async () => {
 test("one query goes out per metric block", async () => {
   const fetchImpl = fakeWorld();
   await runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW });
-  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 2);
+  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 3);
 });
 
 test("a full run posts the readout once", async () => {

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -37,6 +37,44 @@ export const EVENTS = {
 export const COUNTED_EVENTS = Object.values(EVENTS).sort();
 
 /**
+ * The `$lib` values the PostHog SDKs report when a person is the one acting.
+ *
+ * `posthog-react-native` is the app, `web` is posthog-js on the marketing site.
+ * The API uses posthog-node, which reports `posthog-node`, so an allow list
+ * keeps a new server integration out of the activity number by default rather
+ * than letting it in until somebody notices.
+ */
+export const CLIENT_LIBS = ["posthog-react-native", "web"];
+
+/**
+ * Events emitted from `packages/api`, listed so they can be excluded.
+ *
+ * They are captured against the user they are about, so a push the cron sent to
+ * a person who never opened the app still carries that person's distinct id.
+ * Counting them as activity is what turned 20 real users into 579. The `$lib`
+ * allow list above already removes them; this list is the second guard, for the
+ * day one of these is captured through a proxy that rewrites `$lib`.
+ */
+export const SERVER_EVENTS = [
+  "Image Moderation Result",
+  "Match Created",
+  "Message Sent",
+  "Push Receipt Result",
+  "Push Ticket Result",
+  "Reengagement Push Sent",
+  "Signup Attributed",
+  "Subscription Event",
+].sort();
+
+/**
+ * The property posthog-react-native puts on every event from the native app,
+ * read out of the app bundle rather than sent by hand. Web events do not carry
+ * it, so they land in the `unknown` bucket, which is the honest answer for a
+ * browser.
+ */
+export const APP_VERSION_PROPERTY = "$app_version";
+
+/**
  * The breakdowns, each one event split by one property.
  *
  * Three of them double as headline numbers: the successful upgrades, the story
@@ -138,7 +176,25 @@ function windowFilter(windows) {
   ].join("\n  AND ");
 }
 
-/** Distinct people with any event at all, which is the activity denominator. */
+/**
+ * The clause that keeps a query to events a person caused.
+ *
+ * Both halves are needed for the reason each list documents: the `$lib` allow
+ * list is the definition, the event deny list is the backstop.
+ */
+function clientEventFilter() {
+  return [
+    `properties.$lib IN (${CLIENT_LIBS.map(quote).join(", ")})`,
+    `event NOT IN (${SERVER_EVENTS.map(quote).join(", ")})`,
+  ].join("\n  AND ");
+}
+
+/**
+ * Distinct people who did something in the app or on the site.
+ *
+ * Server events are excluded on purpose: the readout is asking how many people
+ * used the product, not how many rows the API wrote about them.
+ */
 export function buildActiveUsersQuery(windows) {
   return [
     "SELECT",
@@ -146,7 +202,30 @@ export function buildActiveUsersQuery(windows) {
     "  count(DISTINCT person_id) AS people",
     "FROM events",
     `WHERE ${windowFilter(windows)}`,
+    `  AND ${clientEventFilter()}`,
     "GROUP BY period",
+  ].join("\n");
+}
+
+/**
+ * The same active users, split by the build they are running.
+ *
+ * A person on two builds inside one window counts once per build, so the
+ * buckets can add up to more than the headline. That is the point: it answers
+ * "is anybody still on the old build", which a single number cannot.
+ */
+export function buildActiveUsersByVersionQuery(windows) {
+  const value = `ifNull(nullIf(toString(properties.${APP_VERSION_PROPERTY}), ''), 'unknown')`;
+  return [
+    "SELECT",
+    `  ${value} AS bucket,`,
+    `  ${periodExpression(windows)} AS period,`,
+    "  count(DISTINCT person_id) AS people",
+    "FROM events",
+    `WHERE ${windowFilter(windows)}`,
+    `  AND ${clientEventFilter()}`,
+    "GROUP BY bucket, period",
+    "ORDER BY bucket, period",
   ].join("\n");
 }
 

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -5,8 +5,11 @@ import { fileURLToPath } from "node:url";
 
 import {
   BREAKDOWNS,
+  CLIENT_LIBS,
   COUNTED_EVENTS,
   EVENTS,
+  SERVER_EVENTS,
+  buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
   buildTotalsQuery,
@@ -42,6 +45,59 @@ test("the active users query buckets by the current window start", () => {
   );
   assert.match(query, /timestamp < toDateTime\('2026-09-02 12:00:00', 'UTC'\)/);
   assert.match(query, /GROUP BY period/);
+});
+
+test("the active users query counts only events a person caused", () => {
+  const query = buildActiveUsersQuery(buildWindows(NOW));
+  assert.match(query, /properties\.\$lib IN \('posthog-react-native', 'web'\)/);
+  for (const event of SERVER_EVENTS) {
+    assert.ok(query.includes(quote(event)), `${event} is not excluded`);
+  }
+  assert.match(query, /event NOT IN \(/);
+});
+
+test("posthog-node never counts as a client library", () => {
+  assert.equal(CLIENT_LIBS.includes("posthog-node"), false);
+  assert.ok(CLIENT_LIBS.includes("posthog-react-native"));
+  assert.ok(CLIENT_LIBS.includes("web"));
+});
+
+test("the events the API emits are all on the deny list", () => {
+  for (const event of [
+    "Image Moderation Result",
+    "Match Created",
+    "Message Sent",
+    "Push Receipt Result",
+    "Push Ticket Result",
+    "Reengagement Push Sent",
+    "Signup Attributed",
+    "Subscription Event",
+  ]) {
+    assert.ok(SERVER_EVENTS.includes(event), `${event} is not denied`);
+  }
+  assert.equal(SERVER_EVENTS.includes("Swipe"), false);
+  assert.equal(SERVER_EVENTS.includes("Push Notification Opened"), false);
+});
+
+test("the version split counts distinct people per build, client events only", () => {
+  const query = buildActiveUsersByVersionQuery(buildWindows(NOW));
+  assert.match(
+    query,
+    /ifNull\(nullIf\(toString\(properties\.\$app_version\), ''\), 'unknown'\) AS bucket/,
+  );
+  assert.match(query, /count\(DISTINCT person_id\) AS people/);
+  assert.match(query, /properties\.\$lib IN \('posthog-react-native', 'web'\)/);
+  assert.match(query, /GROUP BY bucket, period/);
+  assert.match(
+    query,
+    /toDateTime\('2026-08-26 12:00:00', 'UTC'\), 'current', 'previous'/,
+  );
+});
+
+test("the totals query still counts server events, which are volume not activity", () => {
+  const query = buildTotalsQuery(buildWindows(NOW));
+  assert.equal(query.includes("$lib"), false);
+  assert.ok(query.includes(quote("Reengagement Push Sent")));
 });
 
 test("the totals query asks for every counted event once", () => {
@@ -99,7 +155,7 @@ test("every event name still exists in the shared analytics catalogue", () => {
     ),
   );
   assert.ok(declared.size > 20, "the catalogue parse found almost nothing");
-  for (const event of COUNTED_EVENTS) {
+  for (const event of [...COUNTED_EVENTS, ...SERVER_EVENTS]) {
     assert.ok(
       declared.has(event),
       `${event} is no longer in the analytics catalogue`,

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -53,6 +53,24 @@ function formatPercent(value) {
   return value === null ? "n/a" : `${value.toFixed(1)}%`;
 }
 
+/** A share of a denominator, or null when the denominator is empty. */
+function ratio(numerator, denominator) {
+  return denominator === 0 ? null : (numerator / denominator) * 100;
+}
+
+/** A percentage row, with the delta in points and `n/a` on either empty side. */
+function rateRow(label, current, previous) {
+  return {
+    current: formatPercent(current),
+    delta:
+      current === null || previous === null
+        ? "n/a"
+        : formatRateDelta(current, previous),
+    label,
+    previous: formatPercent(previous),
+  };
+}
+
 /** Indexes the totals rows so a lookup cannot depend on result ordering. */
 function indexTotals(rows) {
   const index = new Map();
@@ -69,13 +87,19 @@ function totalOf(index, event, period, field) {
   return index.get(`${event}::${period}`)?.[field] ?? 0;
 }
 
-function indexBreakdown(rows) {
+/**
+ * Buckets a breakdown into one entry per value.
+ *
+ * `field` is which column carries the number: counts come back as `total`, the
+ * version split comes back as `people`, and both render the same table.
+ */
+function indexBreakdown(rows, field = "total") {
   const index = new Map();
   for (const row of rows ?? []) {
     const bucket = String(row.bucket ?? "unknown");
     const entry = index.get(bucket) ?? { current: 0, previous: 0 };
     entry[row.period === "current" ? "current" : "previous"] += Number(
-      row.total ?? 0,
+      row[field] ?? 0,
     );
     index.set(bucket, entry);
   }
@@ -121,8 +145,8 @@ function countRow(index, label, event, field = "total") {
   };
 }
 
-function breakdownTable(rows) {
-  const index = indexBreakdown(rows);
+function breakdownTable(rows, { field = "total", header = "Bucket" } = {}) {
+  const index = indexBreakdown(rows, field);
   if (index.size === 0) {
     return "No events in either window.";
   }
@@ -132,7 +156,7 @@ function breakdownTable(rows) {
     .slice(0, MAX_BREAKDOWN_ROWS);
 
   return [
-    "| Bucket | Last 7 days | Previous 7 days | Delta |",
+    `| ${header} | Last 7 days | Previous 7 days | Delta |`,
     "| --- | ---: | ---: | ---: |",
     ...ordered.map(
       (row) =>
@@ -146,6 +170,7 @@ function breakdownTable(rows) {
  *
  * @param {object} input
  * @param {Array} input.activeUsers rows from the active users query
+ * @param {Array} input.activeUsersByVersion rows from the version split
  * @param {Record<string, Array>} input.breakdowns rows per breakdown id
  * @param {Date} input.generatedAt when the job ran
  * @param {Array} input.totals rows from the totals query
@@ -153,6 +178,7 @@ function breakdownTable(rows) {
  */
 export function buildReport({
   activeUsers,
+  activeUsersByVersion,
   breakdowns,
   generatedAt,
   totals,
@@ -177,11 +203,21 @@ export function buildReport({
   const okCurrent = bucketRate(pushTickets, "ok", "current");
   const okPrevious = bucketRate(pushTickets, "ok", "previous");
 
+  // Opens over sends, not over tickets: a send is one nudge aimed at one
+  // person, which is the thing an open rate is a share of.
+  const openRate = (period) =>
+    ratio(
+      totalOf(index, EVENTS.PUSH_NOTIFICATION_OPENED, period, "total"),
+      totalOf(index, EVENTS.REENGAGEMENT_PUSH_SENT, period, "total"),
+    );
+  const openRateCurrent = openRate("current");
+  const openRatePrevious = openRate("previous");
+
   const core = metricTable([
     {
       current: number(activeCurrent),
       delta: formatDelta(activeCurrent, activePrevious),
-      label: "Active users (any event)",
+      label: "Active users (app and site)",
       previous: number(activePrevious),
     },
     countRow(
@@ -217,21 +253,20 @@ export function buildReport({
 
   const push = metricTable([
     countRow(index, "Reengagement Push Sent", EVENTS.REENGAGEMENT_PUSH_SENT),
+    countRow(
+      index,
+      "Users reached by push",
+      EVENTS.REENGAGEMENT_PUSH_SENT,
+      "people",
+    ),
     countRow(index, "Push Ticket Result", EVENTS.PUSH_TICKET_RESULT),
-    {
-      current: formatPercent(okCurrent),
-      delta:
-        okCurrent === null || okPrevious === null
-          ? "n/a"
-          : formatRateDelta(okCurrent, okPrevious),
-      label: "Push Ticket Result ok rate",
-      previous: formatPercent(okPrevious),
-    },
+    rateRow("Push Ticket Result ok rate", okCurrent, okPrevious),
     countRow(
       index,
       "Push Notification Opened",
       EVENTS.PUSH_NOTIFICATION_OPENED,
     ),
+    rateRow("Push open rate", openRateCurrent, openRatePrevious),
   ]);
 
   const breakdownSections = BREAKDOWNS.map((breakdown) =>
@@ -262,6 +297,13 @@ export function buildReport({
     "### Push",
     "",
     push,
+    "",
+    "### Active users by app version",
+    "",
+    breakdownTable(activeUsersByVersion, {
+      field: "people",
+      header: "App version",
+    }),
     "",
     ...breakdownSections,
     "This comment is rewritten in place by the daily metrics workflow.",

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -24,11 +24,23 @@ function breakdown(rows) {
   return rows.map(([bucket, period, total]) => ({ bucket, period, total }));
 }
 
+function versions(rows) {
+  return rows.map(([bucket, period, people]) => ({ bucket, people, period }));
+}
+
 const FIXTURE = {
   activeUsers: [
     { people: 1240, period: "current" },
     { people: 1100, period: "previous" },
   ],
+  activeUsersByVersion: versions([
+    ["1.4.0", "current", 900],
+    ["1.4.0", "previous", 210],
+    ["1.3.2", "current", 320],
+    ["1.3.2", "previous", 870],
+    ["unknown", "current", 20],
+    ["unknown", "previous", 20],
+  ]),
   breakdowns: {
     fake_door_feature: breakdown([
       ["ai_story_video", "current", 31],
@@ -141,7 +153,7 @@ test("the core table reports counts, distinct people and deltas", () => {
   const body = buildReport(FIXTURE);
   assert.match(
     body,
-    /\| Active users \(any event\) \| 1,240 \| 1,100 \| \+140 \(\+12\.7%\) \|/,
+    /\| Active users \(app and site\) \| 1,240 \| 1,100 \| \+140 \(\+12\.7%\) \|/,
   );
   assert.match(
     body,
@@ -171,6 +183,52 @@ test("the story shares are split out of Share Completed", () => {
     body,
     /\| Share Completed \(option story\) \| 40 \| 10 \| \+30 \(\+300\.0%\) \|/,
   );
+});
+
+test("the app version table splits the active users by build", () => {
+  const body = buildReport(FIXTURE);
+  assert.ok(body.includes("### Active users by app version"));
+  const [, versionSection] = body.split("### Active users by app version");
+  assert.match(versionSection, /\| App version \| Last 7 days \|/);
+  assert.match(
+    versionSection,
+    /\| 1\.4\.0 \| 900 \| 210 \| \+690 \(\+328\.6%\) \|/,
+  );
+  assert.match(
+    versionSection,
+    /\| 1\.3\.2 \| 320 \| 870 \| -550 \(-63\.2%\) \|/,
+  );
+  assert.ok(
+    versionSection.indexOf("| 1.4.0 |") < versionSection.indexOf("| 1.3.2 |"),
+  );
+});
+
+test("a missing app version split says so instead of rendering an empty table", () => {
+  const body = buildReport({ ...FIXTURE, activeUsersByVersion: [] });
+  const [, versionSection] = body.split("### Active users by app version");
+  assert.match(versionSection, /^\n\nNo events in either window\./);
+});
+
+test("the push table reports how many people a send reached", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(
+    body,
+    /\| Reengagement Push Sent \| 1,000 \| 0 \| \+1,000 \(new\) \|/,
+  );
+  assert.match(
+    body,
+    /\| Users reached by push \| 800 \| 0 \| \+800 \(new\) \|/,
+  );
+});
+
+test("the push open rate is opens over sends", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(body, /\| Push open rate \| 14\.0% \| n\/a \| n\/a \|/);
+});
+
+test("the push open rate is n/a rather than infinite when nothing was sent", () => {
+  const body = buildReport({ ...FIXTURE, totals: [] });
+  assert.match(body, /\| Push open rate \| n\/a \| n\/a \| n\/a \|/);
 });
 
 test("the push ok rate is a share of the tickets in each window", () => {


### PR DESCRIPTION
## Summary

The daily readout counted 579 active users against 20 real ones, because every event the API sends is captured against the user it is about. Active users now count only what a person did in the app or on the site, and the readout gains a build split and a push open rate.

## Details

- Active users are now distinct people with at least one event whose `$lib` is a client library. The app reports `posthog-react-native`, the marketing site reports `web`, and the API reports `posthog-node`, so an allow list is enough to tell them apart.
- A deny list of the events emitted from `packages/api` (Reengagement Push Sent, Push Ticket Result, Push Receipt Result, Image Moderation Result, Subscription Event, Signup Attributed, Match Created, Message Sent) is applied as a second guard, with a test that keeps it in step with the shared analytics catalogue.
- New table "Active users by app version", distinct people per `$app_version`, which posthog-react-native puts on every event from the native app. Web events have no build, so they land in `unknown`. Tells us which store build people are actually on before we read any other number.
- New row "Users reached by push", the distinct people behind Reengagement Push Sent, so the reach that used to be hidden inside the activity number stays visible on its own line.
- New row "Push open rate", Push Notification Opened over Reengagement Push Sent, reported as `n/a` when nothing was sent instead of dividing by zero.
- The event totals table is unchanged. Server events are volume, not activity, so they are still counted there.

## Testing steps

1. Open the tracking issue and read the daily metrics comment after the next scheduled run.
2. Check that the active users line is now in the same range as the number of people who really used the app, rather than in the hundreds.
3. Check that the push section shows how many people were reached and what share of the sends were opened.
4. Check that the new app version table lists one row per build, with the newest store build taking over from the older one as people update.

## Screenshots

Rendered from the test fixtures, so the numbers are made up and the shape is real.

```markdown
### Core

| Metric | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| Active users (app and site) | 1,240 | 1,100 | +140 (+12.7%) |

### Push

| Metric | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| Reengagement Push Sent | 1,000 | 900 | +100 (+11.1%) |
| Users reached by push | 800 | 760 | +40 (+5.3%) |
| Push Ticket Result | 100 | 100 | 0 |
| Push Ticket Result ok rate | 90.0% | 96.0% | -6.0 pp |
| Push Notification Opened | 140 | 100 | +40 (+40.0%) |
| Push open rate | 14.0% | 11.1% | +2.9 pp |

### Active users by app version

| App version | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| 1.4.0 | 900 | 210 | +690 (+328.6%) |
| 1.3.2 | 320 | 870 | -550 (-63.2%) |
| unknown | 20 | 20 | 0 |
```
