### PR TITLE
feat(ci): attribute returns to reengagement pushes in the daily readout

### DIFF
--- a/scripts/metrics/daily.mjs
+++ b/scripts/metrics/daily.mjs
@@ -22,6 +22,7 @@ import {
   buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
+  buildPushAttributedReturnsQuery,
   buildTotalsQuery,
   buildWindows,
 } from "./queries.mjs";
@@ -62,21 +63,43 @@ export async function runDailyMetrics({
   const run = (name, query) =>
     queryHogql({ apiKey, fetchImpl, host, name, projectId, query });
 
-  const [activeUsers, activeUsersByVersion, totals, ...breakdownRows] =
-    await Promise.all([
-      run("pegada daily metrics: active users", buildActiveUsersQuery(windows)),
+  // Two queries rather than one grouped query: each window needs its own
+  // activity range, because a push sent at the end of a window is followed by
+  // an hour that falls outside it.
+  const pushReturnWindows = {
+    current: { end: windows.currentEnd, start: windows.currentStart },
+    previous: { end: windows.currentStart, start: windows.previousStart },
+  };
+
+  const [
+    activeUsers,
+    activeUsersByVersion,
+    totals,
+    pushReturnsCurrent,
+    pushReturnsPrevious,
+    ...breakdownRows
+  ] = await Promise.all([
+    run("pegada daily metrics: active users", buildActiveUsersQuery(windows)),
+    run(
+      "pegada daily metrics: active users by app version",
+      buildActiveUsersByVersionQuery(windows),
+    ),
+    run("pegada daily metrics: event totals", buildTotalsQuery(windows)),
+    run(
+      "pegada daily metrics: push attributed returns, last 7 days",
+      buildPushAttributedReturnsQuery(pushReturnWindows.current),
+    ),
+    run(
+      "pegada daily metrics: push attributed returns, previous 7 days",
+      buildPushAttributedReturnsQuery(pushReturnWindows.previous),
+    ),
+    ...BREAKDOWNS.map((breakdown) =>
       run(
-        "pegada daily metrics: active users by app version",
-        buildActiveUsersByVersionQuery(windows),
+        `pegada daily metrics: ${breakdown.id}`,
+        buildBreakdownQuery(windows, breakdown),
       ),
-      run("pegada daily metrics: event totals", buildTotalsQuery(windows)),
-      ...BREAKDOWNS.map((breakdown) =>
-        run(
-          `pegada daily metrics: ${breakdown.id}`,
-          buildBreakdownQuery(windows, breakdown),
-        ),
-      ),
-    ]);
+    ),
+  ]);
 
   const breakdowns = Object.fromEntries(
     BREAKDOWNS.map((breakdown, position) => [
@@ -90,6 +113,10 @@ export async function runDailyMetrics({
     activeUsersByVersion,
     breakdowns,
     generatedAt: now,
+    pushReturns: {
+      current: pushReturnsCurrent,
+      previous: pushReturnsPrevious,
+    },
     totals,
     windows,
   });

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -59,12 +59,20 @@ function fakeWorld({ existingComment = null } = {}) {
           ],
         });
       }
+      if (name.includes("push attributed returns")) {
+        return json({
+          columns: ["people"],
+          results: [[name.includes("previous") ? 160 : 200]],
+        });
+      }
       if (name.endsWith("event totals")) {
         return json({
           columns: ["event", "period", "total", "people"],
           results: [
             ["Swipe", "current", 5400, 300],
             ["Swipe", "previous", 5000, 280],
+            ["Reengagement Push Sent", "current", 1000, 800],
+            ["Reengagement Push Sent", "previous", 900, 640],
             ["Share Tapped", "current", 80, 70],
           ],
         });
@@ -118,7 +126,33 @@ test("a dry run renders the comment and never touches GitHub", async () => {
 test("one query goes out per metric block", async () => {
   const fetchImpl = fakeWorld();
   await runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW });
-  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 3);
+  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 5);
+});
+
+test("both push return windows are asked for separately and land in the table", async () => {
+  const fetchImpl = fakeWorld();
+  const result = await runDailyMetrics({
+    argv: ["--dry-run"],
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  const names = fetchImpl.calls
+    .filter((call) => call.body?.name?.includes("push attributed returns"))
+    .map((call) => call.body.name);
+  assert.deepEqual(names.sort(), [
+    "pegada daily metrics: push attributed returns, last 7 days",
+    "pegada daily metrics: push attributed returns, previous 7 days",
+  ]);
+  assert.match(
+    result.body,
+    /\| Push attributed returns \(60 min\) \| 200 \| 160 \| \+40 \(\+25\.0%\) \|/,
+  );
+  assert.match(
+    result.body,
+    /Coverage note: the store build 1\.6\.2 cannot emit/,
+  );
 });
 
 test("a full run posts the readout once", async () => {

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -67,6 +67,36 @@ export const SERVER_EVENTS = [
 ].sort();
 
 /**
+ * The build most people are actually running, and the readout events it has no
+ * code to send.
+ *
+ * Checked against the app at tag v1.6.2. The list is only client events: the
+ * API emits `Message Sent`, `Reengagement Push Sent`, `Push Ticket Result` and
+ * the rest of `SERVER_EVENTS` from the deployed server, so those rows are real
+ * whatever build a person is on. `Create Dog Profile`, `New Match` and
+ * `Upgrade` do exist in 1.6.2, which is why they are not here.
+ *
+ * `Swipe` covers both the swipe count and the distinct swiper count, since one
+ * missing event empties both rows.
+ *
+ * Keep this in step with what is in the store, not with what is on main. The
+ * point of the note is to stop a reach gap from reading as a dead product.
+ */
+export const STORE_BUILD_COVERAGE = {
+  missingEvents: [
+    EVENTS.EMPTY_DECK_SHOWN,
+    EVENTS.FAKE_DOOR_TAPPED,
+    EVENTS.PAYWALL_VIEWED,
+    EVENTS.PUSH_NOTIFICATION_OPENED,
+    EVENTS.SHARE_COMPLETED,
+    EVENTS.SHARE_PROMPT_TAPPED,
+    EVENTS.SHARE_TAPPED,
+    EVENTS.SWIPE,
+  ],
+  version: "1.6.2",
+};
+
+/**
  * The property posthog-react-native puts on every event from the native app,
  * read out of the app bundle rather than sent by hand. Web events do not carry
  * it, so they land in the `unknown` bucket, which is the honest answer for a
@@ -267,5 +297,69 @@ export function buildBreakdownQuery(windows, breakdown) {
     `  AND event = ${quote(breakdown.event)}`,
     "GROUP BY bucket, period",
     "ORDER BY bucket, period",
+  ].join("\n");
+}
+
+/**
+ * The `$lib` value that only the mobile app reports.
+ *
+ * Narrower than `CLIENT_LIBS` on purpose: a push lands on a phone, so a browser
+ * session on the marketing site is not the person coming back from it.
+ */
+export const PUSH_RETURN_LIB = "posthog-react-native";
+
+/** How long after a send an app event still counts as a return. */
+export const PUSH_RETURN_WINDOW_MINUTES = 60;
+
+/**
+ * People who opened the app soon after a push aimed at them.
+ *
+ * This is a proxy for the open rate, and it exists because the build in the
+ * store cannot emit `Push Notification Opened` at all, so the real rate reads
+ * as a flat zero no matter how well the pushes work.
+ *
+ * It still works on that build: every screen change sends `$screen` from the
+ * app, so a person who opens it after a push leaves a client event behind even
+ * though nothing in the app tracks the tap itself.
+ *
+ * It is a proxy and not the answer. Somebody who was going to open the app in
+ * that hour anyway is counted too, so read the trend rather than the level.
+ *
+ * The join is on `person_id` rather than on the raw distinct id because the
+ * denominator this number is divided by, "Users reached by push", is itself a
+ * count of distinct `person_id`. Joining on anything else would put a numerator
+ * and a denominator that count different things in the same row.
+ *
+ * The activity side reaches `PUSH_RETURN_WINDOW_MINUTES` past the end of the
+ * window so a push sent in the last minutes of it can still be credited, and
+ * the push side stays inside the window so a person is only ever counted in the
+ * window their push was sent in.
+ *
+ * One row, one window: the caller runs it twice rather than grouping, because
+ * the two windows need two different activity ranges.
+ */
+export function buildPushAttributedReturnsQuery({ end, start }) {
+  const activityEnd = new Date(
+    end.getTime() + PUSH_RETURN_WINDOW_MINUTES * 60 * 1000,
+  );
+  return [
+    "SELECT",
+    "  count(DISTINCT push.person_id) AS people",
+    "FROM (",
+    "  SELECT person_id, timestamp AS sent_at",
+    "  FROM events",
+    `  WHERE event = ${quote(EVENTS.REENGAGEMENT_PUSH_SENT)}`,
+    `    AND timestamp >= toDateTime(${quote(clickhouseTime(start))}, 'UTC')`,
+    `    AND timestamp < toDateTime(${quote(clickhouseTime(end))}, 'UTC')`,
+    ") AS push",
+    "INNER JOIN (",
+    "  SELECT person_id, timestamp AS acted_at",
+    "  FROM events",
+    `  WHERE properties.$lib = ${quote(PUSH_RETURN_LIB)}`,
+    `    AND timestamp >= toDateTime(${quote(clickhouseTime(start))}, 'UTC')`,
+    `    AND timestamp < toDateTime(${quote(clickhouseTime(activityEnd))}, 'UTC')`,
+    ") AS activity ON activity.person_id = push.person_id",
+    "WHERE activity.acted_at >= push.sent_at",
+    `  AND activity.acted_at < push.sent_at + toIntervalMinute(${PUSH_RETURN_WINDOW_MINUTES})`,
   ].join("\n");
 }

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -8,10 +8,14 @@ import {
   CLIENT_LIBS,
   COUNTED_EVENTS,
   EVENTS,
+  PUSH_RETURN_LIB,
+  PUSH_RETURN_WINDOW_MINUTES,
   SERVER_EVENTS,
+  STORE_BUILD_COVERAGE,
   buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
+  buildPushAttributedReturnsQuery,
   buildTotalsQuery,
   buildWindows,
   quote,
@@ -160,5 +164,78 @@ test("every event name still exists in the shared analytics catalogue", () => {
       declared.has(event),
       `${event} is no longer in the analytics catalogue`,
     );
+  }
+});
+
+const CURRENT = {
+  end: new Date("2026-09-02T12:00:00.000Z"),
+  start: new Date("2026-08-26T12:00:00.000Z"),
+};
+
+test("the push returns query pairs a send with what the person did after it", () => {
+  const query = buildPushAttributedReturnsQuery(CURRENT);
+  assert.match(query, /count\(DISTINCT push\.person_id\) AS people/);
+  assert.match(query, /WHERE event = 'Reengagement Push Sent'/);
+  assert.match(query, /properties\.\$lib = 'posthog-react-native'/);
+  assert.match(query, /activity\.acted_at >= push\.sent_at/);
+  assert.match(
+    query,
+    /activity\.acted_at < push\.sent_at \+ toIntervalMinute\(60\)/,
+  );
+});
+
+test("the push returns query counts app events only, never the browser", () => {
+  const query = buildPushAttributedReturnsQuery(CURRENT);
+  assert.equal(PUSH_RETURN_LIB, "posthog-react-native");
+  assert.equal(query.includes("'web'"), false);
+});
+
+test("the sends stay inside the window and the activity reaches past its end", () => {
+  const query = buildPushAttributedReturnsQuery(CURRENT);
+  assert.equal(PUSH_RETURN_WINDOW_MINUTES, 60);
+  // The send side closes at the window end so nobody is counted twice.
+  assert.match(query, /timestamp < toDateTime\('2026-09-02 12:00:00', 'UTC'\)/);
+  // The activity side runs an extra hour so a send at 11:59 can still be credited.
+  assert.match(query, /timestamp < toDateTime\('2026-09-02 13:00:00', 'UTC'\)/);
+  assert.match(
+    query,
+    /timestamp >= toDateTime\('2026-08-26 12:00:00', 'UTC'\)/,
+  );
+});
+
+test("the previous window asks about its own seven days", () => {
+  const windows = buildWindows(NOW);
+  const query = buildPushAttributedReturnsQuery({
+    end: windows.currentStart,
+    start: windows.previousStart,
+  });
+  assert.match(
+    query,
+    /timestamp >= toDateTime\('2026-08-19 12:00:00', 'UTC'\)/,
+  );
+  assert.match(query, /timestamp < toDateTime\('2026-08-26 13:00:00', 'UTC'\)/);
+  assert.equal(query.includes("2026-09-02"), false);
+});
+
+test("the coverage list holds real event names and no server event", () => {
+  const known = new Set(Object.values(EVENTS));
+  for (const event of STORE_BUILD_COVERAGE.missingEvents) {
+    assert.ok(known.has(event), `${event} is not an event the readout counts`);
+    assert.equal(
+      SERVER_EVENTS.includes(event),
+      false,
+      `${event} comes from the server, so the app build cannot be why it is zero`,
+    );
+  }
+  assert.ok(STORE_BUILD_COVERAGE.missingEvents.length > 0);
+});
+
+test("the coverage list leaves out the events the store build does send", () => {
+  for (const event of [
+    EVENTS.CREATE_DOG_PROFILE,
+    EVENTS.NEW_MATCH,
+    EVENTS.UPGRADE,
+  ]) {
+    assert.equal(STORE_BUILD_COVERAGE.missingEvents.includes(event), false);
   }
 });

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -6,7 +6,12 @@
  * instead of leaving a new one behind every day.
  */
 
-import { BREAKDOWNS, EVENTS } from "./queries.mjs";
+import {
+  BREAKDOWNS,
+  EVENTS,
+  PUSH_RETURN_WINDOW_MINUTES,
+  STORE_BUILD_COVERAGE,
+} from "./queries.mjs";
 
 export const COMMENT_MARKER = "<!-- pegada-daily-metrics -->";
 
@@ -56,6 +61,30 @@ function formatPercent(value) {
 /** A share of a denominator, or null when the denominator is empty. */
 function ratio(numerator, denominator) {
   return denominator === 0 ? null : (numerator / denominator) * 100;
+}
+
+/**
+ * The single number a one row query answers with, or zero when it matched
+ * nothing. ClickHouse returns no row at all for an empty join, so a missing row
+ * and a zero mean the same thing here.
+ */
+function singleValue(rows, field = "people") {
+  return Number(rows?.[0]?.[field] ?? 0);
+}
+
+/**
+ * The line under the push table naming what the live build cannot send.
+ *
+ * Without it the zero rows read as a product that nobody uses, when what they
+ * actually measure is how many people are running a build that was cut before
+ * the event existed.
+ */
+export function coverageNote(coverage = STORE_BUILD_COVERAGE) {
+  const events = coverage.missingEvents;
+  if (events.length === 0) {
+    return `Coverage note: build ${coverage.version} emits every event in this readout.`;
+  }
+  return `Coverage note: the store build ${coverage.version} cannot emit ${events.join(", ")}, so those rows read zero for anyone still on it. They measure reach, not the product.`;
 }
 
 /** A percentage row, with the delta in points and `n/a` on either empty side. */
@@ -173,6 +202,7 @@ function breakdownTable(rows, { field = "total", header = "Bucket" } = {}) {
  * @param {Array} input.activeUsersByVersion rows from the version split
  * @param {Record<string, Array>} input.breakdowns rows per breakdown id
  * @param {Date} input.generatedAt when the job ran
+ * @param {{ current: Array, previous: Array }} input.pushReturns rows from the push attributed returns query, one per window
  * @param {Array} input.totals rows from the totals query
  * @param {{ currentEnd: Date, currentStart: Date, previousStart: Date }} input.windows
  */
@@ -181,6 +211,7 @@ export function buildReport({
   activeUsersByVersion,
   breakdowns,
   generatedAt,
+  pushReturns,
   totals,
   windows,
 }) {
@@ -251,6 +282,25 @@ export function buildReport({
     countRow(index, "Share Prompt Tapped", EVENTS.SHARE_PROMPT_TAPPED),
   ]);
 
+  // The proxy for the open rate: people the push reached who then used the app
+  // within the hour. It is a proxy and not the truth, because a person who was
+  // going to open the app anyway lands in it too, but it moves when the pushes
+  // work and the real open rate cannot.
+  const reachedCurrent = totalOf(
+    index,
+    EVENTS.REENGAGEMENT_PUSH_SENT,
+    "current",
+    "people",
+  );
+  const reachedPrevious = totalOf(
+    index,
+    EVENTS.REENGAGEMENT_PUSH_SENT,
+    "previous",
+    "people",
+  );
+  const returnedCurrent = singleValue(pushReturns?.current);
+  const returnedPrevious = singleValue(pushReturns?.previous);
+
   const push = metricTable([
     countRow(index, "Reengagement Push Sent", EVENTS.REENGAGEMENT_PUSH_SENT),
     countRow(
@@ -267,6 +317,17 @@ export function buildReport({
       EVENTS.PUSH_NOTIFICATION_OPENED,
     ),
     rateRow("Push open rate", openRateCurrent, openRatePrevious),
+    {
+      current: number(returnedCurrent),
+      delta: formatDelta(returnedCurrent, returnedPrevious),
+      label: `Push attributed returns (${PUSH_RETURN_WINDOW_MINUTES} min)`,
+      previous: number(returnedPrevious),
+    },
+    rateRow(
+      "Push attributed return rate",
+      ratio(returnedCurrent, reachedCurrent),
+      ratio(returnedPrevious, reachedPrevious),
+    ),
   ]);
 
   const breakdownSections = BREAKDOWNS.map((breakdown) =>
@@ -297,6 +358,8 @@ export function buildReport({
     "### Push",
     "",
     push,
+    "",
+    coverageNote(),
     "",
     "### Active users by app version",
     "",

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { buildWindows } from "./queries.mjs";
+import { STORE_BUILD_COVERAGE, buildWindows } from "./queries.mjs";
 import {
   COMMENT_MARKER,
   buildReport,
+  coverageNote,
   formatDelta,
   formatRateDelta,
 } from "./report.mjs";
@@ -85,6 +86,10 @@ const FIXTURE = {
     ]),
   },
   generatedAt: NOW,
+  pushReturns: {
+    current: [{ people: 200 }],
+    previous: [{ people: 160 }],
+  },
   totals: totals([
     ["Create Dog Profile", "current", 120, 118],
     ["Create Dog Profile", "previous", 150, 149],
@@ -273,4 +278,73 @@ test("an empty breakdown says so instead of rendering an empty table", () => {
 test("no emoji reaches the comment", () => {
   const body = buildReport(FIXTURE);
   assert.equal(/\p{Extended_Pictographic}/u.test(body), false);
+});
+
+test("push attributed returns land in the push table over the people reached", () => {
+  const body = buildReport({
+    ...FIXTURE,
+    totals: [
+      ...FIXTURE.totals,
+      {
+        event: "Reengagement Push Sent",
+        people: 640,
+        period: "previous",
+        total: 900,
+      },
+    ],
+  });
+  assert.match(
+    body,
+    /\| Push attributed returns \(60 min\) \| 200 \| 160 \| \+40 \(\+25\.0%\) \|/,
+  );
+  // 200 of the 800 reached came back, against 160 of 640 the week before.
+  assert.match(
+    body,
+    /\| Push attributed return rate \| 25\.0% \| 25\.0% \| 0 \|/,
+  );
+});
+
+test("a window nobody was pushed in reports no rate rather than a division", () => {
+  const body = buildReport({
+    ...FIXTURE,
+    pushReturns: { current: [], previous: [] },
+    totals: FIXTURE.totals.filter(
+      (row) => row.event !== "Reengagement Push Sent",
+    ),
+  });
+  assert.match(body, /\| Push attributed returns \(60 min\) \| 0 \| 0 \| 0 \|/);
+  assert.match(
+    body,
+    /\| Push attributed return rate \| n\/a \| n\/a \| n\/a \|/,
+  );
+});
+
+test("the returns row survives a query that answered with no rows at all", () => {
+  const body = buildReport({ ...FIXTURE, pushReturns: undefined });
+  assert.match(body, /\| Push attributed returns \(60 min\) \| 0 \| 0 \| 0 \|/);
+});
+
+test("the coverage note sits under the push table and names the store build", () => {
+  const body = buildReport(FIXTURE);
+  const note = coverageNote();
+  assert.ok(body.includes(note));
+  assert.ok(
+    body.indexOf(note) > body.indexOf("| Push attributed return rate |"),
+  );
+  assert.ok(
+    body.indexOf(note) < body.indexOf("### Active users by app version"),
+  );
+});
+
+test("the coverage note lists every event the store build cannot send", () => {
+  const note = coverageNote();
+  assert.match(note, /store build 1\.6\.2/);
+  for (const event of STORE_BUILD_COVERAGE.missingEvents) {
+    assert.ok(note.includes(event), `the note should name ${event}`);
+  }
+});
+
+test("the coverage note says so plainly once the store build sends everything", () => {
+  const note = coverageNote({ missingEvents: [], version: "1.8.0" });
+  assert.match(note, /build 1\.8\.0 emits every event in this readout/);
 });


### PR DESCRIPTION
## Summary

The readout could not say whether the reengagement pushes bring anyone back, because the build in the store has no code to send `Push Notification Opened`. This adds a proxy that works on that build, and a line saying which rows the store build cannot fill.

## Details

- New push row: people who were sent a reengagement push and then produced an app event within 60 minutes of it, plus that number as a rate over "Users reached by push".
- One HogQL query per window, so the readout grows by two queries a day. The send side stays inside the window and the activity side runs an hour past its end, so a push sent in the last minutes is still credited and nobody is counted in two windows.
- The join is on `person_id`, matching "Users reached by push", so the numerator and the denominator count the same thing.
- It counts app events only (`$lib` is `posthog-react-native`), not the marketing site, because a push lands on a phone.
- It works on 1.6.2 because every screen change sends `$screen`, so a person who opens the app leaves a client event behind even though nothing there tracks the tap.
- New coverage note under the push table, built from a constant in the script. Checked against the app at tag v1.6.2: it cannot send Empty Deck Shown, Fake Door Tapped, Paywall Viewed, Push Notification Opened, Share Completed, Share Prompt Tapped, Share Tapped or Swipe. It does send Create Dog Profile, New Match and Upgrade. Message Sent, Push Ticket Result and Reengagement Push Sent come from the server, so they are unaffected by the app build.
- A test keeps the constant honest: every name in it has to be an event the readout counts, and none of them may be a server event.

## Testing steps

Open the tracking issue and read the daily readout comment. The push section now has two more rows, one counting people who came back within the hour of a push and one giving that as a share of the people the push reached. Under the table there is a line naming the events the build in the store cannot send, so the zeros above it read as a reach gap rather than as nobody using the app. Nothing else in the readout moves.

## Screenshots

The push section of the readout, rendered from a fixture with the real shape of today's data (pushes going out, no opens coming back):

```markdown
### Push

| Metric | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| Reengagement Push Sent | 1,000 | 900 | +100 (+11.1%) |
| Users reached by push | 800 | 640 | +160 (+25.0%) |
| Push Ticket Result | 100 | 100 | 0 |
| Push Ticket Result ok rate | 90.0% | 96.0% | -6.0 pp |
| Push Notification Opened | 0 | 0 | 0 |
| Push open rate | 0.0% | 0.0% | 0 |
| Push attributed returns (60 min) | 200 | 160 | +40 (+25.0%) |
| Push attributed return rate | 25.0% | 25.0% | 0 |

Coverage note: the store build 1.6.2 cannot emit Empty Deck Shown, Fake Door Tapped, Paywall Viewed, Push Notification Opened, Share Completed, Share Prompt Tapped, Share Tapped, Swipe, so those rows read zero for anyone still on it. They measure reach, not the product.
```
