### PR TITLE
chore(mobile): ota backport for runtime 1.6.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,8 +87,8 @@ APPLE_MAGIC_EMAIL=
 APPLE_MAGIC_CODE=
 
 # How many likes a free account gets in a rolling 24 hours. Optional: unset,
-# blank or unreadable keeps the value the app ships with. Read per request, so
-# changing it takes effect without a deploy.
+# blank or unreadable keeps the value the app ships with. Parsed once at boot
+# like every other variable here, so a change takes effect on the next deploy.
 FREE_DAILY_LIKE_LIMIT=
 
 # Maestro E2E — set to "1" ONLY for the E2E suite (CI). Unlocks the

--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,11 @@ POSTHOG_CLI_PROJECT_ID=
 APPLE_MAGIC_EMAIL=
 APPLE_MAGIC_CODE=
 
+# How many likes a free account gets in a rolling 24 hours. Optional: unset,
+# blank or unreadable keeps the value the app ships with. Read per request, so
+# changing it takes effect without a deploy.
+FREE_DAILY_LIKE_LIMIT=
+
 # Maestro E2E — set to "1" ONLY for the E2E suite (CI). Unlocks the
 # dev-only payment.maestroGrantPremium tRPC mutation used by
 # apps/mobile/.maestro/25-upgrade-journey.yaml. Refuses to run in

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -96,7 +96,14 @@ const AppLayout = () => {
           animation: "default",
         }}
       />
-      <Stack.Screen name="force-update" />
+      <Stack.Screen
+        name="force-update"
+        options={{
+          // There is no way off this screen except the store, so it does not
+          // get the back gesture either.
+          gestureEnabled: false,
+        }}
+      />
       <Stack.Screen
         name="new-match"
         options={{

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -21,6 +21,7 @@ import { useProtectedRoute } from "@/hooks/use-protected-route";
 import { useTrackScreens } from "@/hooks/use-track-screens";
 import { config } from "@/services/config";
 import { sendError } from "@/services/error-tracking";
+import { useForceUpdateOnForeground } from "@/services/force-update";
 import { useGetInitialNotifications } from "@/services/linking";
 import { getExpoPostHog } from "@/services/observability";
 import { useQuickActions } from "@/services/quick-actions";
@@ -76,6 +77,10 @@ const App = () => {
 
   useTrackScreens();
   useGetInitialNotifications();
+  // The launch check only ever runs once. This is the same check on the way
+  // back from the background, for the phones that go weeks without a cold
+  // start and would otherwise never see a raised floor.
+  useForceUpdateOnForeground();
   // Ahead of the auth gate on purpose: the link that carries a referral is
   // usually opened by someone with no account, and the referral has to be on
   // disk before they reach the sign in screen.

--- a/apps/mobile/src/components/LikeLimitReached/index.tsx
+++ b/apps/mobile/src/components/LikeLimitReached/index.tsx
@@ -22,11 +22,13 @@ import {
 import { CloseIcon, styles as pickerStyles } from "@/components/Picker/styles";
 import { Text } from "@/components/text";
 import { analytics } from "@/services/analytics";
+import { getFreeDailyLikeLimit } from "@/services/free-daily-like-limit";
 import { SceneName } from "@/types/scene-name";
 
 import { PinnedCloseButton } from "./styles";
 
 const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
+  likeLimit = FREE_DAILY_SWIPE_LIMIT,
   likeLimitResetAt,
 }) => {
   const timeLeft = useCountdown(likeLimitResetAt);
@@ -51,7 +53,7 @@ const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
             components={{
               b: <Text key="b" fontWeight="semibold" />,
             }}
-            values={{ count: FREE_DAILY_SWIPE_LIMIT }}
+            values={{ count: likeLimit }}
           />
         </Description>
       </View>
@@ -87,12 +89,18 @@ const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
 };
 
 export const showLikeLimitReached = (props: LikeLimitReachedProps) => {
+  // Resolved once so the number in the copy and the number on the event are
+  // the same number, whichever source it came from.
+  const likeLimit = props.likeLimit ?? getFreeDailyLikeLimit();
+
   analytics.track({
     event_type: "Like Limit Reached",
     event_properties: {
-      likeLimit: FREE_DAILY_SWIPE_LIMIT,
+      likeLimit,
       likeLimitResetAt: props.likeLimitResetAt,
     },
   });
-  return magicModal.show(() => <LikeLimitReached {...props} />);
+  return magicModal.show(() => (
+    <LikeLimitReached {...props} likeLimit={likeLimit} />
+  ));
 };

--- a/apps/mobile/src/components/LikeLimitReached/use-countdown.tsx
+++ b/apps/mobile/src/components/LikeLimitReached/use-countdown.tsx
@@ -3,6 +3,11 @@ import { useEffect, useState } from "react";
 import { differenceInSeconds } from "date-fns/differenceInSeconds";
 
 export type LikeLimitReachedProps = {
+  /**
+   * The allowance the server enforced. Absent when the payload came from a
+   * server that predates the field, which falls back to the shipped default.
+   */
+  likeLimit?: number;
   likeLimitResetAt: Date;
 };
 const formatTimeLeft = (totalSeconds: number) => {

--- a/apps/mobile/src/components/NetworkBoundary/styles.tsx
+++ b/apps/mobile/src/components/NetworkBoundary/styles.tsx
@@ -16,7 +16,13 @@ const ThemedLottieView = withUnistyles(LottieView);
 /** Every one of these was a static `.attrs`, which beat the caller's prop. */
 type IllustrationProps = Omit<LottieViewProps, "source">;
 
-const CONTENT_CONTAINER_STYLE = { flex: 1 };
+/**
+ * `flexGrow` rather than `flex`, which pins the content to the viewport height
+ * and leaves nothing to scroll: the empty deck grew past one screen and its
+ * last button became unreachable. Growing still centres a short state and lets
+ * a tall one scroll.
+ */
+const CONTENT_CONTAINER_STYLE = { flexGrow: 1 };
 
 /**
  * This boundary can replace the whole navigation tree, so nothing themed
@@ -27,6 +33,7 @@ const CONTENT_CONTAINER_STYLE = { flex: 1 };
  */
 export const Container = ({ style, ...props }: ScrollViewProps) => (
   <ScrollView
+    bounces={false}
     {...props}
     contentContainerStyle={CONTENT_CONTAINER_STYLE}
     style={[styles.container, style]}

--- a/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.tsx
@@ -41,7 +41,7 @@ import {
 type AddUserPhotoProps = {
   picture: Picture;
   onDelete: () => void;
-  onAdd: ({ url }: { url: string }) => void;
+  onAdd: ({ url, localUri }: { url: string; localUri?: string }) => void;
   /**
    * Position of this slot inside the photo grid. Used to derive a stable
    * `testID` (`add-photo-{index}` / `remove-photo-{index}`) so Maestro flows
@@ -121,14 +121,18 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({
       const selectedImage = await showImagePickerOptions();
 
       /** Early on visual feedback */
-      onAdd({ url: selectedImage.uri });
+      onAdd({ url: selectedImage.uri, localUri: selectedImage.uri });
       setLocalPicture(selectedImage.uri);
 
       const finalUrl = await uploadProfileImage(selectedImage.uri, (s) => {
         stage = s;
       });
 
-      onAdd({ url: finalUrl });
+      // The local URI rides along with the bucket URL for the rest of the
+      // form. The server only holds a fresh upload for a while, and the
+      // profile is not saved until the person has stopped typing, so keeping
+      // the file on hand is what lets the save recover on its own.
+      onAdd({ url: finalUrl, localUri: selectedImage.uri });
 
       // After the upload finishes, not after the picker closes: a photo that
       // never reaches the bucket is a shadowban, not a photo. Profiles without
@@ -183,14 +187,14 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({
 
       // Optimistic feedback identical to the real flow so screenshots/check
       // observers see the same intermediate state.
-      onAdd({ url: placeholderUri });
+      onAdd({ url: placeholderUri, localUri: placeholderUri });
       setLocalPicture(placeholderUri);
 
       const finalUrl = await uploadProfileImage(placeholderUri, (s) => {
         stage = s;
       });
 
-      onAdd({ url: finalUrl });
+      onAdd({ url: finalUrl, localUri: placeholderUri });
     } catch (error) {
       reportUploadFailure(
         error,

--- a/apps/mobile/src/components/ProfileImageUploader/index.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/index.tsx
@@ -40,7 +40,7 @@ const AddUserPhotoWrapper = ({
     });
   };
 
-  const onAdd = ({ url }: { url: string }) => {
+  const onAdd = ({ url, localUri }: { url: string; localUri?: string }) => {
     onChange((images) =>
       images
         .map((currentPicture) => {
@@ -51,6 +51,7 @@ const AddUserPhotoWrapper = ({
           return {
             ...currentPicture,
             url,
+            localUri,
             disabledDrag: false,
             disabledReSorted: false,
           };

--- a/apps/mobile/src/components/ProfileImageUploader/utils/index.ts
+++ b/apps/mobile/src/components/ProfileImageUploader/utils/index.ts
@@ -31,6 +31,15 @@ export type Picture = {
   position: number;
   status?: keyof typeof IMAGE_STATUS;
   blurhash?: string;
+  /**
+   * The photo as it still sits on the phone, kept for the whole life of the
+   * form. `url` points at a bucket object the server only holds for a while,
+   * and the profile is not saved until the person has finished typing, so
+   * this is what makes a second upload possible without asking them to pick
+   * the same photo again. Absent on photos loaded from an existing profile:
+   * those are already permanent.
+   */
+  localUri?: string;
 };
 
 export type DeletedPicture = Omit<Picture, "position">;

--- a/apps/mobile/src/contexts/trpc-provider.tsx
+++ b/apps/mobile/src/contexts/trpc-provider.tsx
@@ -2,7 +2,7 @@ import type { AppRouter } from "@pegada/api";
 
 import { useEffect } from "react";
 import * as React from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 
 import Constants from "expo-constants";
 
@@ -73,6 +73,10 @@ export const trpcQueryClient = api.createClient({
         const appVersion = Constants.expoConfig?.version ?? "0.0.0";
 
         headers.set(RequestHeaders.XAppVersion, appVersion);
+        // Which store this build came from, so the update floor can be raised
+        // on the platform a release is already live on without locking out the
+        // one still waiting on review.
+        headers.set(RequestHeaders.XAppPlatform, Platform.OS);
         headers.set(RequestHeaders.XTRPCSource, "expo-react");
         headers.set(RequestHeaders.AcceptLanguage, i18n.language);
 

--- a/apps/mobile/src/services/analytics/ota-properties.test.ts
+++ b/apps/mobile/src/services/analytics/ota-properties.test.ts
@@ -1,0 +1,98 @@
+import { buildOtaUpdateProperties } from "./ota-properties";
+
+/**
+ * The builder is the only thing standing between a readout that can prove an
+ * update arrived and one that reports `undefined` for every device. Its whole
+ * job is the awkward cases: a development client where the native module
+ * answers nothing, and a `Date` that PostHog would otherwise store as an
+ * object.
+ */
+describe("buildOtaUpdateProperties", () => {
+  it("reports the update a downloaded bundle came from", () => {
+    expect(
+      buildOtaUpdateProperties({
+        updateId: "0c2f3f10-6f2b-4a54-9f0f-9d0a1c3b7e21",
+        isEmbeddedLaunch: false,
+        runtimeVersion: "1.6.2",
+        channel: "production",
+        createdAt: new Date("2026-09-04T12:30:00.000Z"),
+      }),
+    ).toStrictEqual({
+      ota_update_id: "0c2f3f10-6f2b-4a54-9f0f-9d0a1c3b7e21",
+      ota_is_embedded: false,
+      runtime_version: "1.6.2",
+      ota_channel: "production",
+      ota_created_at: "2026-09-04T12:30:00.000Z",
+    });
+  });
+
+  it("keeps the embedded launch distinguishable from a downloaded one", () => {
+    // A store install that has not fetched anything yet still has an update id
+    // and a creation date: they describe the bundle baked into the binary.
+    expect(
+      buildOtaUpdateProperties({
+        updateId: "embedded-update-id",
+        isEmbeddedLaunch: true,
+        runtimeVersion: "1.6.2",
+        channel: "production",
+        createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      }).ota_is_embedded,
+    ).toBe(true);
+  });
+
+  it("returns nulls in a development client where nothing is defined", () => {
+    expect(buildOtaUpdateProperties({})).toStrictEqual({
+      ota_update_id: null,
+      ota_is_embedded: null,
+      runtime_version: null,
+      ota_channel: null,
+      ota_created_at: null,
+    });
+  });
+
+  it("does not turn an unknown embedded state into a false one", () => {
+    // `false` would be a claim that the device downloaded an update. Silence is
+    // the honest answer when the module is disabled.
+    expect(buildOtaUpdateProperties({}).ota_is_embedded).toBeNull();
+    expect(
+      buildOtaUpdateProperties({ isEmbeddedLaunch: false }).ota_is_embedded,
+    ).toBe(false);
+  });
+
+  it("treats explicit nulls the same as missing values", () => {
+    expect(
+      buildOtaUpdateProperties({
+        updateId: null,
+        runtimeVersion: null,
+        channel: null,
+        createdAt: null,
+      }),
+    ).toStrictEqual({
+      ota_update_id: null,
+      ota_is_embedded: null,
+      runtime_version: null,
+      ota_channel: null,
+      ota_created_at: null,
+    });
+  });
+
+  it("drops empty strings so they cannot look like a real update", () => {
+    expect(
+      buildOtaUpdateProperties({ updateId: "", runtimeVersion: "" }),
+    ).toMatchObject({ ota_update_id: null, runtime_version: null });
+  });
+
+  it("accepts a creation date that already arrived as a string", () => {
+    expect(
+      buildOtaUpdateProperties({ createdAt: "2026-09-04T12:30:00.000Z" })
+        .ota_created_at,
+    ).toBe("2026-09-04T12:30:00.000Z");
+  });
+
+  it("ignores an unusable date rather than sending Invalid Date", () => {
+    expect(
+      buildOtaUpdateProperties({ createdAt: new Date("nonsense") })
+        .ota_created_at,
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/src/services/analytics/ota-properties.ts
+++ b/apps/mobile/src/services/analytics/ota-properties.ts
@@ -1,0 +1,74 @@
+/**
+ * Which over the air update a device is actually running.
+ *
+ * `$app_version` comes from the binary, so every device that installed 1.6.2
+ * from the store reports 1.6.2 forever, whether it is running the JavaScript
+ * that shipped inside that binary or an `eas update` published months later.
+ * That makes "did the fix reach anyone?" unanswerable. These properties answer
+ * it: `ota_update_id` names the exact bundle, `ota_is_embedded` separates a
+ * device still on the shipped bundle from one that has downloaded an update,
+ * and `runtime_version` is the compatibility line an update was published
+ * against.
+ *
+ * Registered as super properties, so they ride along on every event rather
+ * than on the handful of call sites someone remembered to annotate.
+ */
+
+/**
+ * The shape read off `expo-updates`.
+ *
+ * Every field is optional even though the module's own types promise
+ * `string | null`: in a development client the constants are backed by a
+ * disabled native module and come back `undefined`, and Expo Go has no
+ * updates module at all. Typing the source honestly is what keeps the guards
+ * below from being dead code.
+ */
+export type OtaUpdateSource = {
+  updateId?: string | null;
+  isEmbeddedLaunch?: boolean | null;
+  runtimeVersion?: string | null;
+  channel?: string | null;
+  createdAt?: Date | string | null;
+};
+
+export type OtaUpdateProperties = {
+  ota_update_id: string | null;
+  ota_is_embedded: boolean | null;
+  runtime_version: string | null;
+  ota_channel: string | null;
+  ota_created_at: string | null;
+};
+
+/** `undefined` and empty strings both mean "nothing to report", not a value. */
+const text = (value: string | null | undefined) =>
+  typeof value === "string" && value.length > 0 ? value : null;
+
+/**
+ * PostHog stores whatever it is given, so a `Date` would land as an object on
+ * some transports and a locale string on others. ISO 8601 sorts and filters.
+ */
+const timestamp = (value: Date | string | null | undefined) => {
+  if (typeof value === "string") return text(value);
+  if (!(value instanceof Date)) return null;
+
+  const time = value.getTime();
+  return Number.isNaN(time) ? null : value.toISOString();
+};
+
+/**
+ * `null` rather than `false` when the module is not reporting, because
+ * "running the embedded bundle" and "we cannot tell" are different answers and
+ * the readout counts them separately.
+ */
+export const buildOtaUpdateProperties = (
+  source: OtaUpdateSource,
+): OtaUpdateProperties => ({
+  ota_update_id: text(source.updateId),
+  ota_is_embedded:
+    typeof source.isEmbeddedLaunch === "boolean"
+      ? source.isEmbeddedLaunch
+      : null,
+  runtime_version: text(source.runtimeVersion),
+  ota_channel: text(source.channel),
+  ota_created_at: timestamp(source.createdAt),
+});

--- a/apps/mobile/src/services/expired-upload-retry.test.ts
+++ b/apps/mobile/src/services/expired-upload-retry.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Issue #282, item 4: "This photo upload has expired" on Create Profile. The
+ * photos go to the bucket the moment they are picked, the name and the bio are
+ * typed afterwards, and the grant used to die ten minutes in. Save then failed,
+ * and the dead URLs stayed in form state, so every further tap failed the same
+ * way and the profile could not be saved at all.
+ *
+ * The server now holds the grant for an hour. This is the client half: one
+ * re-upload, one more save, and a toast if even that does not land.
+ */
+jest.mock<Record<string, unknown>>(
+  "@/components/ProfileImageUploader/utils",
+  () => ({ uploadProfileImage: jest.fn() }),
+);
+
+jest.mock<Record<string, unknown>>("react-native-magic-toast", () => ({
+  magicToast: { alert: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/i18n", () => ({
+  __esModule: true,
+  default: { t: (key: string) => key },
+}));
+
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
+import { magicToast } from "react-native-magic-toast";
+
+import { uploadProfileImage } from "@/components/ProfileImageUploader/utils";
+import { sendError } from "@/services/error-tracking";
+
+import { saveWithExpiredUploadRetry } from "./expired-upload-retry";
+
+const reupload = jest.mocked(uploadProfileImage);
+const alert = jest.mocked(magicToast.alert);
+const report = jest.mocked(sendError);
+
+/** What the tRPC client hands the caller for a server-thrown intentional error. */
+const expiredGrant = () => ({
+  data: {
+    error: {
+      error_code: InvalidUploadGrantError.error_code,
+      code: "BAD_REQUEST",
+    },
+  },
+});
+
+const photos = [
+  { id: "first", url: "https://cdn/stale-one.webp", localUri: "file://one" },
+  { id: "second", url: "https://cdn/stale-two.webp", localUri: "file://two" },
+];
+
+test("saves once and touches nothing when the photos are still good", async () => {
+  const save = jest.fn(async () => "saved");
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).resolves.toBe("saved");
+
+  expect(save).toHaveBeenCalledTimes(1);
+  expect(reupload).not.toHaveBeenCalled();
+});
+
+test("leaves any other failure alone rather than re-uploading on a hunch", async () => {
+  const offline = new TypeError("Network request failed");
+  const save = jest.fn(async () => {
+    throw offline;
+  });
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).rejects.toBe(offline);
+
+  expect(save).toHaveBeenCalledTimes(1);
+  expect(reupload).not.toHaveBeenCalled();
+  expect(alert).not.toHaveBeenCalled();
+});
+
+test("puts the photos back and saves again, once", async () => {
+  reupload
+    .mockResolvedValueOnce("https://cdn/fresh-one.webp")
+    .mockResolvedValueOnce("https://cdn/fresh-two.webp");
+
+  const save = jest
+    .fn<Promise<string>, [typeof photos]>()
+    .mockRejectedValueOnce(expiredGrant())
+    .mockResolvedValueOnce("saved");
+
+  const onReuploaded = jest.fn();
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save, onReuploaded }),
+  ).resolves.toBe("saved");
+
+  expect(reupload).toHaveBeenCalledTimes(2);
+  expect(reupload).toHaveBeenNthCalledWith(1, "file://one");
+  expect(reupload).toHaveBeenNthCalledWith(2, "file://two");
+
+  expect(save).toHaveBeenCalledTimes(2);
+  // The second attempt carries the new URLs, and the form gets them too, so a
+  // manual tap afterwards cannot resubmit the dead ones.
+  const freshened = [
+    { ...photos[0], url: "https://cdn/fresh-one.webp" },
+    { ...photos[1], url: "https://cdn/fresh-two.webp" },
+  ];
+  expect(save).toHaveBeenNthCalledWith(2, freshened);
+  expect(onReuploaded).toHaveBeenCalledWith(freshened);
+
+  // Nothing to tell the user about: the save went through.
+  expect(alert).not.toHaveBeenCalled();
+  expect(report).not.toHaveBeenCalled();
+});
+
+test("keeps a photo that only exists in the bucket exactly as it is", async () => {
+  const alreadySaved = [
+    { id: "old", url: "https://cdn/dogs/permanent.webp" },
+    { id: "new", url: "https://cdn/stale.webp", localUri: "file://new" },
+  ];
+  reupload.mockResolvedValueOnce("https://cdn/fresh.webp");
+
+  const save = jest
+    .fn<Promise<string>, [typeof alreadySaved]>()
+    .mockRejectedValueOnce(expiredGrant())
+    .mockResolvedValueOnce("saved");
+
+  await saveWithExpiredUploadRetry({ images: alreadySaved, save });
+
+  expect(reupload).toHaveBeenCalledTimes(1);
+  expect(save).toHaveBeenNthCalledWith(2, [
+    alreadySaved[0],
+    { ...alreadySaved[1], url: "https://cdn/fresh.webp" },
+  ]);
+});
+
+test("tells the user and stops when the second save fails too", async () => {
+  reupload.mockResolvedValue("https://cdn/fresh.webp");
+
+  const stillExpired = expiredGrant();
+  const save = jest
+    .fn<Promise<string>, [typeof photos]>()
+    .mockRejectedValueOnce(expiredGrant())
+    .mockRejectedValueOnce(stillExpired);
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).rejects.toBe(stillExpired);
+
+  expect(save).toHaveBeenCalledTimes(2);
+  expect(reupload).toHaveBeenCalledTimes(photos.length);
+  expect(alert).toHaveBeenCalledWith("editProfile.photosExpired");
+  expect(report).toHaveBeenCalledWith(stillExpired);
+});
+
+test("tells the user and stops when the photos cannot go back up", async () => {
+  const uploadFailed = new Error("upload PUT returned 500");
+  reupload.mockRejectedValue(uploadFailed);
+
+  const save = jest
+    .fn<Promise<string>, [typeof photos]>()
+    .mockRejectedValueOnce(expiredGrant());
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).rejects.toBe(uploadFailed);
+
+  expect(save).toHaveBeenCalledTimes(1);
+  expect(alert).toHaveBeenCalledWith("editProfile.photosExpired");
+});

--- a/apps/mobile/src/services/expired-upload-retry.ts
+++ b/apps/mobile/src/services/expired-upload-retry.ts
@@ -1,0 +1,73 @@
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
+import { magicToast } from "react-native-magic-toast";
+
+import { uploadProfileImage } from "@/components/ProfileImageUploader/utils";
+import i18n from "@/i18n";
+import { sendError } from "@/services/error-tracking";
+import { getError } from "@/services/get-error";
+
+export type RetryableImage = {
+  url: string;
+  /** Present only while the photo is still on the phone. */
+  localUri?: string;
+};
+
+/**
+ * Save a dog profile, and if the server says the photos went stale, put them
+ * back in the bucket and save one more time.
+ *
+ * Issue #282: Create Profile uploads the photos as soon as they are picked,
+ * then waits for a name, a bio and a gender. The upload grant used to last ten
+ * minutes, so a form filled in slowly failed on save with
+ * `INVALID_UPLOAD_GRANT`, and because the dead URLs stayed in form state every
+ * further tap failed the same way. The grant now lasts an hour, which is the
+ * real fix; this is the floor under it, for the person who leaves the screen
+ * open over lunch or whose phone slept through the whole form.
+ *
+ * Exactly one extra attempt. A loop here would mean re-uploading every photo
+ * on a phone that is failing for some other reason, on someone else's data
+ * plan, forever.
+ */
+export const saveWithExpiredUploadRetry = async <
+  TImage extends RetryableImage,
+  TResult,
+>({
+  images,
+  save,
+  onReuploaded,
+}: {
+  images: TImage[];
+  save: (images: TImage[]) => Promise<TResult>;
+  /**
+   * Hand the fresh URLs back to the form. Without this a manual tap after a
+   * failed retry would submit the dead ones all over again.
+   */
+  onReuploaded?: (images: TImage[]) => void;
+}): Promise<TResult> => {
+  try {
+    return await save(images);
+  } catch (error) {
+    if (!getError(error, InvalidUploadGrantError)) throw error;
+
+    try {
+      const reuploaded = await Promise.all(
+        images.map(async (image) =>
+          image.localUri
+            ? { ...image, url: await uploadProfileImage(image.localUri) }
+            : image,
+        ),
+      );
+
+      onReuploaded?.(reuploaded);
+
+      return await save(reuploaded);
+    } catch (retryError) {
+      // Only now is it worth anyone's attention: the first failure is one the
+      // app recovers from by itself, and reporting it would keep the exception
+      // rows in the issue #188 audit alive for a problem that fixed itself.
+      magicToast.alert(i18n.t("editProfile.photosExpired"));
+      sendError(retryError);
+      throw retryError;
+    }
+  }
+};

--- a/apps/mobile/src/services/force-update.ts
+++ b/apps/mobile/src/services/force-update.ts
@@ -1,0 +1,92 @@
+import type { AppStateStatus } from "react-native";
+
+import { useEffect } from "react";
+import { AppState } from "react-native";
+
+import Constants from "expo-constants";
+import { router } from "expo-router";
+
+import { getTrcpContext } from "@/contexts/trcp-context";
+import { sendError } from "@/services/error-tracking";
+import { SceneName } from "@/types/scene-name";
+
+/** The build the user is on, in the same shape the API compares against. */
+export const getAppVersion = () => Constants.expoConfig?.version ?? "0.0.0";
+
+/**
+ * The floor the API last reported, kept so the update screen can name it in
+ * its analytics without a second round trip on a screen that has no network
+ * state of its own.
+ *
+ * It starts at the running version, which reads as "no gate" until an answer
+ * arrives, and an older API that does not send the floor yet leaves it there.
+ */
+let minimumSupportedVersion = getAppVersion();
+
+export const getMinimumSupportedVersion = () => minimumSupportedVersion;
+
+export const rememberMinimumSupportedVersion = (version?: string) => {
+  if (version) minimumSupportedVersion = version;
+};
+
+/**
+ * A launch is not the only moment a build can fall below the floor.
+ *
+ * The floor is raised by hand, hours after a store approval, and the phones
+ * that matter most at that moment are the ones that never cold start: the app
+ * sits in the background for days and comes back to the same JS context, so
+ * the check on `getInitialRouteName` never runs again. This re-asks on the way
+ * back to the foreground.
+ *
+ * Once the wall is up it stops asking, so a later foreground does not navigate
+ * again and report a second `Update Required Shown` for one wall. That flag is
+ * only ever set after the navigation succeeds: latching it on an attempt that
+ * threw would leave the app both ungated and no longer asking.
+ */
+let blocked = false;
+
+/** Long enough that flicking between apps does not turn into a request each time. */
+const RECHECK_INTERVAL_MS = 60_000;
+let lastCheckedAt = 0;
+
+export const useForceUpdateOnForeground = () => {
+  useEffect(() => {
+    const onChange = (status: AppStateStatus) => {
+      if (status !== "active" || blocked) return;
+
+      const now = Date.now();
+      if (now - lastCheckedAt < RECHECK_INTERVAL_MS) return;
+      lastCheckedAt = now;
+
+      const check = async () => {
+        try {
+          const { forceUpdate, minimumSupportedVersion: minimum } =
+            await getTrcpContext().client.echo.get.query();
+
+          rememberMinimumSupportedVersion(minimum);
+
+          if (!forceUpdate) return;
+
+          // `replace` alone only swaps the top of the stack: everything the
+          // user had pushed stays underneath, and one back gesture puts them
+          // straight back into the app the floor just locked them out of.
+          // Clearing the stack first leaves the wall with nothing behind it.
+          if (router.canDismiss()) router.dismissAll();
+          router.replace(SceneName.ForceUpdate);
+          blocked = true;
+        } catch (error) {
+          // Fail open. This runs on every foreground, so a flaky network or an
+          // API that is briefly down would otherwise wall off an app that is
+          // perfectly up to date.
+          sendError(error);
+        }
+      };
+
+      void check();
+    };
+
+    const subscription = AppState.addEventListener("change", onChange);
+
+    return () => subscription.remove();
+  }, []);
+};

--- a/apps/mobile/src/services/force-update.ts
+++ b/apps/mobile/src/services/force-update.ts
@@ -8,6 +8,7 @@ import { router } from "expo-router";
 
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { sendError } from "@/services/error-tracking";
+import { rememberFreeDailyLikeLimit } from "@/services/free-daily-like-limit";
 import { SceneName } from "@/types/scene-name";
 
 /** The build the user is on, in the same shape the API compares against. */
@@ -60,10 +61,14 @@ export const useForceUpdateOnForeground = () => {
 
       const check = async () => {
         try {
-          const { forceUpdate, minimumSupportedVersion: minimum } =
-            await getTrcpContext().client.echo.get.query();
+          const {
+            forceUpdate,
+            freeDailyLikeLimit,
+            minimumSupportedVersion: minimum,
+          } = await getTrcpContext().client.echo.get.query();
 
           rememberMinimumSupportedVersion(minimum);
+          rememberFreeDailyLikeLimit(freeDailyLikeLimit);
 
           if (!forceUpdate) return;
 

--- a/apps/mobile/src/services/free-daily-like-limit.ts
+++ b/apps/mobile/src/services/free-daily-like-limit.ts
@@ -1,0 +1,18 @@
+import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
+
+/**
+ * The free like allowance the API last reported.
+ *
+ * The server decides this from an environment variable, so the number is
+ * allowed to change without a new build and a shipped constant is only ever a
+ * guess. It starts at the value this build was compiled with, which is the
+ * right answer until the launch query says otherwise and stays the answer on
+ * an older API that does not send the field.
+ */
+let freeDailyLikeLimit = FREE_DAILY_SWIPE_LIMIT;
+
+export const getFreeDailyLikeLimit = () => freeDailyLikeLimit;
+
+export const rememberFreeDailyLikeLimit = (limit?: number) => {
+  if (limit && limit > 0) freeDailyLikeLimit = limit;
+};

--- a/apps/mobile/src/services/get-initial-route-name.test.ts
+++ b/apps/mobile/src/services/get-initial-route-name.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The defect: the launch query got one attempt, and every failure of it -
+ * including the cold start timeout the app already retries everywhere else -
+ * landed the user on sign in. A user with a valid token in storage was sent to
+ * a screen they were already past, and the login there answers "Already logged
+ * in", so there was no way out but reinstalling.
+ *
+ * A token on disk outlives a failed request. It is the only evidence of a
+ * session this function has when nothing answers, so it decides the fallback.
+ *
+ * Every React Native flavoured import is stubbed, matching the other tests in
+ * this package: there is no RN transform here.
+ */
+import { getTrcpContext } from "@/contexts/trcp-context";
+import { getData } from "@/services/storage";
+import { TRANSIENT_RETRY_ATTEMPTS } from "@/services/transient-retry";
+import { SceneName } from "@/types/scene-name";
+
+import {
+  getInitialRouteName,
+  LAUNCH_ROUTE_BUDGET_MS,
+} from "./get-initial-route-name";
+
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+jest.mock<Record<string, unknown>>("expo-constants", () => ({
+  __esModule: true,
+  default: { expoConfig: { version: "1.7.2" } },
+}));
+
+jest.mock<Record<string, unknown>>("@/contexts/trcp-context", () => ({
+  getTrcpContext: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { identify: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/force-update", () => ({
+  rememberMinimumSupportedVersion: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/get-logged-user-id", () => ({
+  getLoggedUserID: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/storage", () => ({
+  getData: jest.fn(),
+  StorageKeys: { Token: "token" },
+}));
+
+const echoQuery = jest.fn();
+const myDogFetch = jest.fn();
+
+const mockGetData = jest.mocked(getData);
+
+/** The failure this function is built around: an attempt that never answered. */
+const timedOut = () => Promise.reject(new TypeError("Aborted"));
+
+/** A server that accepted the connection and then went quiet. */
+const neverAnswers = () =>
+  new Promise(() => {
+    // Accepted, and then nothing.
+  });
+
+/** The same, but honouring the abort the launch attaches to each attempt. */
+const hangsUntilAbandoned = (
+  _input: unknown,
+  options: { signal: AbortSignal },
+) =>
+  new Promise((_resolve, reject) => {
+    options.signal.addEventListener("abort", () => {
+      reject(new TypeError("Aborted"));
+    });
+  });
+
+const dogWithLocation = {
+  images: [],
+  user: { latitude: -23.5, longitude: -46.6 },
+};
+
+beforeEach(() => {
+  jest.mocked(getTrcpContext).mockReturnValue({
+    client: { echo: { get: { query: echoQuery } } },
+    myDog: { get: { fetch: myDogFetch } },
+  } as unknown as ReturnType<typeof getTrcpContext>);
+
+  echoQuery.mockReset();
+  myDogFetch.mockReset();
+  myDogFetch.mockResolvedValue(dogWithLocation);
+  mockGetData.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test("opens the app when the launch query never answers and a token is stored", async () => {
+  echoQuery.mockImplementation(timedOut);
+  mockGetData.mockResolvedValue("stored-token");
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.Swipe);
+});
+
+test("still sends a device with no token to sign in", async () => {
+  echoQuery.mockImplementation(timedOut);
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.SignIn);
+});
+
+test("retries the launch query instead of giving up on the first timeout", async () => {
+  echoQuery.mockImplementation(timedOut);
+  mockGetData.mockResolvedValue("stored-token");
+
+  await getInitialRouteName();
+
+  expect(echoQuery).toHaveBeenCalledTimes(TRANSIENT_RETRY_ATTEMPTS + 1);
+});
+
+test("routes normally when a retry recovers the launch query", async () => {
+  echoQuery
+    .mockImplementationOnce(timedOut)
+    .mockResolvedValue({ authenticated: true, forceUpdate: false });
+  mockGetData.mockResolvedValue("stored-token");
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.Swipe);
+});
+
+test("sends the user to sign in when the server answers that the token is not valid", async () => {
+  echoQuery.mockResolvedValue({ authenticated: false, forceUpdate: false });
+  mockGetData.mockResolvedValue("stored-token");
+
+  // An answer, not a failure: the server looked at the token and refused it.
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.SignIn);
+  expect(echoQuery).toHaveBeenCalledTimes(1);
+});
+
+test("keeps a token holder out of sign in when the dog query is the one that fails", async () => {
+  echoQuery.mockResolvedValue({ authenticated: true, forceUpdate: false });
+  myDogFetch.mockImplementation(timedOut);
+  mockGetData.mockResolvedValue("stored-token");
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.Swipe);
+});
+
+test("gives up on the splash screen once the launch budget is spent", async () => {
+  jest.useFakeTimers();
+  echoQuery.mockImplementation(neverAnswers);
+  mockGetData.mockResolvedValue("stored-token");
+
+  const routeName = getInitialRouteName();
+  await jest.advanceTimersByTimeAsync(LAUNCH_ROUTE_BUDGET_MS);
+
+  // A server that accepts the connection and then says nothing cannot hold the
+  // splash screen open. The stored token answers from disk instead.
+  await expect(routeName).resolves.toBe(SceneName.Swipe);
+});
+
+test("abandons a hanging attempt in time to make another inside the budget", async () => {
+  jest.useFakeTimers();
+  echoQuery.mockImplementation(hangsUntilAbandoned);
+  mockGetData.mockResolvedValue("stored-token");
+
+  const routeName = getInitialRouteName();
+  await jest.advanceTimersByTimeAsync(LAUNCH_ROUTE_BUDGET_MS);
+
+  await expect(routeName).resolves.toBe(SceneName.Swipe);
+  // Two attempts, not one that ran out the clock and not a third the budget
+  // could not pay for.
+  expect(echoQuery).toHaveBeenCalledTimes(2);
+});
+
+test("keeps the launch budget inside a wait someone will sit through", () => {
+  // `useProtectedRoute` runs the launch again when the route segments change,
+  // so the worst case a user feels is twice this.
+  expect(LAUNCH_ROUTE_BUDGET_MS).toBeLessThanOrEqual(10_000);
+});

--- a/apps/mobile/src/services/get-initial-route-name.ts
+++ b/apps/mobile/src/services/get-initial-route-name.ts
@@ -8,6 +8,11 @@ import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
 import { rememberMinimumSupportedVersion } from "@/services/force-update";
 import { getLoggedUserID } from "@/services/get-logged-user-id";
+import { getData, StorageKeys } from "@/services/storage";
+import {
+  shouldRetryTransient,
+  transientRetryDelayMs,
+} from "@/services/transient-retry";
 import { SceneName } from "@/types/scene-name";
 
 import { sendError } from "./error-tracking";
@@ -57,10 +62,108 @@ export const trackUser = () => {
   });
 };
 
-export const getInitialRouteName = async () => {
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Ceiling on one attempt at the launch query.
+ *
+ * Deliberately shorter than the tRPC client's own 15 second ceiling (see
+ * contexts/trpc-provider). That one is sized for a request a screen is waiting
+ * to render, where waiting is the only option. This one is sized for a request
+ * the splash screen is waiting on, where a second attempt is worth more than a
+ * long first one. Four seconds clears a function that has to boot and a Prisma
+ * engine that has to start, and leaves room for the retries inside the budget
+ * below.
+ */
+const LAUNCH_QUERY_TIMEOUT_MS = 4_000;
+
+/**
+ * Ceiling on the whole decision, retries and the dog query included.
+ *
+ * The fallback below answers the same question from disk, instantly, so there
+ * is no reason to hold the splash screen much past one cold boot while the
+ * network makes its mind up. `useProtectedRoute` re-runs this when the route
+ * segments change, so an unbounded launch was paid for twice: a phone with no
+ * connection sat on the splash screen for a minute and a half.
+ */
+export const LAUNCH_ROUTE_BUDGET_MS = 10_000;
+
+/**
+ * One attempt at the launch query, abandoned rather than left hanging.
+ *
+ * `client.echo.get.query()` goes straight down the tRPC client, so nothing
+ * retries it and nothing but the client's own long timeout stops it: the first
+ * request of a cold deployment is also the one request every launch waits on,
+ * and a single blip on it used to decide where the user lands.
+ */
+const queryLaunchState = async () => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), LAUNCH_QUERY_TIMEOUT_MS);
+
+  try {
+    return await getTrcpContext().client.echo.get.query(undefined, {
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Retries the launch query under the same policy the auth mutations use, for
+ * as long as the budget can still pay for another attempt. React Query already
+ * retries `myDog.get.fetch()`, so only this call needs the wrapper.
+ */
+const withTransientRetry = async <T>(
+  run: () => Promise<T>,
+  deadline: number,
+  failureCount = 0,
+): Promise<T> => {
+  try {
+    return await run();
+  } catch (error) {
+    if (!shouldRetryTransient(failureCount, error)) throw error;
+
+    const delay = transientRetryDelayMs(failureCount);
+    // Never start an attempt that cannot finish before the budget runs out.
+    // Firing it would cost a request nobody is left waiting for.
+    if (Date.now() + delay + LAUNCH_QUERY_TIMEOUT_MS > deadline) throw error;
+
+    await wait(delay);
+    return withTransientRetry(run, deadline, failureCount + 1);
+  }
+};
+
+/**
+ * Where to land when the launch query never answered.
+ *
+ * The stored token is the only evidence of a session that survives a failed
+ * request, and this branch runs precisely when no request succeeded. Sending a
+ * user who holds one to sign in was the loop: they are already signed in, so
+ * the login mutation answers "Already logged in" and there is no way forward.
+ *
+ * Into the app instead. Every screen there fetches for itself, and a token the
+ * server actually rejects comes back as a 401, which the tRPC client turns
+ * into a real logout. Sign in stays the answer for a device with no token,
+ * which is the only case where it is the truth.
+ */
+const getOfflineRouteName = async () => {
+  try {
+    const token = await getData(StorageKeys.Token);
+    return token ? SceneName.Swipe : SceneName.SignIn;
+  } catch (error) {
+    sendError(error);
+    return SceneName.SignIn;
+  }
+};
+
+const resolveInitialRouteName = async (deadline: number) => {
   try {
     const { authenticated, forceUpdate, minimumSupportedVersion } =
-      await getTrcpContext().client.echo.get.query();
+      await withTransientRetry(queryLaunchState, deadline);
 
     rememberMinimumSupportedVersion(minimumSupportedVersion);
 
@@ -68,6 +171,8 @@ export const getInitialRouteName = async () => {
       return SceneName.ForceUpdate;
     }
 
+    // The server looked at the token and said no. That is an answer, not a
+    // failure, so sign in is correct here even with a token on disk.
     if (!authenticated) {
       return SceneName.SignIn;
     }
@@ -85,6 +190,24 @@ export const getInitialRouteName = async () => {
     return SceneName.Swipe;
   } catch (error) {
     sendError(error);
-    return SceneName.SignIn;
+    return getOfflineRouteName();
+  }
+};
+
+export const getInitialRouteName = async () => {
+  const deadline = Date.now() + LAUNCH_ROUTE_BUDGET_MS;
+
+  let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+  const budgetSpent = new Promise<void>((resolve) => {
+    budgetTimer = setTimeout(resolve, LAUNCH_ROUTE_BUDGET_MS);
+  });
+
+  try {
+    return await Promise.race([
+      resolveInitialRouteName(deadline),
+      budgetSpent.then(getOfflineRouteName),
+    ]);
+  } finally {
+    clearTimeout(budgetTimer);
   }
 };

--- a/apps/mobile/src/services/get-initial-route-name.ts
+++ b/apps/mobile/src/services/get-initial-route-name.ts
@@ -6,6 +6,7 @@ import Constants from "expo-constants";
 
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
+import { rememberMinimumSupportedVersion } from "@/services/force-update";
 import { getLoggedUserID } from "@/services/get-logged-user-id";
 import { SceneName } from "@/types/scene-name";
 
@@ -58,8 +59,10 @@ export const trackUser = () => {
 
 export const getInitialRouteName = async () => {
   try {
-    const { authenticated, forceUpdate } =
+    const { authenticated, forceUpdate, minimumSupportedVersion } =
       await getTrcpContext().client.echo.get.query();
+
+    rememberMinimumSupportedVersion(minimumSupportedVersion);
 
     if (forceUpdate) {
       return SceneName.ForceUpdate;

--- a/apps/mobile/src/services/get-initial-route-name.ts
+++ b/apps/mobile/src/services/get-initial-route-name.ts
@@ -7,6 +7,7 @@ import Constants from "expo-constants";
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
 import { rememberMinimumSupportedVersion } from "@/services/force-update";
+import { rememberFreeDailyLikeLimit } from "@/services/free-daily-like-limit";
 import { getLoggedUserID } from "@/services/get-logged-user-id";
 import { getData, StorageKeys } from "@/services/storage";
 import {
@@ -162,10 +163,15 @@ const getOfflineRouteName = async () => {
 
 const resolveInitialRouteName = async (deadline: number) => {
   try {
-    const { authenticated, forceUpdate, minimumSupportedVersion } =
-      await withTransientRetry(queryLaunchState, deadline);
+    const {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit,
+      minimumSupportedVersion,
+    } = await withTransientRetry(queryLaunchState, deadline);
 
     rememberMinimumSupportedVersion(minimumSupportedVersion);
+    rememberFreeDailyLikeLimit(freeDailyLikeLimit);
 
     if (forceUpdate) {
       return SceneName.ForceUpdate;

--- a/apps/mobile/src/services/linking/handlers/initial-notification.ts
+++ b/apps/mobile/src/services/linking/handlers/initial-notification.ts
@@ -1,24 +1,67 @@
 /**
- * The notification URL the app was cold-launched from, if any.
+ * The notification tap waiting to be handled, if any.
  *
  * Held in a module-local binding with an accessor rather than exported as a
  * `let`: a re-exported mutable binding is a live view of someone else's
  * variable, which is exactly the shape `import/no-mutable-exports` exists to
  * stop, and callers only ever need "read it" and "clear it".
+ *
+ * Every tap lands here, because the listener in `_layout.tsx` runs for the
+ * whole app lifetime, cold start and warm tap alike. Only one of them still
+ * needs handling from here: a warm tap is already handled on the spot by the
+ * listener `processLinks` registers. So the store is consume-once, keyed by
+ * the notification id, and the pair below is what enforces it.
  */
-let initialNotificationUrl: string | undefined;
-let initialNotificationKind: string | undefined;
+type StoredNotification = {
+  id: string;
+  url?: string;
+  /**
+   * Which scheduled nudge the notification came from, if any. Kept beside the
+   * url so the open reported on launch carries the same breakdown the one
+   * reported while the app runs does.
+   */
+  kind?: string;
+};
 
-export const getInitialNotification = () => initialNotificationUrl;
+let storedNotification: StoredNotification | undefined;
+let lastHandledId: string | undefined;
+
+export const setInitialNotification = (
+  notification?: StoredNotification,
+): void => {
+  storedNotification = notification;
+};
 
 /**
- * Which scheduled nudge the cold-start notification came from, if any. Kept
- * beside the url so the open reported on launch carries the same breakdown the
- * one reported while the app runs does.
+ * Takes ownership of a tap. Returns false when this exact tap was already
+ * handled, which is what keeps one tap to one `Push Notification Opened`.
+ *
+ * A single id is enough memory: only one tap is ever stored at a time, so the
+ * only replay to defend against is of the tap that was just handled.
  */
-export const getInitialNotificationKind = () => initialNotificationKind;
+export const claimNotification = (id: string): boolean => {
+  if (id && id === lastHandledId) return false;
 
-export const setInitialNotification = (url?: string, kind?: string) => {
-  initialNotificationUrl = url;
-  initialNotificationKind = kind;
+  lastHandledId = id;
+  // The tap being handled right now is also sitting in the store, written
+  // there by the app-wide listener. Dropping it as it is claimed is what
+  // stops the next mount of the Swipe screen replaying it.
+  if (storedNotification?.id === id) storedNotification = undefined;
+
+  return true;
+};
+
+/**
+ * Reads the stored tap and clears it in the same call, so a second read can
+ * never see it. Returns nothing when the tap was already handled elsewhere.
+ */
+export const consumeInitialNotification = ():
+  | StoredNotification
+  | undefined => {
+  const notification = storedNotification;
+  storedNotification = undefined;
+
+  if (!notification || !claimNotification(notification.id)) return undefined;
+
+  return notification;
 };

--- a/apps/mobile/src/services/linking/handlers/notification.ts
+++ b/apps/mobile/src/services/linking/handlers/notification.ts
@@ -31,6 +31,18 @@ export const getNotificationKind = (
   return response.notification.request.content.data?.kind as string | undefined;
 };
 
+/**
+ * Identity of a tap, so the same one is never reported twice. Two listeners
+ * see every warm tap (one in `_layout.tsx`, one in `processLinks`) and
+ * `getLastNotificationResponseAsync` keeps handing the last one back, so
+ * "have I already handled this?" needs something stable to ask about.
+ */
+export const getNotificationId = (
+  response: Notifications.NotificationResponse,
+): string => {
+  return response.notification.request.identifier;
+};
+
 const handleUnknownNotification = (url: string) => {
   sendError(new Error(`Unknown notification: ${url}`));
 };

--- a/apps/mobile/src/services/linking/index.test.ts
+++ b/apps/mobile/src/services/linking/index.test.ts
@@ -1,0 +1,162 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { router } from "expo-router";
+
+jest.mock<Partial<typeof import("expo-router")>>("expo-router", () => ({
+  router: { push: jest.fn() } as unknown as typeof import("expo-router").router,
+}));
+
+// The module under test also wires up notification handling
+// (useGetInitialNotifications / processLinks), which pulls in
+// expo-notifications and the observability stack at import time. The stub
+// keeps the import side-effect-free the way action.test.ts mocks
+// error-tracking, and doubles as the tap simulator the replay tests drive:
+// it hands back the registered listeners so a tap can be delivered to every
+// one of them, exactly as the native module does.
+jest.mock<Record<string, unknown>>("expo-notifications", () => ({
+  addNotificationResponseReceivedListener: (
+    listener: (response: unknown) => void,
+  ) => {
+    mockResponseListeners.add(listener);
+    return {
+      remove: () => {
+        mockResponseListeners.delete(listener);
+      },
+    };
+  },
+  getLastNotificationResponseAsync: () =>
+    Promise.resolve(mockLastNotificationResponse),
+}));
+
+const mockResponseListeners = new Set<(response: unknown) => void>();
+let mockLastNotificationResponse: unknown = null;
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { track: jest.fn() },
+}));
+
+// `useGetInitialNotifications` registers the app wide listener inside a plain
+// `useEffect`, and `renderToStaticMarkup` has no commit phase — real
+// `useEffect` never fires under it. Running the callback inline mirrors how
+// this package's other tests stub effect-shaped hooks for the same reason
+// (see NewMatch's `useFocusEffect` stub): a static render already stands in
+// for "the effect ran".
+jest.mock<Record<string, unknown>>("react", () => {
+  const actual = jest.requireActual("react") as typeof React;
+  return {
+    ...actual,
+    useEffect: (effect: () => void) => effect(),
+  };
+});
+
+import { analytics } from "@/services/analytics";
+
+import { processLinks, useGetInitialNotifications } from ".";
+import { setInitialNotification } from "./handlers/initial-notification";
+
+const push = jest.mocked(router.push);
+const track = jest.mocked(analytics.track);
+
+const notificationResponse = (identifier: string, url: string) => ({
+  notification: { request: { identifier, content: { data: { url } } } },
+});
+
+/** Mounts the root layout, which is where the app wide tap listener lives. */
+const mountLayout = async () => {
+  const LayoutHarness = () => {
+    useGetInitialNotifications();
+    return null;
+  };
+
+  renderToStaticMarkup(React.createElement(LayoutHarness));
+  // getLastNotificationResponseAsync resolves on a microtask, and the cold
+  // start tap is only stored once it does.
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+/** Delivers a tap to every registered listener, the way the OS does. */
+const tap = (response: ReturnType<typeof notificationResponse>) => {
+  for (const listener of mockResponseListeners) listener(response);
+};
+
+const countReported = (eventType: string) =>
+  track.mock.calls.filter(([event]) => event.event_type === eventType).length;
+
+afterEach(() => {
+  mockResponseListeners.clear();
+  mockLastNotificationResponse = null;
+  setInitialNotification(undefined);
+  track.mockClear();
+  push.mockClear();
+});
+
+test("reports a cold start tap once, and not again when Swipe remounts", async () => {
+  mockLastNotificationResponse = notificationResponse("cold-1", "swipe");
+  await mountLayout();
+
+  const firstMount = processLinks();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+
+  firstMount.remove();
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+});
+
+test("reports a tap taken while the app is open once, and not again when Swipe remounts", async () => {
+  await mountLayout();
+  const firstMount = processLinks();
+
+  tap(notificationResponse("warm-1", "swipe"));
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+
+  firstMount.remove();
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(countReported("Deep Link Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+});
+
+test("handles a tap taken while Swipe is unmounted on the next mount, once", async () => {
+  await mountLayout();
+  processLinks().remove();
+
+  tap(notificationResponse("warm-2", "swipe"));
+
+  expect(countReported("Push Notification Opened")).toBe(0);
+
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(1);
+  expect(push).toHaveBeenCalledTimes(1);
+});
+
+test("reports nothing when Swipe mounts with no tap waiting", async () => {
+  await mountLayout();
+
+  processLinks().remove();
+  processLinks().remove();
+
+  expect(countReported("Push Notification Opened")).toBe(0);
+  expect(push).not.toHaveBeenCalled();
+});

--- a/apps/mobile/src/services/linking/index.ts
+++ b/apps/mobile/src/services/linking/index.ts
@@ -5,18 +5,23 @@ import * as Notifications from "expo-notifications";
 import { sendError } from "@/services/error-tracking";
 
 import {
-  getInitialNotification,
-  getInitialNotificationKind,
+  claimNotification,
+  consumeInitialNotification,
   setInitialNotification,
 } from "./handlers/initial-notification";
 import {
   customNotificationHandler,
+  getNotificationId,
   getNotificationKind,
   getNotificationUrl,
 } from "./handlers/notification";
 
 export const processLinks = () => {
-  const initialNotification = getInitialNotification();
+  // Consuming clears the stored tap in the same call, and hands back nothing
+  // for a tap the listener below already handled. Without that, every mount of
+  // this screen re-ran the whole handler on the last tap: a second
+  // "Push Notification Opened", and a second jump to the notification target.
+  const initialNotification = consumeInitialNotification();
 
   if (initialNotification) {
     // The handler is synchronous — expo-router's push is — so a rejected
@@ -24,19 +29,22 @@ export const processLinks = () => {
     // url" was, and `.catch` never saw it.
     try {
       customNotificationHandler(
-        initialNotification,
-        getInitialNotificationKind(),
+        initialNotification.url,
+        initialNotification.kind,
       );
     } catch (error) {
       sendError(error);
     }
   }
 
-  setInitialNotification(undefined);
-
   // When the app is already running, and the user clicks on a notification
   const notificationSubscription =
     Notifications.addNotificationResponseReceivedListener((response) => {
+      // Claiming here is what marks the tap as spent for the mount path, and
+      // it also covers two of these listeners briefly overlapping while the
+      // screen remounts.
+      if (!claimNotification(getNotificationId(response))) return;
+
       const url = getNotificationUrl(response);
       try {
         customNotificationHandler(url, getNotificationKind(response));
@@ -52,28 +60,28 @@ export const processLinks = () => {
   };
 };
 
+const storeNotification = (response: Notifications.NotificationResponse) => {
+  setInitialNotification({
+    id: getNotificationId(response),
+    url: getNotificationUrl(response),
+    kind: getNotificationKind(response),
+  });
+};
+
 export const useGetInitialNotifications = () => {
   useEffect(() => {
     // When the app is not already running, and the user clicks on a notification
     Notifications.getLastNotificationResponseAsync()
       .then((response) => {
         if (!response) return;
-        setInitialNotification(
-          getNotificationUrl(response),
-          getNotificationKind(response),
-        );
+        storeNotification(response);
         return undefined;
       })
       .catch(sendError);
 
     // When the app is already running, and the user clicks on a notification
     const notificationSubscription =
-      Notifications.addNotificationResponseReceivedListener((response) => {
-        setInitialNotification(
-          getNotificationUrl(response),
-          getNotificationKind(response),
-        );
-      });
+      Notifications.addNotificationResponseReceivedListener(storeNotification);
 
     return () => {
       notificationSubscription.remove();

--- a/apps/mobile/src/services/observability.ts
+++ b/apps/mobile/src/services/observability.ts
@@ -2,6 +2,7 @@ import * as Updates from "expo-updates";
 
 import { getExpoPostHog, initExpo } from "magic-observability/expo";
 
+import { buildOtaUpdateProperties } from "@/services/analytics/ota-properties";
 import { config } from "@/services/config";
 
 /**
@@ -47,6 +48,18 @@ export const observability = initExpo({
   sessionReplay: false,
   posthogOptions: { captureAppLifecycleEvents: false },
 });
+
+/**
+ * Every event carries the update the device is running, not just the binary
+ * version it was installed from.
+ *
+ * Store users sit on build 1.6.2 while `main` publishes to a newer runtime, so
+ * `$app_version` alone cannot say whether a fix published as an OTA update has
+ * reached anybody. Registering these once, here, means the answer is already in
+ * the data by the time somebody thinks to ask, including on the `$exception`
+ * events the error tracker sends without going through `analytics.track`.
+ */
+observability.register(buildOtaUpdateProperties(Updates));
 
 /**
  * The raw `posthog-react-native` instance, or `null` when telemetry is off.

--- a/apps/mobile/src/services/payments/index.ts
+++ b/apps/mobile/src/services/payments/index.ts
@@ -441,10 +441,32 @@ const restorePurchases = async () => {
   await Purchases.restorePurchases();
 };
 
+/**
+ * What a completed purchase actually was, for the analytics call site.
+ *
+ * `Upgrade` with `type: "success"` is the only client side signal that somebody
+ * paid, and on its own it cannot tell an App Store charge from a sandbox one or
+ * from the grant the Maestro flows hand themselves. All three read as revenue
+ * in the readout and only one of them is, which is how successful upgrades can
+ * show up with no matching RevenueCat webhook event behind them.
+ *
+ * `null` rather than `false` when the entitlement is missing, because "not a
+ * sandbox purchase" and "we could not read the receipt" are different answers.
+ */
+const describePurchase = (customerInfo?: CustomerInfo | null) => {
+  const entitlement = customerInfo?.entitlements.active[Entitlement.Premium];
+
+  return {
+    is_sandbox: entitlement?.isSandbox ?? null,
+    source: isMaestroMockMode ? ("maestro_mock" as const) : ("store" as const),
+  };
+};
+
 export const payments = {
   init,
   getOfferings,
   purchasePackage,
+  describePurchase,
   getPlan,
   logIn,
   restorePurchases,

--- a/apps/mobile/src/services/storage.test.ts
+++ b/apps/mobile/src/services/storage.test.ts
@@ -47,6 +47,39 @@ test("migrates a legacy token when it is first read", async () => {
   expect(asyncStorage.removeItem).toHaveBeenCalledWith(StorageKeys.Token);
 });
 
+test("looks again when the keychain is not ready for the first read", async () => {
+  secureStore.getItemAsync
+    .mockRejectedValueOnce(
+      new Error("Calling the 'getValueWithKeyAsync' function has failed"),
+    )
+    .mockResolvedValueOnce("signed-token");
+
+  await expect(getData(StorageKeys.Token)).resolves.toBe("signed-token");
+  expect(secureStore.getItemAsync).toHaveBeenCalledTimes(2);
+  expect(asyncStorage.getItem).not.toHaveBeenCalled();
+});
+
+test("gives the keychain error back when every read fails", async () => {
+  const failure = new Error(
+    "Calling the 'getValueWithKeyAsync' function has failed",
+  );
+  secureStore.getItemAsync
+    .mockRejectedValueOnce(failure)
+    .mockRejectedValueOnce(failure)
+    .mockRejectedValueOnce(failure);
+
+  await expect(getData(StorageKeys.Token)).rejects.toBe(failure);
+  expect(secureStore.getItemAsync).toHaveBeenCalledTimes(3);
+});
+
+test("does not retry a phone that simply has no token", async () => {
+  secureStore.getItemAsync.mockResolvedValueOnce(null);
+  asyncStorage.getItem.mockResolvedValueOnce(null);
+
+  await expect(getData(StorageKeys.Token)).resolves.toBeNull();
+  expect(secureStore.getItemAsync).toHaveBeenCalledTimes(1);
+});
+
 test("removes current and legacy token copies on logout", async () => {
   await deleteData(StorageKeys.Token);
 

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -48,9 +48,54 @@ export const storeData = async <T extends StorageKeys>(
   return value;
 };
 
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * How many times the keychain is asked for the token before the read is given
+ * up on.
+ *
+ * iOS answers a keychain read with "a required entitlement isn't present" when
+ * the app process is not attached yet, which is what a launch the user did not
+ * start looks like: the system prewarming the app, or a notification waking it
+ * while the phone is still locked. The entitlement is on the build, the check
+ * is just not ready to see it, and it becomes ready a moment later. Three
+ * looks, because the launch is waiting on this answer and a fourth would cost
+ * more than it recovers.
+ */
+const KEYCHAIN_READ_ATTEMPTS = 3;
+
+/** Grows per attempt, so the last look happens well after the first. */
+const KEYCHAIN_RETRY_DELAY_MS = 150;
+
+/**
+ * The keychain read, retried.
+ *
+ * An absent token is not an error here: `getItemAsync` resolves to `null` for
+ * a phone that was never signed in, so a signed out launch never pays for a
+ * single retry. Only a thrown read comes back around, and a read that keeps
+ * throwing still throws, so a genuine misconfiguration stays visible instead
+ * of turning into a silent "no token".
+ */
+const readSecureValue = async (
+  key: StorageKeys,
+  attempt = 1,
+): Promise<string | null> => {
+  try {
+    return await SecureStore.getItemAsync(key);
+  } catch (error) {
+    if (attempt >= KEYCHAIN_READ_ATTEMPTS) throw error;
+
+    await wait(KEYCHAIN_RETRY_DELAY_MS * attempt);
+    return readSecureValue(key, attempt + 1);
+  }
+};
+
 export const getData = async <T extends StorageKeys>(key: T) => {
   if (key === StorageKeys.Token) {
-    const secureValue = await SecureStore.getItemAsync(key);
+    const secureValue = await readSecureValue(key);
     if (secureValue) return secureValue as StorageDataTypes[T];
 
     const legacyValue = await AsyncStorage.getItem(key);

--- a/apps/mobile/src/services/transient-retry.test.ts
+++ b/apps/mobile/src/services/transient-retry.test.ts
@@ -60,6 +60,13 @@ describe("shouldRetryTransient", () => {
     expect(shouldRetryTransient(0, serverError(429))).toBe(false);
   });
 
+  it("leaves an already logged in login alone", () => {
+    // The login guard used to throw a bare Error, which tRPC could only send
+    // as a 500, so this very policy turned one tap into three requests. It
+    // throws CONFLICT now, and a 409 is final.
+    expect(shouldRetryTransient(0, serverError(409))).toBe(false);
+  });
+
   it("stops once the attempts are spent", () => {
     const error = serverError(500);
 

--- a/apps/mobile/src/store/reducers/dogs/swipe.ts
+++ b/apps/mobile/src/store/reducers/dogs/swipe.ts
@@ -21,6 +21,8 @@ type IInitialState = {
     limit: number;
     hasMore: boolean;
     lastCardId?: string;
+    /** The free like allowance the server enforced when it last said no. */
+    likeLimit?: number;
     likeLimitResetAt?: Date;
   };
 };
@@ -35,6 +37,7 @@ export const initialState: IInitialState = {
     limit: 15,
     hasMore: true,
     lastCardId: undefined,
+    likeLimit: undefined,
     likeLimitResetAt: undefined,
   },
 };
@@ -51,7 +54,11 @@ const asyncActions = createAsyncAction(
   SwipeAction.SwipeDogRequest,
   SwipeAction.SwipeDogSuccess,
   SwipeAction.SwipeDogFailure,
-)<{ id: string; swipeType: Swipe }, undefined, { likeLimitResetAt?: Date }>();
+)<
+  { id: string; swipeType: Swipe },
+  undefined,
+  { likeLimit?: number; likeLimitResetAt?: Date }
+>();
 
 const swipeBack = createAction(SwipeAction.SwipeBack)();
 
@@ -92,6 +99,7 @@ const swipeUserError = (
   { payload }: ActionType<typeof asyncActions.failure>,
 ) =>
   produce(state, (draft) => {
+    draft.config.likeLimit = payload.likeLimit;
     draft.config.likeLimitResetAt = payload.likeLimitResetAt;
 
     // We should return to the last dog if we have a failure

--- a/apps/mobile/src/store/sagas/dogs/swipe.ts
+++ b/apps/mobile/src/store/sagas/dogs/swipe.ts
@@ -33,12 +33,12 @@ const swipeUserRequest = function* ({
 
     // If the user is not premium, check if the like limit has been reached
     if (!isPremium && _swipeType !== Swipe.Dislike) {
-      const { likeLimitResetAt } = (yield select(
+      const { likeLimit, likeLimitResetAt } = (yield select(
         (state: RootReducer) => state.dogs.config,
       )) as RootReducer["dogs"]["config"];
 
       if (likeLimitResetAt && isBefore(new Date(), likeLimitResetAt)) {
-        throw new LikeLimitReachedError({ likeLimitResetAt });
+        throw new LikeLimitReachedError({ likeLimit, likeLimitResetAt });
       }
     }
 
@@ -64,12 +64,12 @@ const swipeUserRequest = function* ({
   } catch (error: unknown) {
     const likeLimitReachedError = getError(error, LikeLimitReachedError);
     if (likeLimitReachedError) {
-      const { likeLimitResetAt } = likeLimitReachedError;
-      showLikeLimitReached({ likeLimitResetAt });
+      const { likeLimit, likeLimitResetAt } = likeLimitReachedError;
+      showLikeLimitReached({ likeLimit, likeLimitResetAt });
       // Glanceable countdown outside the app: Dynamic Island/lock screen on
       // iOS, a (promoted) countdown notification on Android.
       yield call(startLikeLimitLiveStatus, likeLimitResetAt);
-      yield put(Actions.dogs.swipe.failure({ likeLimitResetAt }));
+      yield put(Actions.dogs.swipe.failure({ likeLimit, likeLimitResetAt }));
       return;
     }
 

--- a/apps/mobile/src/views/(auth)/CreateProfile/index.tsx
+++ b/apps/mobile/src/views/(auth)/CreateProfile/index.tsx
@@ -8,6 +8,7 @@ import { View, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
 import { dogQuickClientSchema } from "@pegada/shared/schemas/dog-schema";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -31,6 +32,8 @@ import {
 } from "@/hooks/use-keyboard-aware-scroll";
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
+import { saveWithExpiredUploadRetry } from "@/services/expired-upload-retry";
+import { getError } from "@/services/get-error";
 import { SceneName } from "@/types/scene-name";
 
 import { DragHint, MultilineInput, PhotoHint, styles } from "./styles";
@@ -45,7 +48,7 @@ const DEFAULT_VALUES: DogQuickClientSchema = {
 const CreateProfile = () => {
   const { t } = useTranslation();
 
-  const { control, handleSubmit, getValues } = useForm({
+  const { control, handleSubmit, getValues, setValue } = useForm({
     defaultValues: DEFAULT_VALUES,
     resolver: zodResolver(dogQuickClientSchema),
   });
@@ -77,26 +80,58 @@ const CreateProfile = () => {
       });
     },
     onError: (error) => {
+      // Photos that went stale while the form was being filled in are handled
+      // by `saveWithExpiredUploadRetry` below, which uploads them again and
+      // saves a second time. Toasting here would put an error on screen for an
+      // attempt the person never needed to know about.
+      if (getError(error, InvalidUploadGrantError)) return;
+
       magicToast.alert(t("editProfile.profileError"));
       sendError(error);
     },
   });
 
   const saveUser = handleSubmit(async (data) => {
-    const dogData = {
-      name: data.name,
-      bio: data.bio,
-      gender: data.gender,
-      images: data.images
-        .filter((image) => Boolean(image.url))
-        .map((image, index) => ({
-          id: image.id,
-          url: image.url as string,
-          position: index,
-        })),
-    };
+    const images = (data.images as Picture[])
+      .filter((image) => Boolean(image.url))
+      .map((image, index) => ({
+        id: image.id,
+        url: image.url,
+        position: index,
+        localUri: image.localUri,
+      }));
 
-    await dogCreateMutation.mutateAsync(dogData);
+    try {
+      await saveWithExpiredUploadRetry({
+        images,
+        save: (attemptImages) =>
+          dogCreateMutation.mutateAsync({
+            name: data.name,
+            bio: data.bio,
+            gender: data.gender,
+            images: attemptImages.map(({ id, url, position }) => ({
+              id,
+              url,
+              position,
+            })),
+          }),
+        onReuploaded: (attemptImages) => {
+          setValue(
+            "images",
+            (getValues("images") as Picture[]).map((picture) => {
+              const reuploaded = attemptImages.find(
+                (image) => image.id === picture.id,
+              );
+
+              return reuploaded ? { ...picture, url: reuploaded.url } : picture;
+            }),
+          );
+        },
+      });
+    } catch {
+      // Both failure paths have already reported and toasted. The screen keeps
+      // the form exactly as it is so the next tap is a save, not a rebuild.
+    }
   });
 
   const [gesturesEnabled, setGesturesEnabled] = useState(true);

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeBackButton/styles.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeBackButton/styles.ts
@@ -10,16 +10,26 @@ export const styles = StyleSheet.create((theme) => ({
     position: "absolute",
     right: 0,
   },
+  /**
+   * Sits inside the card rather than against the screen edge. It used to be a
+   * 68 wide box pinned to `right: 0` with only its left corners rounded and
+   * the arrow pushed to one side by a left padding, which reads as a pill that
+   * ran off the screen. Rounded on all four corners, inset past the card's own
+   * margin and with the arrow centred, it reads as the floating control it is.
+   */
   goBack: {
-    width: 68,
+    width: 56,
     height: 50,
     borderTopLeftRadius: theme.radii.md,
+    borderTopRightRadius: theme.radii.md,
+    borderBottomRightRadius: theme.radii.md,
     borderBottomLeftRadius: theme.radii.md,
     backgroundColor: theme.colors.card,
+    alignItems: "center",
     justifyContent: "center",
     marginLeft: "auto",
     marginTop: theme.spacing[24],
-    paddingLeft: theme.spacing[4],
+    marginRight: theme.spacing[4],
     shadowColor: GO_BACK_SHADOW_COLOR,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.025,

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.test.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.test.tsx
@@ -1,0 +1,213 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import SwipeRequestFeedback from "./index";
+
+/**
+ * This screen renders behind the deck on every visit to the swipe tab, not
+ * only when the deck runs out — the cards are stacked on top of it in
+ * `views/(tabs)/Swipe/index.tsx`. What is pinned here is that the whole
+ * empty state is in the tree only when the deck is genuinely empty, so the
+ * empty deck funnel's tap rate is not divided by every visit to the tab.
+ *
+ * Rendering goes through `react-dom/server`, matching the other suites in
+ * this package: there is no React Native renderer here, so the RN-flavoured
+ * imports are stubbed. Names are `mock`-prefixed because jest hoists the
+ * factories.
+ */
+
+type RequestState = {
+  loading: boolean;
+  error: boolean;
+  data: { id: string }[];
+};
+
+let mockRequest: RequestState = { loading: false, error: false, data: [] };
+let mockLastCardId: string | undefined;
+let mockOffline = false;
+let mockAlertRequestedAt: Date | undefined;
+
+// The two buttons this screen already owned both talk to the API, and the
+// real client reaches `expo-constants`, which ships untransformed ESM.
+jest.mock<Record<string, unknown>>("@/contexts/trpc-provider", () => ({
+  api: {
+    user: {
+      requestNewDogsAlert: {
+        useMutation: () => ({ mutateAsync: () => Promise.resolve() }),
+      },
+      me: {
+        useQuery: () => ({
+          data: { newDogsAlertRequestedAt: mockAlertRequestedAt },
+          isPending: false,
+        }),
+      },
+    },
+  },
+}));
+
+jest.mock<Record<string, unknown>>("react-native", () => {
+  const { createElement } = require("react") as typeof React;
+
+  return {
+    View: ({ children }: { children?: React.ReactNode }) =>
+      createElement("div", null, children),
+    Alert: { alert: () => undefined },
+    Share: { share: () => Promise.resolve({ action: "dismissedAction" }) },
+    // The invite button reaches `@/constants`, which sizes the swipe card off
+    // the screen at import time. Any number will do; nothing here reads it.
+    Dimensions: { get: () => ({ width: 390, height: 844 }) },
+  };
+});
+
+jest.mock<Record<string, unknown>>("./styles", () => {
+  const { createElement } = require("react") as typeof React;
+  const passthrough =
+    (tag: string) =>
+    ({ children }: { children?: React.ReactNode }) =>
+      createElement(tag, null, children);
+
+  return {
+    styles: {
+      container: {},
+      scroll: {},
+      emptyAnimation: {},
+      logoLoading: {},
+      title: {},
+      description: {},
+      notifyDone: {},
+      notifyDoneText: {},
+    },
+    Container: passthrough("div"),
+    Content: passthrough("div"),
+    EmptyAnimation: passthrough("div"),
+    LogoLoading: passthrough("div"),
+    Title: passthrough("span"),
+    Description: passthrough("span"),
+    DoneCheck: () => createElement("svg", null),
+    DoneLabel: passthrough("span"),
+  };
+});
+
+jest.mock<Record<string, unknown>>("@/components/NetworkBoundary", () => ({
+  OfflineComponent: () => null,
+  RequestErrorComponent: () => null,
+  useIsOffline: () => mockOffline,
+}));
+
+jest.mock<Record<string, unknown>>(
+  "@/components/NetworkBoundary/styles",
+  () => {
+    const { createElement } = require("react") as typeof React;
+    const passthrough = ({ children }: { children?: React.ReactNode }) =>
+      createElement("div", null, children);
+
+    return { Container: passthrough, Content: passthrough };
+  },
+);
+
+jest.mock<Record<string, unknown>>("@/components/Button", () => {
+  const { createElement } = require("react") as typeof React;
+
+  return {
+    Button: ({ children }: { children?: React.ReactNode }) =>
+      createElement("button", { type: "button" }, children),
+  };
+});
+
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { track: jest.fn() },
+}));
+
+// Reaches `magic-observability/expo`, ESM that jest cannot parse.
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: () => undefined,
+}));
+
+jest.mock<Record<string, unknown>>(
+  "@/services/get-push-notification-token",
+  () => ({
+    getPushNotificationToken: () => Promise.resolve(undefined),
+    isPushDeniedError: () => false,
+    setPushNotificationToken: () => Promise.resolve(),
+  }),
+);
+
+jest.mock<Record<string, unknown>>("@/services/storage", () => ({
+  StorageKeys: { NewDogsAlertRequested: "newDogsAlertRequested" },
+  getData: () => Promise.resolve(null),
+  storeData: () => Promise.resolve(),
+}));
+
+jest.mock<Record<string, unknown>>("@/store/reducers", () => ({
+  Actions: { dogs: { list: { refetch: jest.fn() } } },
+}));
+
+jest.mock<Record<string, unknown>>("@/types/scene-name", () => ({
+  SceneName: { Preferences: "/preferences" },
+}));
+
+jest.mock<Record<string, unknown>>("expo-router", () => ({
+  router: { push: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock<Record<string, unknown>>("react-native-reanimated", () => {
+  const { createElement } = require("react") as typeof React;
+
+  return {
+    __esModule: true,
+    default: {
+      View: ({ children }: { children?: React.ReactNode }) =>
+        createElement("div", null, children),
+    },
+    FadeInDown: {},
+    FadeOutDown: {},
+  };
+});
+
+// The real `getActiveCards` runs against this state, so the swipe-back rule
+// it encodes (the dog just swiped stays in `data` and only leaves the active
+// cards) is exercised here rather than restated.
+jest.mock<Record<string, unknown>>("react-redux", () => ({
+  useDispatch: () => jest.fn(),
+  useSelector: (selector: (state: unknown) => unknown) =>
+    selector({
+      dogs: { request: mockRequest, config: { lastCardId: mockLastCardId } },
+    }),
+}));
+
+beforeEach(() => {
+  mockRequest = { loading: false, error: false, data: [] };
+  mockLastCardId = undefined;
+  mockOffline = false;
+  mockAlertRequestedAt = undefined;
+});
+
+test("drops the button chrome once the notify opt-in has been taken", () => {
+  mockAlertRequestedAt = new Date();
+
+  const html = renderToStaticMarkup(<SwipeRequestFeedback deckIsEmpty />);
+  const done = "swipeRequestFeedback.notifyNewDogsDone";
+
+  // A disabled button paints its label at half opacity, which put this at
+  // 1.7:1 on the light background with nothing saying why it would not
+  // respond. There is nothing to press any more, so it is not a button.
+  expect(html).toContain(done);
+  expect(html).not.toContain(`<button type="button">${done}`);
+  expect(html).not.toContain("swipeRequestFeedback.notifyNewDogsButton");
+});
+
+test("renders nothing at all while cards are still on the deck", () => {
+  mockRequest = { loading: false, error: false, data: [{ id: "dog-1" }] };
+
+  const html = renderToStaticMarkup(
+    <SwipeRequestFeedback deckIsEmpty={false} />,
+  );
+
+  // The whole empty state stays out of the tree behind a full deck, which is
+  // what keeps `Empty Deck Shown` off a deck that still has cards on it.
+  expect(html).not.toContain("swipeRequestFeedback.emptyTitle");
+});

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/index.tsx
@@ -40,6 +40,8 @@ import {
 } from "./new-dogs-alert";
 import {
   Description,
+  DoneCheck,
+  DoneLabel,
   EmptyAnimation,
   LogoLoading,
   Title,
@@ -132,19 +134,36 @@ const NotifyNewDogsButton = () => {
     }
   };
 
+  // Once the opt-in is taken there is nothing left to press, so it stops being
+  // a button. It used to stay one and go disabled, which paints the whole
+  // control at half opacity: pale pink on white, 1.7:1, and no sign of why it
+  // would not respond. A check and a full contrast label say the same thing
+  // and read as an answer rather than a dead control.
+  if (requested) {
+    return (
+      <View style={styles.notifyDone}>
+        <DoneCheck width={16} height={15} />
+        <DoneLabel
+          fontSize="lg"
+          fontWeight="bold"
+          style={styles.notifyDoneText}
+        >
+          {t("swipeRequestFeedback.notifyNewDogsDone")}
+        </DoneLabel>
+      </View>
+    );
+  }
+
   return (
     <Button
       // On a fresh install the answer is only on the server, so the button
       // stays out of reach until it arrives. Offering it in that window lets
       // someone who already opted in tap a second time.
-      disabled={requested || me.isPending}
+      disabled={me.isPending}
       loading={loading}
       onPress={() => void handlePress()}
-      variant={requested ? "outline" : "default"}
     >
-      {requested
-        ? t("swipeRequestFeedback.notifyNewDogsDone")
-        : t("swipeRequestFeedback.notifyNewDogsButton")}
+      {t("swipeRequestFeedback.notifyNewDogsButton")}
     </Button>
   );
 };
@@ -187,34 +206,45 @@ const EmptyState = () => {
   const { t } = useTranslation();
 
   return (
-    <Content>
-      <View>
-        <LogoLoading
-          style={styles.logoLoading}
-          autoPlay
-          source={require("@/assets/animations/loadingLogo.json")}
-          speed={0.5}
-        />
-        <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
-          <Title fontWeight="bold" style={styles.title}>
-            {t("swipeRequestFeedback.emptyTitle")}
-          </Title>
-          <Description fontSize="xs" style={styles.description}>
-            {t("swipeRequestFeedback.emptyDescription")}
-          </Description>
-          <View style={styles.actions}>
-            <NotifyNewDogsButton />
-            <InviteFriendButton />
-            <Button
-              onPress={() => router.push(SceneName.Preferences)}
-              variant="outline"
-            >
-              {t("swipeRequestFeedback.preferencesButton")}
-            </Button>
-          </View>
-        </Animated.View>
-      </View>
-    </Content>
+    // The column runs past the fold on a short phone, and the last thing in it
+    // is the preferences button the copy points at. Scrolling is the safety
+    // net: `Content` still centres the column whenever it fits.
+    <Container style={styles.scroll}>
+      <Content>
+        <View>
+          <LogoLoading
+            style={styles.logoLoading}
+            autoPlay
+            source={require("@/assets/animations/loadingLogo.json")}
+            speed={0.5}
+          />
+          <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
+            <Title fontWeight="bold" style={styles.title}>
+              {t("swipeRequestFeedback.emptyTitle")}
+            </Title>
+            <Description fontSize="xs" style={styles.description}>
+              {t("swipeRequestFeedback.emptyDescription")}
+            </Description>
+            <View style={styles.actions}>
+              <NotifyNewDogsButton />
+              <InviteFriendButton />
+              <Button
+                onPress={() => {
+                  analytics.track({
+                    event_type: "Empty Deck Action Tapped",
+                    event_properties: { action: EmptyDeckAction.Preferences },
+                  });
+                  router.push(SceneName.Preferences);
+                }}
+                variant="outline"
+              >
+                {t("swipeRequestFeedback.preferencesButton")}
+              </Button>
+            </View>
+          </Animated.View>
+        </View>
+      </Content>
+    </Container>
   );
 };
 

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/new-dogs-alert.ts
@@ -8,6 +8,11 @@ import type { ShareAction } from "react-native";
 export enum EmptyDeckAction {
   NotifyNewDogs = "notify_new_dogs",
   InviteFriend = "invite_friend",
+  /**
+   * The body copy tells people to adjust their preferences and this is the
+   * only way there from here, so the funnel has to be able to count it.
+   */
+  Preferences = "preferences",
 }
 
 export enum PushPermission {

--- a/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/styles.ts
+++ b/apps/mobile/src/views/(tabs)/Swipe/components/SwipeRequestFeedback/styles.ts
@@ -1,12 +1,42 @@
 import LottieView from "lottie-react-native";
 import { StyleSheet, withUnistyles } from "react-native-unistyles";
 
+import Check from "@/assets/images/Check.svg";
 import * as LikeFeedbackStyles from "@/components/FeedbackCard/components/LikeFeedback/styles";
 import { Text } from "@/components/text";
 
 export const styles = StyleSheet.create((theme) => ({
   container: {
     backgroundColor: "transparent",
+  },
+  /**
+   * The empty state is taller than one screen once the share card is in it,
+   * and the preferences button is the last thing in the column — the copy asks
+   * people to adjust their preferences, so that button has to be reachable on
+   * the shortest phone we support.
+   */
+  scroll: {
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    backgroundColor: "transparent",
+  },
+  notifyDone: {
+    flexDirection: "row",
+    gap: theme.spacing[2],
+    alignItems: "center",
+    justifyContent: "center",
+    paddingTop: theme.spacing[4],
+    paddingBottom: theme.spacing[4],
+  },
+  /**
+   * The label takes the body text colour and only the check is pink. The
+   * primary pink is a 3:1 foreground on the light background, which is under
+   * the 4.5:1 this size needs, and it is also the colour of everything on this
+   * screen that can still be tapped.
+   */
+  notifyDoneText: {
+    color: theme.colors.text,
   },
   emptyAnimation: {
     width: 100,
@@ -45,3 +75,10 @@ export const LogoLoading = withUnistyles(LottieView);
 export const Title = Text;
 
 export const Description = Text;
+
+/** The check on the notify opt-in once it has been taken. */
+export const DoneCheck = withUnistyles(Check, (theme) => ({
+  color: theme.colors.primary,
+}));
+
+export const DoneLabel = Text;

--- a/apps/mobile/src/views/EditProfile/index.tsx
+++ b/apps/mobile/src/views/EditProfile/index.tsx
@@ -8,6 +8,7 @@ import { View, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
 import { dogClientSchema } from "@pegada/shared/schemas/dog-schema";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { format } from "date-fns/format";
@@ -37,6 +38,8 @@ import {
 import { analytics } from "@/services/analytics";
 import { colors, sizes } from "@/services/consts";
 import { sendError } from "@/services/error-tracking";
+import { saveWithExpiredUploadRetry } from "@/services/expired-upload-retry";
+import { getError } from "@/services/get-error";
 import { maskDate } from "@/services/mask-date";
 import { Actions } from "@/store/reducers";
 
@@ -146,6 +149,11 @@ const EditProfile = () => {
       router.back();
     },
     onError: (error) => {
+      // Newly added photos that went stale while the rest of the form was
+      // being filled in are handled by `saveWithExpiredUploadRetry` below,
+      // which uploads them again and saves a second time.
+      if (getError(error, InvalidUploadGrantError)) return;
+
       magicToast.alert(t("editProfile.profileError"));
       sendError(error);
     },
@@ -162,14 +170,44 @@ const EditProfile = () => {
       breedId: data.breedId ? data.breedId : null,
       color: data.color ? data.color : null,
       size: data.size ?? null,
-      images: data.images?.map((image, index) => ({
-        id: image.id,
-        url: image.url,
-        position: index,
-      })),
     };
 
-    await myDogUpdateMutation.mutateAsync(updateData);
+    const images = ((data.images ?? []) as Picture[]).map((image, index) => ({
+      id: image.id,
+      url: image.url,
+      position: index,
+      localUri: image.localUri,
+    }));
+
+    try {
+      await saveWithExpiredUploadRetry({
+        images,
+        save: (attemptImages) =>
+          myDogUpdateMutation.mutateAsync({
+            ...updateData,
+            images: attemptImages.map(({ id, url, position }) => ({
+              id,
+              url,
+              position,
+            })),
+          }),
+        onReuploaded: (attemptImages) => {
+          setValue(
+            "images",
+            (getValues("images") as Picture[]).map((picture) => {
+              const reuploaded = attemptImages.find(
+                (image) => image.id === picture.id,
+              );
+
+              return reuploaded ? { ...picture, url: reuploaded.url } : picture;
+            }),
+          );
+        },
+      });
+    } catch {
+      // Both failure paths have already reported and toasted. The screen keeps
+      // the form exactly as it is so the next tap is a save, not a rebuild.
+    }
   });
 
   return (

--- a/apps/mobile/src/views/ForceUpdate/index.tsx
+++ b/apps/mobile/src/views/ForceUpdate/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Linking } from "react-native";
 
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { useTranslation } from "react-i18next";
 import { useUnistyles } from "react-native-unistyles";
 
@@ -8,13 +9,37 @@ import Logo from "@/assets/images/logo";
 import { BottomAction } from "@/components/BottomAction";
 import { Button } from "@/components/Button";
 import { APP_SHARE_LINK_BASE } from "@/constants";
+import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
+import {
+  getAppVersion,
+  getMinimumSupportedVersion,
+} from "@/services/force-update";
 
 import { CenterText, Container, styles } from "./styles";
+
+/**
+ * Both events carry the running build and the floor that rejected it, which is
+ * what turns "people are stuck" into "people on 1.6.2 are stuck behind 1.7.2"
+ * without joining anything.
+ */
+const versionProperties = () => ({
+  app_version: getAppVersion(),
+  minimum_version: getMinimumSupportedVersion(),
+});
 
 const ForceUpdate: React.FC = () => {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
+
+  // Mount is the whole event: this screen replaces the app, and the only way
+  // off it is the store.
+  React.useEffect(() => {
+    analytics.track({
+      event_type: ANALYTICS_EVENTS.UPDATE_REQUIRED_SHOWN,
+      event_properties: versionProperties(),
+    });
+  }, []);
 
   return (
     <Container testID="force-update-screen" style={styles.container}>
@@ -39,6 +64,10 @@ const ForceUpdate: React.FC = () => {
         <Button
           testID="force-update-button"
           onPress={() => {
+            analytics.track({
+              event_type: ANALYTICS_EVENTS.UPDATE_REQUIRED_STORE_TAPPED,
+              event_properties: versionProperties(),
+            });
             // Store automatically redirects to the app store or play store
             Linking.openURL(`${APP_SHARE_LINK_BASE}/store`).catch(sendError);
           }}

--- a/apps/mobile/src/views/UpgradeWall/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/index.tsx
@@ -102,7 +102,7 @@ const UpgradeWall: React.FC = () => {
         },
       });
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       haptics.success();
 
       analytics.track({
@@ -110,6 +110,11 @@ const UpgradeWall: React.FC = () => {
         event_properties: {
           package: selectedOffering?.product.identifier,
           type: "success",
+          // Says whether the money was real. A sandbox receipt and the grant
+          // the Maestro flows hand themselves both land here otherwise
+          // indistinguishable from an App Store charge, and only the charge
+          // produces a RevenueCat webhook event on the server.
+          ...payments.describePurchase(result?.customerInfo),
         },
       });
       router.back();

--- a/packages/api/src/routes/echo.test.ts
+++ b/packages/api/src/routes/echo.test.ts
@@ -1,0 +1,148 @@
+import type { NextRequest } from "next/server";
+
+import { config } from "../shared/config";
+import { createInnerTRPCContext } from "../trpc";
+import { echoRouter } from "./echo";
+
+jest.mock("../shared/observability", () => ({
+  observability: {
+    enabled: false,
+    disabledReason: "explicitly-disabled",
+    capture: jest.fn(),
+    captureError: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    register: jest.fn(),
+    flush: jest.fn(),
+    shutdown: jest.fn(),
+  },
+  getPostHogNode: jest.fn(() => null),
+}));
+
+jest.mock("superjson", () => ({
+  __esModule: true,
+  default: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value,
+  },
+}));
+
+/**
+ * The floors are read off `config` at call time, so a test sets them the same
+ * way an operator sets an environment variable, and puts them back afterwards.
+ */
+const floors = {
+  MIN_APP_VERSION: config.MIN_APP_VERSION,
+  MIN_APP_VERSION_IOS: config.MIN_APP_VERSION_IOS,
+  MIN_APP_VERSION_ANDROID: config.MIN_APP_VERSION_ANDROID,
+};
+
+beforeEach(() => {
+  config.MIN_APP_VERSION = "1.5.0";
+  config.MIN_APP_VERSION_IOS = undefined;
+  config.MIN_APP_VERSION_ANDROID = undefined;
+});
+
+afterEach(() => {
+  Object.assign(config, floors);
+});
+
+/** An anonymous call carrying whatever headers a client chose to send. */
+const echo = (headers: Record<string, string>) =>
+  echoRouter
+    .createCaller(
+      createInnerTRPCContext({
+        session: null,
+        req: { headers: new Headers(headers) } as unknown as NextRequest,
+      }),
+    )
+    .get();
+
+describe("echo.get force update", () => {
+  it("gates a build below the shared floor", async () => {
+    const result = await echo({ "x-app-version": "1.4.9" });
+
+    expect(result.forceUpdate).toBe(true);
+    expect(result.minimumSupportedVersion).toBe("1.5.0");
+  });
+
+  it("lets the floor itself and anything above it through", async () => {
+    await expect(echo({ "x-app-version": "1.5.0" })).resolves.toMatchObject({
+      forceUpdate: false,
+    });
+    await expect(echo({ "x-app-version": "2.0.0" })).resolves.toMatchObject({
+      forceUpdate: false,
+    });
+  });
+
+  describe("with a release live on one store and in review on the other", () => {
+    beforeEach(() => {
+      config.MIN_APP_VERSION_IOS = "1.7.2";
+    });
+
+    it("gates the platform the release shipped on", async () => {
+      const result = await echo({
+        "x-app-version": "1.6.2",
+        "x-app-platform": "ios",
+      });
+
+      expect(result.forceUpdate).toBe(true);
+      expect(result.minimumSupportedVersion).toBe("1.7.2");
+    });
+
+    it("leaves the platform with nothing to install alone", async () => {
+      const result = await echo({
+        "x-app-version": "1.6.2",
+        "x-app-platform": "android",
+      });
+
+      expect(result.forceUpdate).toBe(false);
+      expect(result.minimumSupportedVersion).toBe("1.5.0");
+    });
+
+    it("holds a client that does not say which platform it is on to the shared floor", async () => {
+      const result = await echo({ "x-app-version": "1.6.2" });
+
+      expect(result.forceUpdate).toBe(false);
+      expect(result.minimumSupportedVersion).toBe("1.5.0");
+    });
+  });
+
+  it("applies an Android floor to Android only", async () => {
+    config.MIN_APP_VERSION_ANDROID = "1.7.2";
+
+    await expect(
+      echo({ "x-app-version": "1.6.2", "x-app-platform": "android" }),
+    ).resolves.toMatchObject({ forceUpdate: true });
+    await expect(
+      echo({ "x-app-version": "1.6.2", "x-app-platform": "ios" }),
+    ).resolves.toMatchObject({ forceUpdate: false });
+  });
+
+  // The wall has no way out except the store, so every unreadable input has to
+  // resolve to "let them in". A throw here would 500 the one query a launch
+  // waits on, and a `true` would lock people out on a header we misread.
+  describe("failing open", () => {
+    it("does not gate a client that sends no version", async () => {
+      await expect(echo({})).resolves.toMatchObject({ forceUpdate: false });
+    });
+
+    it("does not gate, or throw on, a version it cannot parse", async () => {
+      await expect(
+        echo({ "x-app-version": "not-a-version" }),
+      ).resolves.toMatchObject({ forceUpdate: false });
+    });
+
+    it("falls back to the shared floor on an unknown platform", async () => {
+      config.MIN_APP_VERSION_IOS = "1.7.2";
+
+      const result = await echo({
+        "x-app-version": "1.6.2",
+        "x-app-platform": "windows-phone",
+      });
+
+      expect(result.forceUpdate).toBe(false);
+      expect(result.minimumSupportedVersion).toBe("1.5.0");
+    });
+  });
+});

--- a/packages/api/src/routes/echo.test.ts
+++ b/packages/api/src/routes/echo.test.ts
@@ -146,3 +146,22 @@ describe("echo.get force update", () => {
     });
   });
 });
+
+/**
+ * The app puts this number in front of the user, so it has to come from the
+ * same place the server enforces it rather than from whatever the build was
+ * compiled with.
+ */
+describe("echo.get free like limit", () => {
+  const shippedLimit = config.FREE_DAILY_LIKE_LIMIT;
+
+  afterEach(() => {
+    config.FREE_DAILY_LIKE_LIMIT = shippedLimit;
+  });
+
+  it("reports the limit the server is configured with", async () => {
+    config.FREE_DAILY_LIKE_LIMIT = 25;
+
+    await expect(echo({})).resolves.toMatchObject({ freeDailyLikeLimit: 25 });
+  });
+});

--- a/packages/api/src/routes/echo.ts
+++ b/packages/api/src/routes/echo.ts
@@ -1,6 +1,6 @@
 import { RequestHeaders } from "@pegada/shared/types/types";
 
-import { EchoService } from "../services/echo-service";
+import { appPlatformSchema, EchoService } from "../services/echo-service";
 import { semverSchema } from "../shared/config";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 
@@ -8,14 +8,25 @@ export const echoRouter = createTRPCRouter({
   get: publicProcedure.query(async ({ ctx }) => {
     if (!ctx.req) throw new Error("Missing request data");
 
-    const appVersionHeader = ctx.req.headers.get(RequestHeaders.XAppVersion);
-    const currentAppVersion = semverSchema.parse(appVersionHeader);
+    // Both headers are read leniently. They come off a client, and an old
+    // build that predates the platform header, or a version string a store
+    // rewrote, must not turn the one query every launch waits on into a 500.
+    // Unreadable means unset, and unset means no gate.
+    const currentAppVersion = semverSchema.safeParse(
+      ctx.req.headers.get(RequestHeaders.XAppVersion),
+    ).data;
 
-    const { authenticated, forceUpdate } = await EchoService.get(
-      currentAppVersion,
-      ctx.session?.user.id,
-    );
+    const platform = appPlatformSchema.safeParse(
+      ctx.req.headers.get(RequestHeaders.XAppPlatform),
+    ).data;
 
-    return { authenticated, forceUpdate };
+    const { authenticated, forceUpdate, minimumSupportedVersion } =
+      await EchoService.get({
+        currentAppVersion,
+        platform,
+        userId: ctx.session?.user.id,
+      });
+
+    return { authenticated, forceUpdate, minimumSupportedVersion };
   }),
 });

--- a/packages/api/src/routes/echo.ts
+++ b/packages/api/src/routes/echo.ts
@@ -20,13 +20,22 @@ export const echoRouter = createTRPCRouter({
       ctx.req.headers.get(RequestHeaders.XAppPlatform),
     ).data;
 
-    const { authenticated, forceUpdate, minimumSupportedVersion } =
-      await EchoService.get({
-        currentAppVersion,
-        platform,
-        userId: ctx.session?.user.id,
-      });
+    const {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit,
+      minimumSupportedVersion,
+    } = await EchoService.get({
+      currentAppVersion,
+      platform,
+      userId: ctx.session?.user.id,
+    });
 
-    return { authenticated, forceUpdate, minimumSupportedVersion };
+    return {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit,
+      minimumSupportedVersion,
+    };
   }),
 });

--- a/packages/api/src/routes/swipe-security.test.ts
+++ b/packages/api/src/routes/swipe-security.test.ts
@@ -11,6 +11,7 @@ import { appRouter } from "../root";
 import { DogService } from "../services/dog-service";
 import { PushNotificationService } from "../services/push-notification-service";
 import { SwipeService } from "../services/swipe-service";
+import { config } from "../shared/config";
 import { createInnerTRPCContext } from "../trpc";
 
 jest.mock("../services/push-notification-service", () => ({
@@ -299,5 +300,71 @@ it("keeps banned and self profiles out of the swipe deck and direct lookup", asy
   ).rejects.toMatchObject({
     code: "NOT_FOUND",
     message: DogUnavailableError.message,
+  });
+});
+
+/**
+ * The ceiling is an environment variable so it can be moved without a deploy,
+ * which only helps if the swipe path reads it per request. Both cases run the
+ * real mutation rather than a stubbed quota, because the number has to hold at
+ * the point where a like is actually written.
+ */
+describe("the configured free like limit", () => {
+  const shippedLimit = config.FREE_DAILY_LIKE_LIMIT;
+
+  afterEach(() => {
+    config.FREE_DAILY_LIKE_LIMIT = shippedLimit;
+  });
+
+  /** Likes exactly `limit` dogs, and hands back one more nobody has liked. */
+  const likeUpToTheCeiling = async (limit: number) => {
+    config.FREE_DAILY_LIKE_LIMIT = limit;
+
+    const requester = await generateFakeUserWithDog();
+    const targets = await Promise.all(
+      Array.from({ length: limit + 1 }, () => generateFakeUserWithDog()),
+    );
+    const caller = callerFor(requester.user.id);
+
+    for (const { dog } of targets.slice(0, limit)) {
+      // Sequential on purpose: the point is the count, not concurrency.
+      // eslint-disable-next-line no-await-in-loop
+      await caller.swipe.swipe({ id: dog.id, swipeType: "INTERESTED" });
+    }
+
+    return { caller, oneMore: targets[limit]!, requester };
+  };
+
+  it("refuses the fourth like when the ceiling is three", async () => {
+    const { caller, oneMore, requester } = await likeUpToTheCeiling(3);
+
+    await expect(
+      caller.swipe.swipe({ id: oneMore.dog.id, swipeType: "INTERESTED" }),
+    ).rejects.toMatchObject({ code: "TOO_MANY_REQUESTS", likeLimit: 3 });
+
+    await expect(
+      prisma.interest.count({ where: { requesterId: requester.dog.id } }),
+    ).resolves.toBe(3);
+  });
+
+  it("lets six through, and refuses the seventh, when the ceiling is six", async () => {
+    const { caller, oneMore, requester } = await likeUpToTheCeiling(6);
+
+    await expect(
+      caller.swipe.swipe({ id: oneMore.dog.id, swipeType: "INTERESTED" }),
+    ).rejects.toMatchObject({ code: "TOO_MANY_REQUESTS", likeLimit: 6 });
+
+    await expect(
+      prisma.interest.count({ where: { requesterId: requester.dog.id } }),
+    ).resolves.toBe(6);
+  });
+
+  it("reports the configured ceiling on the remaining quota", async () => {
+    config.FREE_DAILY_LIKE_LIMIT = 25;
+    const { user } = await generateFakeUserWithDog();
+
+    await expect(
+      new SwipeService({}).getRemainingDailyLikes({ userId: user.id }),
+    ).resolves.toMatchObject({ likeLimit: 25, remainingSwipes: 25 });
   });
 });

--- a/packages/api/src/routes/swipe-security.test.ts
+++ b/packages/api/src/routes/swipe-security.test.ts
@@ -304,10 +304,10 @@ it("keeps banned and self profiles out of the swipe deck and direct lookup", asy
 });
 
 /**
- * The ceiling is an environment variable so it can be moved without a deploy,
- * which only helps if the swipe path reads it per request. Both cases run the
- * real mutation rather than a stubbed quota, because the number has to hold at
- * the point where a like is actually written.
+ * The ceiling is an environment variable, parsed once at boot, so it reaches
+ * the swipe path on the next deploy. Both cases run the real mutation rather
+ * than a stubbed quota, because the number has to hold at the point where a
+ * like is actually written.
  */
 describe("the configured free like limit", () => {
   const shippedLimit = config.FREE_DAILY_LIKE_LIMIT;

--- a/packages/api/src/services/echo-service.ts
+++ b/packages/api/src/services/echo-service.ts
@@ -1,16 +1,60 @@
 import semver from "semver";
+import { z } from "zod";
 
 import { config } from "../shared/config";
 import { UserService } from "./user-service";
 
+/**
+ * The two platforms that have a store to send someone to, and so the only two
+ * that can carry a floor of their own. Anything else falls back to the shared
+ * floor.
+ */
+export const appPlatformSchema = z.enum(["android", "ios"]);
+
+export type AppPlatform = z.infer<typeof appPlatformSchema>;
+
 export class EchoService {
+  /**
+   * The floor this caller has to clear.
+   *
+   * The platform override wins when it is set, so a release that is live on
+   * one store and still in review on the other can be enforced on the store
+   * that shipped without locking out the platform that has nothing to install.
+   * A caller that does not say which platform it is on falls back to the
+   * shared floor, which is also what every client built before the platform
+   * header existed does.
+   */
+  static minimumVersionFor(platform?: AppPlatform) {
+    const perPlatform: Record<AppPlatform, string | undefined> = {
+      android: config.MIN_APP_VERSION_ANDROID,
+      ios: config.MIN_APP_VERSION_IOS,
+    };
+
+    return (platform && perPlatform[platform]) ?? config.MIN_APP_VERSION;
+  }
+
   /**
    * Returns whether the user is authenticated and whether or not
    * they need to update their app version.
    */
-  static async get(currentAppVersion: string, userId?: string) {
-    const minAppVersion = config.MIN_APP_VERSION;
-    const forceUpdate = semver.gt(minAppVersion, currentAppVersion);
+  static async get({
+    currentAppVersion,
+    platform,
+    userId,
+  }: {
+    currentAppVersion?: string;
+    platform?: AppPlatform;
+    userId?: string;
+  }) {
+    const minimumSupportedVersion = EchoService.minimumVersionFor(platform);
+
+    // A version we cannot read is never a version we lock out. This is the
+    // only query standing between a launch and the app, so an unfamiliar or
+    // missing header has to mean "let them in" rather than "show the wall":
+    // the wall has no way out except the store.
+    const forceUpdate = currentAppVersion
+      ? semver.gt(minimumSupportedVersion, currentAppVersion)
+      : false;
 
     let authenticated = false;
     if (userId) {
@@ -18,6 +62,6 @@ export class EchoService {
       authenticated = Boolean(user);
     }
 
-    return { authenticated, forceUpdate };
+    return { authenticated, forceUpdate, minimumSupportedVersion };
   }
 }

--- a/packages/api/src/services/echo-service.ts
+++ b/packages/api/src/services/echo-service.ts
@@ -62,6 +62,14 @@ export class EchoService {
       authenticated = Boolean(user);
     }
 
-    return { authenticated, forceUpdate, minimumSupportedVersion };
+    // The like allowance rides along on the query every launch already waits
+    // on, so the number the app puts on screen is the number the server will
+    // actually enforce, without a second round trip or a new deploy.
+    return {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit: config.FREE_DAILY_LIKE_LIMIT,
+      minimumSupportedVersion,
+    };
   }
 }

--- a/packages/api/src/services/echo-service.ts
+++ b/packages/api/src/services/echo-service.ts
@@ -64,7 +64,7 @@ export class EchoService {
 
     // The like allowance rides along on the query every launch already waits
     // on, so the number the app puts on screen is the number the server will
-    // actually enforce, without a second round trip or a new deploy.
+    // actually enforce, without a second round trip or a new app build.
     return {
       authenticated,
       forceUpdate,

--- a/packages/api/src/services/swipe-service.ts
+++ b/packages/api/src/services/swipe-service.ts
@@ -3,7 +3,6 @@ import type { Language } from "@pegada/shared/i18n/types/types";
 import type { Prisma } from "@prisma/client";
 
 import prisma from "@pegada/database";
-import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
 import {
   AccountBlockedError,
   DogUnavailableError,
@@ -15,6 +14,7 @@ import { addDays } from "date-fns/addDays";
 import { subDays } from "date-fns/subDays";
 
 import { sendError } from "../errors/errors";
+import { config } from "../shared/config";
 import MatchService from "./match-service";
 import { PushNotificationService } from "./push-notification-service";
 import { TranslationService } from "./translation-service";
@@ -84,8 +84,14 @@ export class SwipeService {
 
     if (!user) throw new AccountBlockedError();
 
+    // Read at call time, not at import time, so changing the environment
+    // variable takes effect on the next request instead of the next deploy.
+    const likeLimit = config.FREE_DAILY_LIKE_LIMIT;
+
     // Only apply daily swipe limit to free users
-    if (user.plan !== PlanType.FREE) return { remainingSwipes: Infinity };
+    if (user.plan !== PlanType.FREE) {
+      return { likeLimit, remainingSwipes: Infinity };
+    }
 
     const windowStart = subDays(new Date(), 1);
     const dailyLikeCount = await db.interest.findMany({
@@ -95,18 +101,19 @@ export class SwipeService {
       },
       orderBy: { lastPositiveAt: "desc" },
       select: { lastPositiveAt: true },
-      take: FREE_DAILY_SWIPE_LIMIT,
+      take: likeLimit,
     });
 
-    const remainingSwipes = FREE_DAILY_SWIPE_LIMIT - dailyLikeCount.length;
+    const remainingSwipes = likeLimit - dailyLikeCount.length;
 
-    if (remainingSwipes > 0) return { remainingSwipes };
+    if (remainingSwipes > 0) return { likeLimit, remainingSwipes };
 
     // If the user has reached their daily swipe limit, return the time at which the limit will reset
     const oldestLike = dailyLikeCount.at(-1);
-    if (!oldestLike?.lastPositiveAt) return { remainingSwipes };
+    if (!oldestLike?.lastPositiveAt) return { likeLimit, remainingSwipes };
 
     return {
+      likeLimit,
       remainingSwipes,
       likeLimitResetAt: addDays(oldestLike.lastPositiveAt, 1),
     };
@@ -192,6 +199,7 @@ export class SwipeService {
 
             if (remainingDailyLikes.likeLimitResetAt) {
               throw new LikeLimitReachedError({
+                likeLimit: remainingDailyLikes.likeLimit,
                 likeLimitResetAt: remainingDailyLikes.likeLimitResetAt,
               });
             }

--- a/packages/api/src/services/swipe-service.ts
+++ b/packages/api/src/services/swipe-service.ts
@@ -84,8 +84,10 @@ export class SwipeService {
 
     if (!user) throw new AccountBlockedError();
 
-    // Read at call time, not at import time, so changing the environment
-    // variable takes effect on the next request instead of the next deploy.
+    // Read off `config` here rather than captured at module scope, so a test
+    // can move the ceiling the same way an operator moves the variable. The
+    // environment itself is parsed once at boot, so a change to the variable
+    // reaches this line on the next deploy.
     const likeLimit = config.FREE_DAILY_LIKE_LIMIT;
 
     // Only apply daily swipe limit to free users

--- a/packages/api/src/shared/config.test.ts
+++ b/packages/api/src/shared/config.test.ts
@@ -1,0 +1,35 @@
+import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
+
+import { freeDailyLikeLimitSchema } from "./config";
+
+/**
+ * This value gates whether a swipe is accepted, and it is typed into a hosting
+ * dashboard by hand. Every shape a person can leave in that box has to resolve
+ * to a usable number, because the alternative is an API that will not boot.
+ */
+describe("FREE_DAILY_LIKE_LIMIT parsing", () => {
+  it("takes the number an operator set", () => {
+    expect(freeDailyLikeLimitSchema.parse("25")).toBe(25);
+    expect(freeDailyLikeLimitSchema.parse("1")).toBe(1);
+  });
+
+  it("keeps the shipped default when the variable is not set", () => {
+    expect(freeDailyLikeLimitSchema.parse(undefined)).toBe(
+      FREE_DAILY_SWIPE_LIMIT,
+    );
+  });
+
+  // Clearing the box is how someone turns the experiment off on a host that
+  // keeps a variable once it has been added.
+  it("treats a blank value as unset", () => {
+    expect(freeDailyLikeLimitSchema.parse("")).toBe(FREE_DAILY_SWIPE_LIMIT);
+  });
+
+  it("falls back instead of throwing on a value it cannot use", () => {
+    for (const value of ["abc", "0", "-5", "2.5", null, {}, "1e999"]) {
+      expect(freeDailyLikeLimitSchema.parse(value)).toBe(
+        FREE_DAILY_SWIPE_LIMIT,
+      );
+    }
+  });
+});

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -1,12 +1,30 @@
 import semver from "semver";
 import { z } from "zod";
 
-export const semverSchema = z.string().refine((version) => {
-  const isValid = semver.valid(version);
-  if (!isValid) throw new Error("Invalid version");
+/**
+ * Throwing inside `refine` was never caught by `safeParse`: zod lets an
+ * exception from a refinement escape, so the "safe" call was only safe for
+ * strings that were already valid. Returning a boolean keeps the same message
+ * on an invalid `MIN_APP_VERSION` at boot and makes `safeParse` usable on the
+ * version header, which arrives from a client and can be anything.
+ */
+export const semverSchema = z
+  .string()
+  .refine((version) => semver.valid(version) !== null, {
+    message: "Invalid version",
+  });
 
-  return isValid;
-});
+/**
+ * A semver that is allowed to be absent.
+ *
+ * An empty string counts as absent on purpose. Vercel keeps a variable in the
+ * project once it has been added, so blanking the value is how someone turns a
+ * gate back off, and that has to mean the same thing as never setting it.
+ */
+export const optionalSemverSchema = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  semverSchema.optional(),
+);
 
 const configSchema = z.object({
   /** GENERAL */
@@ -92,8 +110,25 @@ const configSchema = z.object({
    */
   CRON_SECRET: z.string().optional(),
 
-  /** APP */
+  /**
+   * APP
+   *
+   * The oldest build allowed to keep running. Anything below it gets the
+   * blocking update screen instead of the app.
+   *
+   * `MIN_APP_VERSION` is the floor both stores share. The per platform pair
+   * exists because approvals do not land together: a build can be live on the
+   * App Store while the same build is still in review on Google Play, and
+   * raising one global floor in that window locks every Android user out of an
+   * app they have no way to update yet. Raise the platform that shipped, leave
+   * the other alone, and clear both once the release is out everywhere.
+   *
+   * Unset or empty on a platform means "no platform floor", which falls back
+   * to `MIN_APP_VERSION`.
+   */
   MIN_APP_VERSION: semverSchema,
+  MIN_APP_VERSION_IOS: optionalSemverSchema,
+  MIN_APP_VERSION_ANDROID: optionalSemverSchema,
 
   /**
    * APPLE MAGIC

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -152,9 +152,10 @@ const configSchema = z.object({
   /**
    * FREE LIKES
    *
-   * The daily like allowance for free accounts, movable without a deploy so
-   * the ceiling can be tuned against matches per swiper rather than guessed
-   * once and frozen into a build. Unset keeps the value the app shipped with.
+   * The daily like allowance for free accounts, moved by an environment
+   * variable so the ceiling can be tuned against matches per swiper rather
+   * than guessed once and frozen into a shipped build. Unset keeps the value
+   * the app shipped with.
    */
   FREE_DAILY_LIKE_LIMIT: freeDailyLikeLimitSchema,
 

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -1,3 +1,4 @@
+import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
 import semver from "semver";
 import { z } from "zod";
 
@@ -25,6 +26,24 @@ export const optionalSemverSchema = z.preprocess(
   (value) => (value === "" ? undefined : value),
   semverSchema.optional(),
 );
+
+/**
+ * How many likes a free account gets in a rolling 24 hours.
+ *
+ * Never throws. This number decides whether a swipe is accepted, and an
+ * operator fat fingering the variable must not take the whole API down at
+ * boot: anything that is not a positive whole number falls back to the value
+ * the app has always used. Blank counts as unset for the same reason the
+ * version floors do, because Vercel keeps a variable once it has been added
+ * and clearing the box is how someone puts the default back.
+ */
+export const freeDailyLikeLimitSchema = z
+  .preprocess(
+    (value) => (value === "" ? undefined : value),
+    z.coerce.number().int().positive().optional(),
+  )
+  .catch(undefined)
+  .transform((value) => value ?? FREE_DAILY_SWIPE_LIMIT);
 
 const configSchema = z.object({
   /** GENERAL */
@@ -129,6 +148,15 @@ const configSchema = z.object({
   MIN_APP_VERSION: semverSchema,
   MIN_APP_VERSION_IOS: optionalSemverSchema,
   MIN_APP_VERSION_ANDROID: optionalSemverSchema,
+
+  /**
+   * FREE LIKES
+   *
+   * The daily like allowance for free accounts, movable without a deploy so
+   * the ceiling can be tuned against matches per swiper rather than guessed
+   * once and frozen into a build. Unset keeps the value the app shipped with.
+   */
+  FREE_DAILY_LIKE_LIMIT: freeDailyLikeLimitSchema,
 
   /**
    * APPLE MAGIC

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -60,6 +60,8 @@ export const ANALYTICS_EVENTS = {
   SUBSCRIPTION_EVENT: "Subscription Event",
   SWIPE: "Swipe",
   SWIPE_BACK: "Swipe Back",
+  UPDATE_REQUIRED_SHOWN: "Update Required Shown",
+  UPDATE_REQUIRED_STORE_TAPPED: "Update Required Store Tapped",
   UPGRADE: "Upgrade",
 } as const;
 
@@ -237,6 +239,21 @@ export type MobileEventProperties = {
     swipe_type: SwipeKind;
   };
   [ANALYTICS_EVENTS.SWIPE_BACK]: undefined;
+  /**
+   * Both halves of the forced update carry the same two versions, so the wall
+   * and the tap that leaves it join on their own without a session lookup.
+   * `Update Required Shown` grouped by `app_version` is how many people a
+   * raised floor is actually holding, and the ratio to
+   * `Update Required Store Tapped` is how many of them go and get the build.
+   */
+  [ANALYTICS_EVENTS.UPDATE_REQUIRED_SHOWN]: {
+    app_version: string;
+    minimum_version: string;
+  };
+  [ANALYTICS_EVENTS.UPDATE_REQUIRED_STORE_TAPPED]: {
+    app_version: string;
+    minimum_version: string;
+  };
   [ANALYTICS_EVENTS.UPGRADE]: {
     package?: string;
     trial?: boolean | null;
@@ -423,6 +440,8 @@ export const MOBILE_EVENT_NAMES = [
   ANALYTICS_EVENTS.SKIP_COMPLETE_DOG_PROFILE,
   ANALYTICS_EVENTS.SWIPE,
   ANALYTICS_EVENTS.SWIPE_BACK,
+  ANALYTICS_EVENTS.UPDATE_REQUIRED_SHOWN,
+  ANALYTICS_EVENTS.UPDATE_REQUIRED_STORE_TAPPED,
   ANALYTICS_EVENTS.UPGRADE,
 ] as const;
 

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -82,8 +82,11 @@ export type PaywallTrigger =
 /** An OS permission answer, collapsed to the two states that matter. */
 export type PermissionStatus = "denied" | "granted";
 
-/** The two things the empty swipe deck offers besides the preferences link. */
-export type EmptyDeckAction = "invite_friend" | "notify_new_dogs";
+/** What the user picked on the empty swipe deck. */
+export type EmptyDeckAction =
+  | "invite_friend"
+  | "notify_new_dogs"
+  | "preferences";
 
 /**
  * The push answer as the empty deck sees it. Wider than

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -255,7 +255,21 @@ export type MobileEventProperties = {
     minimum_version: string;
   };
   [ANALYTICS_EVENTS.UPGRADE]: {
+    /**
+     * Whether the receipt behind a successful upgrade was a sandbox one.
+     * `null` when the entitlement could not be read, which is a different
+     * answer from `false` and is counted separately.
+     */
+    is_sandbox?: boolean | null;
     package?: string;
+    /**
+     * Where a successful upgrade came from. `store` is a real purchase through
+     * RevenueCat, which is the only one that also produces a `Subscription
+     * Event` on the server. `maestro_mock` is the premium grant the end to end
+     * flows hand themselves, which produces nothing server side and is not
+     * revenue.
+     */
+    source?: "maestro_mock" | "store";
     trial?: boolean | null;
     type: "cancel" | "error" | "start" | "success";
   };

--- a/packages/shared/errors/errors.ts
+++ b/packages/shared/errors/errors.ts
@@ -45,12 +45,26 @@ export class InvalidOTPCodeError extends IntentionalError {
 
 export class LikeLimitReachedError extends IntentionalError {
   likeLimitResetAt: Date;
+  /**
+   * The allowance that was just used up. It travels with the error because the
+   * server decides it from an environment variable, so a build that hardcoded
+   * the old number would otherwise tell someone they liked ten dogs on a day
+   * they were allowed twenty five. Optional so a client reading a payload from
+   * a server that predates the field can fall back to the shipped default.
+   */
+  likeLimit?: number;
 
   static message = "You have reached the like limit";
   static error_code = "LIKE_LIMIT_REACHED";
   error_code = LikeLimitReachedError.error_code;
 
-  constructor({ likeLimitResetAt }: { likeLimitResetAt: Date }) {
+  constructor({
+    likeLimit,
+    likeLimitResetAt,
+  }: {
+    likeLimit?: number;
+    likeLimitResetAt: Date;
+  }) {
     super({
       code: "TOO_MANY_REQUESTS",
       message: LikeLimitReachedError.message,
@@ -58,6 +72,7 @@ export class LikeLimitReachedError extends IntentionalError {
 
     this.name = "LikeLimitReachedError";
     this.likeLimitResetAt = likeLimitResetAt;
+    this.likeLimit = likeLimit;
   }
 }
 

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -330,7 +330,7 @@
     "small": "Small"
   },
   "swipeRequestFeedback": {
-    "emptyDescription": "But hang tight! We've just launched and still have small user base.\n\nWe're working hard to ensure a space filled with doggos very soon 🐶\n\nTry adjusting your preferences or check back later! 😉",
+    "emptyDescription": "We just launched and there are still few dogs nearby 🐶\n\nAdjust your preferences or check back later 😉",
     "emptyTitle": "We couldn't find any more dogs!",
     "inviteFriendButton": "Invite a friend",
     "inviteFriendMessage": "Pegada is where my dog makes friends. Bring yours along:\n{{link}}",

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -122,6 +122,7 @@
     "female": "Female",
     "gender": "Gender",
     "male": "Male",
+    "photosExpired": "Couldn't re-upload your photos. Add them again and save the profile.",
     "profileError": "Unable to save profile information",
     "profileUpdated": "Your profile has been updated!",
     "saveProfile": "Save Profile",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -122,6 +122,7 @@
     "female": "Fêmea",
     "gender": "Sexo",
     "male": "Macho",
+    "photosExpired": "Não foi possível reenviar suas fotos. Adicione de novo e salve o perfil.",
     "profileError": "Não foi possível salvar as informações do perfil",
     "profileUpdated": "Seu perfil foi atualizado!",
     "saveProfile": "Salvar perfil",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -1,6 +1,6 @@
 {
   "likeLimit": {
-    "dailyLikeLimit": "Limite de Curtidas Diário",
+    "dailyLikeLimit": "Limite de curtidas diário",
     "description": "Você curtiu <b>{{count}} cachorros</b> em <b>24h</b>. Espere ou vire <b>premium</b> para continuar deslizando.",
     "remaining": "restantes",
     "timeHours": "{{time}}h",
@@ -29,7 +29,7 @@
   },
   "askForLocation": {
     "activateLocation": "Ativar localização",
-    "enableLocation": "Ativar Localização",
+    "enableLocation": "Ativar localização",
     "activate": "Ativar",
     "locationUsage": "Sua localização será utilizada para mostrar doguinhos perto de você.",
     "permissionPrompt": "Você precisa permitir o acesso à localização para usar o Pegada."
@@ -67,7 +67,7 @@
   },
   "completeProfile": {
     "additionalInfo": "Assim como você poderá selecionar suas preferências para dogs, os outros doguinhos também podem.\n\nEssas informações servem para que possamos te mostrar para os melhores matches!",
-    "birthDate": "Data de Nascimento",
+    "birthDate": "Data de nascimento",
     "breed": "Raça",
     "color": "Cor",
     "female": "Fêmea",
@@ -81,10 +81,10 @@
     "bio": "Bio",
     "clickAndHold": "* Clique e segure na foto para alterar a ordem.",
     "createProfile": "Criar perfil",
-    "dogName": "Nome do Doguinho",
+    "dogName": "Nome do doguinho",
     "howToCallDog": "Como podemos chamar seu doguinho?",
     "minimumOnePhoto": "Pelo menos uma foto deve incluir você (dono/a)",
-    "profilePictures": "Fotinhas do Dog",
+    "profilePictures": "Fotinhas do dog",
     "tellSomethingCool": "Conte alguma coisa legal sobre vocês.",
     "title": "Crie seu perfil"
   },
@@ -98,7 +98,7 @@
   "dogProfile": {
     "profileInfoError": "⚠️ Oops. Tente novamente mais tarde.",
     "cancel": "Cancelar",
-    "dogProfile": "Perfil do Doguinho",
+    "dogProfile": "Perfil do doguinho",
     "report": "Denunciar",
     "reportBody": "Eu gostaria de denunciar a conta número {{id}}, pertencente a {{name}} por:\n",
     "reportMessage": "Ao denunciar um perfil, você estará nos ajudando a manter a comunidade segura. Deseja continuar?",
@@ -115,16 +115,16 @@
   "editProfile": {
     "bio": "Bio",
     "bioPlaceholder": "Conte alguma coisa legal sobre vocês.",
-    "birthDate": "Data de Nascimento",
+    "birthDate": "Data de nascimento",
     "color": "Cor",
-    "dogName": "Nome do Doguinho",
+    "dogName": "Nome do doguinho",
     "dogNamePlaceholder": "Como podemos chamar seu doguinho?",
     "female": "Fêmea",
     "gender": "Sexo",
     "male": "Macho",
     "profileError": "Não foi possível salvar as informações do perfil",
     "profileUpdated": "Seu perfil foi atualizado!",
-    "saveProfile": "Salvar Perfil",
+    "saveProfile": "Salvar perfil",
     "size": "Tamanho",
     "title": "Editar perfil",
     "weight": "Peso (kg)"
@@ -132,7 +132,7 @@
   "forceUpdate": {
     "button": "Atualizar",
     "description": "Uma nova versão do Pegada está disponível. Por favor, atualize para continuar usando o app.",
-    "title": "Atualização Obrigatória"
+    "title": "Atualização obrigatória"
   },
   "formErrors": {
     "bioTooLong": "A bio deve conter no máximo {{length}} caracteres",
@@ -148,11 +148,11 @@
   },
   "imagePicker": {
     "cancel": "Cancelar",
-    "chooseFromLibrary": "Escolher da Galeria",
+    "chooseFromLibrary": "Escolher da galeria",
     "message": "Tirar uma foto ou escolher da galeria",
     "permissionsRequiredMessage": "Por favor, conceda as permissões necessárias para acessar a câmera e a galeria de fotos.",
     "permissionsRequiredTitle": "Desculpe, precisamos dessa permissão para que isso funcione!",
-    "takePhoto": "Tirar Foto",
+    "takePhoto": "Tirar foto",
     "title": "O que você prefere?",
     "uploadFailed": "Não foi possível enviar a imagem. Tente novamente.",
     "uploadFailedDev": "Falha no upload: {{reason}}"
@@ -161,7 +161,7 @@
     "accountCode": "Vamos enviar um código de 6 dígitos para autorizar sua conta. Se ainda não tem uma, vamos criá-la.",
     "continue": "Continuar",
     "emailPlaceholder": "oi@email.com",
-    "findDogsNearYou": "<view><title>Encontre </title><highlight>Dogs</highlight></view><view><title>perto de </title><highlight>Você</highlight><view/>",
+    "findDogsNearYou": "<view><title>Encontre </title><highlight>dogs</highlight></view><view><title>perto de </title><highlight>você</highlight><view/>",
     "insertEmail": "Insira seu <1>email</1>",
     "loginError": "Ocorreu um erro ao fazer login.",
     "validEmail": "Insira um email válido"
@@ -169,7 +169,7 @@
   "locationMap": {
     "adjustYourPosition": "Ajuste sua posição",
     "areYouHere": "Você está aqui?",
-    "confirmLocation": "Confirmar Localização",
+    "confirmLocation": "Confirmar localização",
     "title": "Localização",
     "updateLocationError": "Ocorreu um erro ao atualizar sua localização."
   },
@@ -178,21 +178,21 @@
     "itsAMatchDescription": "Você deu match com esse doguinho!"
   },
   "matches": {
-    "matchedDogs": "Doguinhos Que Deram Match 🐶",
+    "matchedDogs": "Doguinhos que deram Match 🐶",
     "messages": "Mensagens",
     "sendFirstMessage": "Envie a primeira mensagem!"
   },
   "messages": {
     "empty": {
-      "clearSearch": "Limpar Busca",
+      "clearSearch": "Limpar busca",
       "description": " Aqui você irá ver e enviar mensagens para seus Matches.",
-      "searchForDogs": "Procurar Doguinhos",
+      "searchForDogs": "Procurar doguinhos",
       "title": "Não encontramos Matches, procure por novos doguinhos!"
     }
   },
   "newMatch": {
-    "keepSwiping": "Continue Deslizando",
-    "sendMessage": "Enviar Mensagem",
+    "keepSwiping": "Continue deslizando",
+    "sendMessage": "Enviar mensagem",
     "youGotA": "Você deu um",
     "youLikedEachOther": "Você e {{name}} se curtiram!"
   },
@@ -212,7 +212,7 @@
     "color": "Cor",
     "maxDistance": "Distância máxima",
     "preferencesUpdated": "Suas preferências foram atualizadas!",
-    "savePreferences": "Salvar Preferências",
+    "savePreferences": "Salvar preferências",
     "size": "Tamanho",
     "title": "Preferências",
     "updateError": "Ocorreu um erro ao atualizar suas preferências.",
@@ -254,7 +254,7 @@
     "theme": "Tema",
     "updateLocation": "Atualizar localização",
     "plan": {
-      "currentPlan": "Plano Atual",
+      "currentPlan": "Plano atual",
       "errorLoading": "Erro ao carregar o plano",
       "clickToRetry": "Tente novamente",
       "upgradeToPremium": "Atualize para Premium",
@@ -262,7 +262,7 @@
     }
   },
   "plans": {
-    "FREE": "Grátuito",
+    "FREE": "Gratuito",
     "PREMIUM": "Premium",
     "day": "dia",
     "week": "semana",
@@ -274,17 +274,17 @@
     "yearly": "Anual",
     "save": "Economize {{percent}}%",
     "benefits": {
-      "priorityQueue": "Prioridade na Fila",
+      "priorityQueue": "Prioridade na fila",
       "getSeenFirst": "Seja visto primeiro pelos populares!",
-      "unlimitedLikes": "Curtidas Ilimitadas",
+      "unlimitedLikes": "Curtidas ilimitadas",
       "noDailyLimits": "Sem limites para o amor",
-      "rewind": "Voltar na Lista de Doguinhos",
+      "rewind": "Voltar na lista de doguinhos",
       "madeAMistake": "Cometeu um erro? Sem problemas",
-      "noAds": "Sem Anúncios",
+      "noAds": "Sem anúncios",
       "noAdsDescription": "Aproveite o app sem distrações"
     },
     "restorePurchases": {
-      "restore": "Restaurar Compras"
+      "restore": "Restaurar compras"
     },
     "errors": {
       "fetchingOfferingsDevice": "Ocorreu um erro ao buscar as ofertas. Tente em um dispositivo real.",
@@ -323,7 +323,7 @@
     "expiredMessage": "Faça login novamente para continuar."
   },
   "sizes": {
-    "extraSmall": "Extra Pequeno",
+    "extraSmall": "Extra pequeno",
     "giant": "Gigante",
     "large": "Grande",
     "medium": "Médio",
@@ -336,7 +336,7 @@
     "inviteFriendMessage": "O Pegada é onde meu cachorro faz amigos. Traz o seu também:\n{{link}}",
     "notifyNewDogsButton": "Avisar quando chegar dog novo",
     "notifyNewDogsDone": "Vamos te avisar",
-    "preferencesButton": "Ver Preferências"
+    "preferencesButton": "Ver preferências"
   },
   "themes": {
     "automatic": "Automático",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -330,7 +330,7 @@
     "small": "Pequeno"
   },
   "swipeRequestFeedback": {
-    "emptyDescription": "Mas calma! Acabamos de lançar e ainda temos poucos usuários.\n\nEstamos trabalhando para garantir um espaço cheio de doguinhos logo logo 🐶\n\nTente ajustar suas preferências ou volte mais tarde! 😉",
+    "emptyDescription": "Acabamos de lançar e ainda tem pouca gente por perto 🐶\n\nAjusta suas preferências ou volta mais tarde 😉",
     "emptyTitle": "Parece que os doguinhos acabaram!",
     "inviteFriendButton": "Convidar um amigo",
     "inviteFriendMessage": "O Pegada é onde meu cachorro faz amigos. Traz o seu também:\n{{link}}",

--- a/packages/shared/types/types.ts
+++ b/packages/shared/types/types.ts
@@ -1,6 +1,7 @@
 export enum RequestHeaders {
   Authorization = "authorization",
   XAppVersion = "x-app-version",
+  XAppPlatform = "x-app-platform",
   XTRPCSource = "x-trpc-source",
   AcceptLanguage = "accept-language",
 }


### PR DESCRIPTION
## Summary

This is a backport branch for the users still on runtime 1.6.2. It is based on `37fa5e2`, the commit behind the last EAS update those users actually received, not on the `v1.6.2` tag. CI kept publishing updates from `main` to runtime 1.6.2 until the universal links merge bumped the version to 1.7.1, so a 1.6.2 phone today is already running `37fa5e2`, not the tag.

**Do not merge this into `main`.** It exists only to publish over the air updates to the 1.6.2 channel. Merging it would replay commits that are already on `main`.

## Details

Ported on top of `37fa5e2`, each as its own commit:

* `fix(mobile): stop the swipe screen replaying the last notification tap` (backport of #231). The stored tap is keyed by the notification id and consumed once, so the mount path and the app wide listener cannot both report it. The pending dog profile store does not exist on this base, so its mock, harness and five tests are left out; the suite covers the replay cases only. The re-engagement push kind is on this base, so the kind carried into the reported open is kept.
* `fix(shared): put the Portuguese interface in sentence case` (backport of #252). Only the pt-BR translation keys present on this base change: 29 values, no keys added or removed. The `web.json` half is dropped, because the footer and waitlist sections it rewrote are not on this base.
* `fix(mobile): make the empty deck reachable and its done state readable` (backport of #248). The empty state column scrolls, the notify opt in stops being a half opacity disabled button once taken, and the preferences tap is counted. The `SharePromptCard` this column renders upstream belongs to the native share work, which is not on this base, so the card, its import, its test mock and the three tests that assert on it are left out. Everything else stands on its own.
* `feat: minimum app version per platform` (backport of #274). The minimum supported version becomes a per platform floor, and the client now sends its platform alongside its version so the server can answer with the right one. This is what makes retiring 1.6.2 possible: without it a 1.6.2 client sends no platform header and ignores the per platform floors, so the only way to move the floor would be to cut iOS and Android off together. The update wall also clears the stack before it navigates, sets its seen flag only once the navigation actually went through, and no longer accepts the back gesture, so one back swipe cannot drop someone back into the app the floor just locked. The pending dog profile import the original adds to the root layout is left out, since that store is not on this base. The `packages/api` half comes along because the mobile tRPC types infer from the router and the echo tests cover the floor logic; it is inert for this branch, since the API ships with the server and production already runs `main`.

* `feat(mobile): tag analytics with the running update` (backport of #285). Every PostHog event now carries the update the device is actually running: `ota_update_id`, `ota_is_embedded`, `runtime_version`, `ota_channel` and `ota_created_at`, registered once as super properties so they ride along on exceptions too, not just on `analytics.track` calls. This is what makes "did the update reach anyone?" answerable for the people stuck on the 1.6.2 binary, whose `$app_version` says 1.6.2 forever. The metrics script half of the original is dropped: `scripts/metrics/` does not exist on this base, and the readout runs from `main`.

* `fix(mobile): keep a signed in user out of the sign in loop` (backport of #283). The launch query now retries under the shared transient policy with a four second ceiling per attempt and a ten second ceiling on the whole decision, and a device that already holds a token routes into the app instead of being dropped back on sign in when the network is slow. Both commits of the original come across. The `packages/api` half, which turns the already logged in throw into a coded CONFLICT, is left out: it ships with the server and production already runs `main`, and the mobile side only calls the existing echo route, so nothing here depends on it.
* `fix(mobile): re-upload profile photos when the grant went stale` (backport of #284). Saving a profile whose upload grant expired now puts the photos back in the bucket and saves once more, exactly one extra attempt, and falls back to a toast in Portuguese and English telling the person to add the photos again. The two translation keys come along because they ship inside the bundle. The `packages/api` half, which lengthens the grant to an hour, is left out for the same reason as above, and it already reached production from `main`. The client side is the floor under that fix, not a replacement for it.

* `fix(mobile): look again when the keychain is not ready at launch` (backport of #286). The token read at launch now asks the keychain up to three times with a growing pause between attempts. iOS answers that read with "a required entitlement isn't present" when the app process is not attached yet, which is what a launch nobody started looks like: the system prewarming the app, or a notification waking it while the phone is still locked. A phone with no token is not affected, because an absent item comes back as an empty answer rather than a failure and never costs a retry, and a read that keeps failing still fails, so a real misconfiguration stays visible. Worst case this adds 450ms, and only to a launch that was already failing. Both halves of the original cherry pick clean onto this base, so nothing is left out. This one matters most here: every event in the audit came from the store build, so the 1.6.2 users are the only ones it reaches.

* `feat(mobile): say whether an upgrade was a real purchase` (backport of the mobile half of #290). A successful upgrade now carries `source` and `is_sandbox` next to the package it bought, so an App Store charge, a sandbox receipt and the premium grant the end to end flows hand themselves stop counting as the same thing in the readout. Only the store purchase produces a subscription event on the server, which is how successful upgrades could show up with nothing behind them. `is_sandbox` is null rather than false when the entitlement cannot be read, so a receipt nobody could open is not filed as real money. The server half of the original is left out: it ships with the server, and production already runs `main`.

* `feat(api): make the free daily like limit configurable` (backport of #295). The free daily like allowance stops being a number compiled into the app. The launch query and the foreground check both read `freeDailyLikeLimit` off the echo route, and the refusal the server sends when someone runs out carries the allowance it actually enforced, so the limit sheet copy and the `Like Limit Reached` event report the number the server used rather than the number this binary was built with. A payload without the field leaves the shipped default of ten in place, which is what an older server answers with, so nothing regresses if the two sides disagree. All three commits cherry pick clean onto this base. The `packages/api` half comes along because the mobile tRPC types infer from the router; it is inert on this branch, since the server ships from `main`, where the same change already landed.

Deliberately not ported:

* The paywall without a trial, the funnel events, the review ask after the first match and the empty deck actions. These already reached 1.6.2 users through CI updates from `main` before the version bump, so backporting them would be a no op at best.
* The quiet empty deck, the sign in banner, the native share sheet and the story card. All of them need native code or components this base does not have.
* The API only commits, which ship with the server and not with an update.

Measurement. The baseline from #188 is 800 re-engagement pushes sent this week with 0 opens recorded, because 1.6.2 does not track opens at all. The readout is the PostHog event `Push Notification Opened` filtered to app version 1.6.2.

Publish record, newest first:

* Seventh publish: update group `d2d03804-1c3d-4010-88ab-36e6fd594605` from commit `5f280c2` (server driven free daily like limit, #295) on channel `main` at runtime 1.6.2, iOS update `01a07b68-6aac-716b-b627-a6c11a576ff0`. Preflight group `06eb7d5d-181c-4fb2-99e1-225d325b7ffd`, iOS update `01a07b65-3d7e-7469-bccb-508f706ee4fa`, was verified first on a release simulator build pinned to the `ota-preflight` channel and built before the preflight group was published. The binary carried `expo-channel-name: ota-preflight` in its update request headers at runtime 1.6.2. On the first launch the device logged `didFinishBackgroundUpdateWithStatus=NewUpdateLoaded` against that update id, and on the second it came back `checkCompleteUnavailable` with `isUpToDate=1` and no update left to fetch. Its updates database recorded two successful launches and zero failed ones against that update id, and zero launches against the embedded bundle, so the published bundle is what ran both times. No crash was logged and the app rendered its screen past the splash on both starts. Rollback of this one alone is `eas update:rollback d2d03804-1c3d-4010-88ab-36e6fd594605`, which republishes `fd7ca41a`.

* Sixth publish: update group `fd7ca41a-bef1-4d2d-8a7c-25433753643e` from commit `29696e0` (upgrade event properties, mobile half of #290 by way of #291) on channel `main` at runtime 1.6.2, iOS update `01a076f5-ed18-71d3-a992-31fc2e4df878`. Preflight group `e4fba8a7-4dc9-44e8-b8a7-eb990fbb8668`, iOS update `01a076f2-8bce-76d5-b2e7-db21ceaf2ca9`, was verified first on a release simulator build pinned to the `ota-preflight` channel and built before the preflight group was published. The binary carried `expo-channel-name: ota-preflight` in its update request headers, and the row the device stored for the published update id carries the same header back. That row came out ready with two successful launches and zero failed ones across two cold starts, against one launch for the embedded bundle, so the published bundle is what ran. No crash report was written, and the app rendered its screen past sign in both times. Rollback of this one alone is `eas update:rollback fd7ca41a-bef1-4d2d-8a7c-25433753643e`, which republishes `c240833f`.

* Fifth publish: update group `c240833f-e043-4762-987d-6c16623b188a` from commit `ac36c13` (keychain read retry at launch, #286) on channel `main` at runtime 1.6.2, iOS update `01a071b6-cbd0-7f8c-b371-73a5c17bcf16`. Preflight group `e1ba57f2-d6b5-4be3-946e-5e0a4fd4c3fe`, iOS update `01a071b2-b2ca-74e9-8d8e-2dd5ab9a1af4`, was verified first on a release simulator build pinned to the `ota-preflight` channel and built before the preflight group was published. The device logged `didStartLoadingUpdate` against that update id, pulled all 52 assets with none failed, finished `didFinishBackgroundUpdateWithStatus=NewUpdateLoaded`, and came back `checkCompleteUnavailable` with `isUpToDate=1` on the next launch. Its updates database recorded two successful launches and zero failed ones against that update id, and none at all against the embedded one, so the published bundle is what ran. The app rendered the sign in screen both times, which is the launch routing path this change touches. Rollback of this one alone is `eas update:rollback c240833f-e043-4762-987d-6c16623b188a`, which republishes `ba2798f2`.

* Fourth publish: update group `ba2798f2-6c48-49d3-a1e7-245f0197b5dd` from commit `52c913a` (sign in loop and stale upload grant, #283 and #284) on channel `main` at runtime 1.6.2. Preflight group `408792c9-e140-4408-9c18-d548b1ee52aa` was verified on the same release simulator build first: it downloaded, logged `NewUpdateLoaded`, came back `isUpToDate` on the next launch, recorded two successful launches and zero failed ones, and the app rendered the sign in screen past the splash, which is the launch routing path this change touches. Rollback of this one alone is `eas update:rollback ba2798f2-6c48-49d3-a1e7-245f0197b5dd`, which republishes `19f2351e`.
* Third publish: update group `19f2351e-5cb2-4a06-9027-05cd054c68c5` from commit `5b74b2e` (analytics tagged with the running update, #285) on channel `main` at runtime 1.6.2. Preflight group `48cb7ff0-88f3-4abf-9d88-d3cd7624c036` was verified on a release simulator build pinned to the `ota-preflight` channel first: the device downloaded it, logged `NewUpdateLoaded` and then `isUpToDate` on the next launch, recorded two successful launches and zero failed ones, and PostHog came up registering `ota_update_id` equal to the update the launcher actually loaded. Rollback of this one alone is `eas update:rollback 19f2351e-5cb2-4a06-9027-05cd054c68c5`, which republishes `bc9927dc`.
* Second publish: update group `bc9927dc-b7ce-4e0a-83d5-ac3f48a40c09` from commit `b356e90` (minimum app version gate per platform, #274) at 01:03 UTC on 2026-09-05, preflight group `f86b0b0c-f6e4-4708-bbf1-0655ffcac1ba` verified on device. Rollback of this one alone is `eas update:rollback bc9927dc-b7ce-4e0a-83d5-ac3f48a40c09`, which republishes `85e75f28`.

Rollback chain, newest to oldest: `d2d03804` to `fd7ca41a` to `c240833f` to `ba2798f2` to `19f2351e` to `bc9927dc` to `85e75f28` to `0eebf8e3`.

Lesson recorded: build the preflight binary first, publish the preflight group second, or the binary refuses the older update.

## Testing steps

1. Run the type check, the linter, the formatter check and the mobile test suite at the repo root after each port. All pass.
2. `npx oxfmt --check` over the 22 changed TypeScript files. All correctly formatted.
3. Confirm `apps/mobile/app.config.ts` still says version `1.6.2` with the `appVersion` runtime policy, and that `apps/mobile/package.json` and `pnpm-lock.yaml` are byte identical to `37fa5e2`. No dependency moves, so the runtime stays compatible with the binary already on people's phones.
4. Grep the whole range for `expo-sharing`, `react-native-view-shot`, `expo-clipboard`, `associatedDomains`, `intentFilters`, `DogShareOptions` and `usePendingDogProfile`. Zero hits, so nothing here needs a native rebuild.
5. Check the version floor both ways: a client below its platform floor is sent to the update wall, and one at or above it is not. The echo tests cover the per platform answer, including a client that sends no platform at all.
6. Publish to the `ota-preflight` channel and open a release build of 1.6.2 pointed at that channel. The update downloads, the app relaunches on it, and the screenshots below come from that build.
7. On an account without a subscription, use up the free likes for the day. The sheet that appears names the same number of likes the server allows, and it still names ten when the server does not send a number at all.

## Screenshots

Paywall, yearly preselected with the saving badge:

![Paywall with the yearly plan preselected](https://raw.githubusercontent.com/GSTJ/pegada/shots/release/ota-1.6.2/shots/paywall-yearly-preselected.png)

Full paywall, no free trial copy anywhere in the column:

![Paywall scrolled to the bottom with no trial copy](https://raw.githubusercontent.com/GSTJ/pegada/shots/release/ota-1.6.2/shots/paywall-no-trial-copy.png)

Portuguese in sentence case, sign in:

![Sign in screen in Portuguese sentence case](https://raw.githubusercontent.com/GSTJ/pegada/shots/release/ota-1.6.2/shots/ptbr-sentence-case-sign-in.png)

Portuguese in sentence case, create profile:

![Create profile screen in Portuguese sentence case](https://raw.githubusercontent.com/GSTJ/pegada/shots/release/ota-1.6.2/shots/ptbr-sentence-case-create-profile.png)




