### PR TITLE
feat(ci): events audit readout on the tracking issue

### DIFF
--- a/.github/workflows/events-audit.yml
+++ b/.github/workflows/events-audit.yml
@@ -1,0 +1,51 @@
+name: Events Audit
+
+# Dispatch only. This is a "what is the tracking actually doing" pass, run when
+# somebody is about to trust a funnel or has just shipped instrumentation, not
+# something worth a comment rewrite every morning.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Print the audit in the job log instead of commenting
+        type: boolean
+        default: false
+
+# The job edits one comment in place, so two runs overlapping would race each
+# other for the same body.
+concurrency:
+  group: events-audit
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  # Writing the audit comment on the tracking issue.
+  issues: write
+
+jobs:
+  audit:
+    name: 🔍 Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: 🏗 Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22.x
+
+      # No `pnpm install`, for the same reason the daily readout skips it: the
+      # script is plain Node with no dependencies, and it reads the catalogue
+      # out of the checkout as text rather than importing it.
+      - name: 🔍 Post the audit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: pnpm run metrics:events-audit ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:security": "node scripts/test-image-size-patch.cjs",
     "test:metrics": "node --test scripts/metrics/*.test.mjs",
     "metrics:daily": "node scripts/metrics/daily.mjs",
+    "metrics:events-audit": "node scripts/metrics/events-audit.mjs",
     "build": "dotenv -e .env.dev -- turbo build",
     "lint": "oxlint --report-unused-disable-directives",
     "lint:fix": "oxlint --report-unused-disable-directives --fix",

--- a/scripts/metrics/events-audit-catalogue.mjs
+++ b/scripts/metrics/events-audit-catalogue.mjs
@@ -1,0 +1,315 @@
+/**
+ * The typed catalogue, read as text.
+ *
+ * `packages/shared/analytics/events.ts` is TypeScript inside a workspace, and
+ * the audit runs as plain Node from the repository root with no install step,
+ * exactly like the daily readout. So the catalogue is parsed rather than
+ * imported: names out of `ANALYTICS_EVENTS`, and the property keys out of the
+ * three `*EventProperties` maps, with `key?:` meaning optional and everything
+ * else required.
+ *
+ * Parsing beats hardcoding a second copy of the list. A copy goes stale the
+ * first time somebody adds an event, and an audit whose idea of the catalogue
+ * is out of date reports the new event as unknown.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/** Where the catalogue lives, relative to this file. */
+export const CATALOGUE_PATH = fileURLToPath(
+  new URL("../../packages/shared/analytics/events.ts", import.meta.url),
+);
+
+/** The three property maps, and the surface each one describes. */
+const PROPERTY_MAPS = [
+  { surface: "mobile", type: "MobileEventProperties" },
+  { surface: "server", type: "ServerEventProperties" },
+  { surface: "web", type: "WebEventProperties" },
+];
+
+/** Where the string literal that starts at `start` ends, escapes included. */
+function endOfString(source, start) {
+  const quoteChar = source[start];
+  let index = start + 1;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === "\\") {
+      index += 2;
+    } else if (char === quoteChar) {
+      return index + 1;
+    } else {
+      index += 1;
+    }
+  }
+  return source.length;
+}
+
+/**
+ * Removes comments so a brace or a colon inside prose cannot be read as code.
+ *
+ * The catalogue is heavily commented and several of those comments contain
+ * both, so stripping them first is what keeps the rest of this file a scanner
+ * rather than a parser that has to know what it is looking at. String literals
+ * are copied through whole, since the event names live in them.
+ */
+export function stripComments(source) {
+  let output = "";
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (char === '"' || char === "'" || char === "`") {
+      const end = endOfString(source, index);
+      output += source.slice(index, end);
+      index = end;
+    } else if (char === "/" && next === "/") {
+      const end = source.indexOf("\n", index);
+      index = end === -1 ? source.length : end;
+    } else if (char === "/" && next === "*") {
+      const end = source.indexOf("*/", index + 2);
+      index = end === -1 ? source.length : end + 2;
+      // A newline in place of the comment, so two declarations separated only
+      // by one do not end up glued together on a single line.
+      output += "\n";
+    } else {
+      output += char;
+      index += 1;
+    }
+  }
+  return output;
+}
+
+/**
+ * The `{ ... }` block that starts at or after `from`, brace balanced.
+ *
+ * Returns the inside of the block, without the outer braces.
+ */
+function readBlock(source, from) {
+  if (from < 0) {
+    return null;
+  }
+  const start = source.indexOf("{", from);
+  if (start === -1) {
+    return null;
+  }
+  let depth = 0;
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(start + 1, index);
+      }
+    }
+  }
+  return null;
+}
+
+/** `CONSTANT` to event name, out of the `ANALYTICS_EVENTS` object. */
+function parseEventNames(source) {
+  const block = readBlock(source, source.indexOf("ANALYTICS_EVENTS = "));
+  if (block === null) {
+    throw new Error("The catalogue has no ANALYTICS_EVENTS object");
+  }
+  const names = new Map();
+  for (const match of block.matchAll(/(\w+):\s*"([^"]*)"/g)) {
+    names.set(match[1], match[2]);
+  }
+  if (names.size === 0) {
+    throw new Error("The catalogue's ANALYTICS_EVENTS object is empty");
+  }
+  return names;
+}
+
+/**
+ * The keys of one object type literal, with whether each one is optional.
+ *
+ * Only depth one is read: a nested object is the shape of a value, not a
+ * property of the event, and counting `from` and `to` inside
+ * `Record<string, { from: unknown; to: unknown }>` as event properties would
+ * report two keys that never appear in PostHog.
+ */
+function parseObjectKeys(block) {
+  const keys = [];
+  let depth = 0;
+  let atEntryStart = true;
+  for (let index = 0; index < block.length; index += 1) {
+    const char = block[index];
+    if (char === "{" || char === "(" || char === "[") {
+      depth += 1;
+    } else if (char === "}" || char === ")" || char === "]") {
+      depth -= 1;
+    } else if (depth === 0 && (char === ";" || char === ",")) {
+      atEntryStart = true;
+    } else if (depth === 0 && atEntryStart && /\S/.test(char)) {
+      const match = /^(?<key>[A-Za-z_$][\w$]*)(?<optional>\?)?\s*:/.exec(
+        block.slice(index),
+      );
+      if (match) {
+        keys.push({
+          name: match.groups.key,
+          optional: Boolean(match.groups.optional),
+        });
+      }
+      atEntryStart = false;
+    }
+  }
+  return keys;
+}
+
+/** Object type aliases in the file, so `LandingAttribution & { ... }` resolves. */
+function parseTypeAliases(source) {
+  const aliases = new Map();
+  for (const match of source.matchAll(/type\s+(\w+)\s*=\s*\{/g)) {
+    const block = readBlock(source, match.index + match[0].length - 1);
+    if (block !== null) {
+      aliases.set(match[1], parseObjectKeys(block));
+    }
+  }
+  return aliases;
+}
+
+/**
+ * The keys of one event's property type.
+ *
+ * `undefined` means the event carries no properties of its own. An
+ * intersection is walked part by part so the keys an alias contributes count
+ * the same as the ones written inline.
+ */
+function parseValueKeys(value, aliases) {
+  const trimmed = value.trim();
+  if (trimmed === "undefined" || trimmed === "") {
+    return [];
+  }
+
+  const parts = [];
+  let depth = 0;
+  let current = "";
+  for (const char of trimmed) {
+    if (char === "{" || char === "(" || char === "<") {
+      depth += 1;
+    } else if (char === "}" || char === ")" || char === ">") {
+      depth -= 1;
+    }
+    if (char === "&" && depth === 0) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current);
+
+  const keys = new Map();
+  for (const part of parts) {
+    const piece = part.trim();
+    const contributed = piece.startsWith("{")
+      ? parseObjectKeys(readBlock(piece, 0) ?? "")
+      : (aliases.get(piece) ?? []);
+    for (const key of contributed) {
+      keys.set(key.name, key);
+    }
+  }
+  return [...keys.values()];
+}
+
+/** `[ANALYTICS_EVENTS.X]: <type>;` entries of one property map. */
+function parsePropertyMap(source, typeName, names, aliases) {
+  const block = readBlock(source, source.indexOf(`type ${typeName} = `));
+  if (block === null) {
+    throw new Error(`The catalogue has no ${typeName} map`);
+  }
+  const entries = new Map();
+  let index = 0;
+  while (index < block.length) {
+    const start = block.indexOf("[ANALYTICS_EVENTS.", index);
+    if (start === -1) {
+      break;
+    }
+    const constantEnd = block.indexOf("]", start);
+    const constant = block.slice(
+      start + "[ANALYTICS_EVENTS.".length,
+      constantEnd,
+    );
+    const colon = block.indexOf(":", constantEnd);
+    let depth = 0;
+    let end = colon + 1;
+    while (end < block.length) {
+      const char = block[end];
+      if (char === "{" || char === "(" || char === "<") {
+        depth += 1;
+      } else if (char === "}" || char === ")" || char === ">") {
+        depth -= 1;
+      } else if (char === ";" && depth === 0) {
+        break;
+      }
+      end += 1;
+    }
+    const name = names.get(constant);
+    if (name) {
+      entries.set(name, parseValueKeys(block.slice(colon + 1, end), aliases));
+    }
+    index = end + 1;
+  }
+  return entries;
+}
+
+/**
+ * The whole catalogue: one entry per event name, carrying the surfaces that
+ * send it and the property keys each surface types.
+ *
+ * An event sent from both the app and the API, which "Message Sent" is, gets
+ * one entry with both surfaces and the union of the two key lists. Such a key
+ * only stays required when every surface that sends the event requires it:
+ * `has_text` is required by the app and unknown to the API, so half the rows
+ * are supposed to be missing it and calling it required would report a fault
+ * that is not there.
+ */
+export function parseCatalogue(rawSource) {
+  const source = stripComments(rawSource);
+  const names = parseEventNames(source);
+  const aliases = parseTypeAliases(source);
+
+  const events = new Map();
+  for (const name of names.values()) {
+    events.set(name, { name, perSurface: [], surfaces: [] });
+  }
+
+  for (const { surface, type } of PROPERTY_MAPS) {
+    const map = parsePropertyMap(source, type, names, aliases);
+    for (const [name, keys] of map) {
+      const event = events.get(name);
+      event.surfaces.push(surface);
+      event.perSurface.push(keys);
+    }
+  }
+
+  return [...events.values()]
+    .map((event) => {
+      const seen = new Set(
+        event.perSurface.flatMap((keys) => keys.map((key) => key.name)),
+      );
+      const required = [...seen].filter((name) =>
+        event.perSurface.every((keys) =>
+          keys.some((key) => key.name === name && !key.optional),
+        ),
+      );
+      return {
+        name: event.name,
+        optionalKeys: [...seen]
+          .filter((name) => !required.includes(name))
+          .sort(),
+        requiredKeys: required.sort(),
+        surfaces: event.surfaces,
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/** The catalogue as it sits on disk right now. */
+export function loadCatalogue(path = CATALOGUE_PATH) {
+  return parseCatalogue(readFileSync(path, "utf8"));
+}

--- a/scripts/metrics/events-audit-catalogue.test.mjs
+++ b/scripts/metrics/events-audit-catalogue.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  loadCatalogue,
+  parseCatalogue,
+  stripComments,
+} from "./events-audit-catalogue.mjs";
+
+/**
+ * A miniature catalogue carrying every shape the real one uses: a plain
+ * object, an event with no properties, an intersection with a type alias, a
+ * nested object value, and one name sent from two surfaces.
+ */
+const FIXTURE = `
+/**
+ * A comment with a { brace } and a colon: in it.
+ */
+export const ANALYTICS_EVENTS = {
+  EMPTY_DECK_SHOWN: "Empty Deck Shown",
+  LANDING_VIEWED: "Landing Viewed",
+  MESSAGE_SENT: "Message Sent",
+  PAYWALL_VIEWED: "Paywall Viewed",
+  SAVE_PREFERENCES_PRESSED: "Save Preferences Pressed",
+  SWIPE: "Swipe",
+} as const;
+
+export type LandingAttribution = {
+  ref?: string;
+  utm_source?: string;
+};
+
+export type MobileEventProperties = {
+  [ANALYTICS_EVENTS.EMPTY_DECK_SHOWN]: undefined;
+  // A trailing note about the trigger: it matters.
+  [ANALYTICS_EVENTS.MESSAGE_SENT]: { has_text: boolean; match_id: string };
+  [ANALYTICS_EVENTS.PAYWALL_VIEWED]: { trigger: PaywallTrigger };
+  [ANALYTICS_EVENTS.SAVE_PREFERENCES_PRESSED]: {
+    changes: Record<string, { from: unknown; to: unknown }>;
+  };
+  [ANALYTICS_EVENTS.SWIPE]: {
+    dog_id: string;
+    source?: SwipeSource;
+    swipe_type: SwipeKind;
+  };
+};
+
+export type ServerEventProperties = {
+  [ANALYTICS_EVENTS.MESSAGE_SENT]: { match_id: string; message_type: "text" };
+};
+
+export type WebEventProperties = {
+  [ANALYTICS_EVENTS.LANDING_VIEWED]: LandingAttribution & { locale: string };
+};
+`;
+
+function find(catalogue, name) {
+  const event = catalogue.find((candidate) => candidate.name === name);
+  assert.ok(event, `${name} is not in the parsed catalogue`);
+  return event;
+}
+
+test("comments go, string contents stay", () => {
+  const stripped = stripComments(`const a = "keep // this"; // drop this`);
+  assert.equal(stripped.trim(), `const a = "keep // this";`);
+  assert.equal(
+    stripComments("a /* b { c: } */ d").replaceAll("\n", ""),
+    "a  d",
+  );
+});
+
+test("every catalogue name becomes an event", () => {
+  const catalogue = parseCatalogue(FIXTURE);
+  assert.deepEqual(
+    catalogue.map((event) => event.name),
+    [
+      "Empty Deck Shown",
+      "Landing Viewed",
+      "Message Sent",
+      "Paywall Viewed",
+      "Save Preferences Pressed",
+      "Swipe",
+    ],
+  );
+});
+
+test("optional keys are told apart from required ones", () => {
+  const catalogue = parseCatalogue(FIXTURE);
+  const swipe = find(catalogue, "Swipe");
+  assert.deepEqual(swipe.requiredKeys, ["dog_id", "swipe_type"]);
+  assert.deepEqual(swipe.optionalKeys, ["source"]);
+  assert.deepEqual(swipe.surfaces, ["mobile"]);
+});
+
+test("an event with no properties has no keys", () => {
+  const empty = find(parseCatalogue(FIXTURE), "Empty Deck Shown");
+  assert.deepEqual(empty.requiredKeys, []);
+  assert.deepEqual(empty.optionalKeys, []);
+});
+
+test("the keys of a nested value are not keys of the event", () => {
+  const preferences = find(parseCatalogue(FIXTURE), "Save Preferences Pressed");
+  assert.deepEqual(preferences.requiredKeys, ["changes"]);
+  assert.equal(preferences.optionalKeys.includes("from"), false);
+});
+
+test("an intersection picks up the keys of the alias it extends", () => {
+  const landing = find(parseCatalogue(FIXTURE), "Landing Viewed");
+  assert.deepEqual(landing.requiredKeys, ["locale"]);
+  assert.deepEqual(landing.optionalKeys, ["ref", "utm_source"]);
+  assert.deepEqual(landing.surfaces, ["web"]);
+});
+
+test("a key only one surface sends is not required of the other", () => {
+  const message = find(parseCatalogue(FIXTURE), "Message Sent");
+  assert.deepEqual(message.surfaces, ["mobile", "server"]);
+  assert.deepEqual(message.requiredKeys, ["match_id"]);
+  assert.deepEqual(message.optionalKeys, ["has_text", "message_type"]);
+});
+
+test("a catalogue without the events object is refused", () => {
+  assert.throws(
+    () => parseCatalogue('export const SOMETHING_ELSE = { A: "b" };'),
+    /no ANALYTICS_EVENTS object/,
+  );
+});
+
+test("the catalogue on disk parses, and the funnel events keep their shape", () => {
+  const catalogue = loadCatalogue();
+  assert.ok(catalogue.length > 40, "the real catalogue should not be tiny");
+
+  assert.deepEqual(find(catalogue, "Paywall Viewed").requiredKeys, ["trigger"]);
+  assert.deepEqual(find(catalogue, "Swipe").requiredKeys, [
+    "dog_id",
+    "source",
+    "swipe_type",
+  ]);
+  assert.deepEqual(find(catalogue, "New Match").requiredKeys, ["action"]);
+  assert.deepEqual(find(catalogue, "Empty Deck Shown").requiredKeys, []);
+  assert.deepEqual(find(catalogue, "Create Dog Profile").optionalKeys, [
+    "gender",
+    "name",
+  ]);
+  assert.deepEqual(find(catalogue, "Reengagement Push Sent").requiredKeys, [
+    "dedupe_key",
+    "kind",
+  ]);
+
+  for (const event of catalogue) {
+    assert.ok(
+      event.surfaces.length > 0,
+      `${event.name} is in ANALYTICS_EVENTS but in none of the property maps`,
+    );
+  }
+});

--- a/scripts/metrics/events-audit-queries.mjs
+++ b/scripts/metrics/events-audit-queries.mjs
@@ -1,0 +1,187 @@
+/**
+ * HogQL builders for the events audit.
+ *
+ * Three queries answer the whole readout: what came in, who sent it, and what
+ * the funnel events carried. Everything here is pure, so the query surface is
+ * checkable without a PostHog key, the same arrangement `queries.mjs` uses for
+ * the daily readout.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** How far back the audit looks. */
+export const AUDIT_WINDOW_DAYS = 7;
+
+/**
+ * The row cap every query states out loud.
+ *
+ * PostHog applies `LIMIT 100` to a HogQL query that does not bring its own,
+ * and a truncated answer here does not look like an error: it looks like an
+ * event with no properties. The first run of this audit reported `Swipe` as
+ * missing all three of its required keys for exactly that reason. High enough
+ * to never be reached by this project, and stated so the day it is reached is
+ * a number that stops moving rather than a silent cut.
+ */
+export const MAX_ROWS = 10_000;
+
+/**
+ * The `$lib` values that get a column of their own, in report order.
+ *
+ * Anything else lands in `other`, which is where a rogue integration or a
+ * proxy that rewrites `$lib` would show up rather than quietly joining the app.
+ */
+export const LIB_BUCKETS = ["posthog-react-native", "web", "posthog-node"];
+
+/** The libraries a person is behind, so app version only applies to those. */
+export const CLIENT_LIBS = ["posthog-react-native", "web"];
+
+/** The property posthog-react-native puts the build number on. */
+export const APP_VERSION_PROPERTY = "$app_version";
+
+/**
+ * The funnel events the audit checks property by property, and the other names
+ * each one has plausibly been sent under.
+ *
+ * The aliases exist because the brief cannot assume the catalogue name is the
+ * one in PostHog: an event renamed in code keeps sending the old name from
+ * every build already on a phone. A target resolves to its catalogue name when
+ * that name has volume, and to an alias only when it does not.
+ */
+export const FUNNEL_TARGETS = [
+  {
+    aliases: ["Paywall Shown", "Paywall Opened"],
+    name: "Paywall Viewed",
+  },
+  {
+    aliases: ["Swiped", "Card Swiped", "Dog Swiped", "Swipe Card"],
+    name: "Swipe",
+  },
+  { aliases: ["Match", "Match Created"], name: "New Match" },
+  { aliases: ["Dog Profile Created"], name: "Create Dog Profile" },
+  { aliases: ["Empty Deck"], name: "Empty Deck Shown" },
+  { aliases: ["Re-engagement Push Sent"], name: "Reengagement Push Sent" },
+];
+
+/**
+ * Quotes a value for a HogQL string literal, escaping backslashes and quotes
+ * in one pass so an escape cannot be escaped twice.
+ */
+export function quote(value) {
+  return `'${String(value).replaceAll(/(['\\])/g, String.raw`\$1`)}'`;
+}
+
+/** `2026-09-04 12:00:00`, the shape ClickHouse parses without a hint. */
+function clickhouseTime(date) {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+/** The single seven day window, half open so the boundary counts once. */
+export function buildAuditWindow(now) {
+  const end = new Date(now);
+  return { end, start: new Date(end.getTime() - AUDIT_WINDOW_DAYS * DAY_MS) };
+}
+
+function windowFilter(window) {
+  return [
+    `timestamp >= toDateTime(${quote(clickhouseTime(window.start))}, 'UTC')`,
+    `timestamp < toDateTime(${quote(clickhouseTime(window.end))}, 'UTC')`,
+  ].join("\n  AND ");
+}
+
+/**
+ * Every event name in the window with its per event totals.
+ *
+ * People are counted here rather than in the split query below because a
+ * person on two builds is one person: summing distinct counts across buckets
+ * would report more users than the project has.
+ *
+ * `anonymous_events` uses the shape of the distinct id. The app identifies with
+ * the user's cuid, and posthog-react-native's own device id is a uuid, so a row
+ * whose distinct id is a uuid is a row PostHog never saw a login for. It is a
+ * heuristic, and it is the only one available without reading person profiles
+ * for every row.
+ */
+export function buildEventTotalsQuery(window) {
+  const anonymous = `match(distinct_id, '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')`;
+  return [
+    "SELECT",
+    "  event,",
+    "  count() AS total,",
+    "  count(DISTINCT person_id) AS people,",
+    "  count(DISTINCT distinct_id) AS distinct_ids,",
+    `  countIf(${anonymous}) AS anonymous_events`,
+    "FROM events",
+    `WHERE ${windowFilter(window)}`,
+    "GROUP BY event",
+    "ORDER BY total DESC, event",
+    `LIMIT ${MAX_ROWS}`,
+  ].join("\n");
+}
+
+/**
+ * The same events split by the library that sent them and, for the app, by the
+ * build the phone was running.
+ *
+ * Counts only. See above for why the people column is not repeated here.
+ */
+export function buildEventSplitQuery(window) {
+  const lib = `ifNull(nullIf(toString(properties.$lib), ''), 'unknown')`;
+  const version = `ifNull(nullIf(toString(properties.${APP_VERSION_PROPERTY}), ''), 'unknown')`;
+  return [
+    "SELECT",
+    "  event,",
+    `  ${lib} AS lib,`,
+    `  ${version} AS app_version,`,
+    "  count() AS total",
+    "FROM events",
+    `WHERE ${windowFilter(window)}`,
+    "GROUP BY event, lib, app_version",
+    "ORDER BY event, lib, app_version",
+    `LIMIT ${MAX_ROWS}`,
+  ].join("\n");
+}
+
+/**
+ * One row per property key per funnel event, with how many events carried it.
+ *
+ * `JSONExtractKeys` is the only way to ask PostHog what keys an event actually
+ * has: dot access needs the key name up front, which is the thing being looked
+ * for. Divided by the event's total from {@link buildEventTotalsQuery}, the
+ * count is also the answer to "what share is missing this key", so the audit
+ * does not need a second query listing keys it already expects.
+ *
+ * A key sent with a null value counts as present, because that is what the
+ * payload says. The readout states this where it matters.
+ */
+export function buildPropertyKeysQuery(window, events) {
+  return [
+    "SELECT",
+    "  event,",
+    "  arrayJoin(JSONExtractKeys(properties)) AS key,",
+    "  count() AS total",
+    "FROM events",
+    `WHERE ${windowFilter(window)}`,
+    `  AND event IN (${events.map(quote).join(", ")})`,
+    "GROUP BY event, key",
+    "ORDER BY event, key",
+    `LIMIT ${MAX_ROWS}`,
+  ].join("\n");
+}
+
+/**
+ * Picks the name each funnel target is really sent under.
+ *
+ * The catalogue name wins whenever it has volume, so an alias can never take a
+ * live event's place; an alias is only reported when the catalogue name is
+ * silent and the alias is not.
+ */
+export function resolveFunnelEvents(seenEvents, targets = FUNNEL_TARGETS) {
+  const seen = new Set(seenEvents);
+  return targets.map((target) => {
+    if (seen.has(target.name)) {
+      return { name: target.name, target: target.name };
+    }
+    const alias = target.aliases.find((candidate) => seen.has(candidate));
+    return { name: alias ?? target.name, target: target.name };
+  });
+}

--- a/scripts/metrics/events-audit-queries.test.mjs
+++ b/scripts/metrics/events-audit-queries.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  AUDIT_WINDOW_DAYS,
+  CLIENT_LIBS,
+  FUNNEL_TARGETS,
+  LIB_BUCKETS,
+  MAX_ROWS,
+  buildAuditWindow,
+  buildEventSplitQuery,
+  buildEventTotalsQuery,
+  buildPropertyKeysQuery,
+  quote,
+  resolveFunnelEvents,
+} from "./events-audit-queries.mjs";
+
+const NOW = new Date("2026-09-04T12:00:00.000Z");
+
+test("the window is the seven days ending at now", () => {
+  const window = buildAuditWindow(NOW);
+  assert.equal(AUDIT_WINDOW_DAYS, 7);
+  assert.equal(window.end.toISOString(), "2026-09-04T12:00:00.000Z");
+  assert.equal(window.start.toISOString(), "2026-08-28T12:00:00.000Z");
+});
+
+test("quote escapes what would otherwise end the literal early", () => {
+  assert.equal(quote("Paywall Viewed"), "'Paywall Viewed'");
+  assert.equal(quote("it's"), String.raw`'it\'s'`);
+  assert.equal(quote(String.raw`back\slash`), String.raw`'back\\slash'`);
+});
+
+test("the totals query counts every event, not a list of them", () => {
+  const query = buildEventTotalsQuery(buildAuditWindow(NOW));
+  assert.match(query, /GROUP BY event/);
+  assert.equal(query.includes("event IN ("), false);
+  assert.match(query, /count\(DISTINCT person_id\) AS people/);
+  assert.match(query, /count\(DISTINCT distinct_id\) AS distinct_ids/);
+  assert.match(
+    query,
+    /timestamp >= toDateTime\('2026-08-28 12:00:00', 'UTC'\)/,
+  );
+  assert.match(query, /timestamp < toDateTime\('2026-09-04 12:00:00', 'UTC'\)/);
+});
+
+test("the totals query counts anonymous rows by the shape of the distinct id", () => {
+  const query = buildEventTotalsQuery(buildAuditWindow(NOW));
+  assert.match(query, /countIf\(match\(distinct_id, '\^\[0-9a-fA-F\]\{8\}/);
+  assert.match(query, /AS anonymous_events/);
+});
+
+test("the split query breaks down by library and app version at once", () => {
+  const query = buildEventSplitQuery(buildAuditWindow(NOW));
+  assert.match(query, /properties\.\$lib/);
+  assert.match(query, /properties\.\$app_version/);
+  assert.match(query, /GROUP BY event, lib, app_version/);
+  // Missing and empty collapse into one bucket rather than two.
+  assert.match(
+    query,
+    /ifNull\(nullIf\(toString\(properties\.\$lib\), ''\), 'unknown'\)/,
+  );
+});
+
+test("the property query asks PostHog which keys the payload had", () => {
+  const query = buildPropertyKeysQuery(buildAuditWindow(NOW), [
+    "Swipe",
+    "New Match",
+  ]);
+  assert.match(query, /arrayJoin\(JSONExtractKeys\(properties\)\) AS key/);
+  assert.match(query, /event IN \('Swipe', 'New Match'\)/);
+  assert.match(query, /GROUP BY event, key/);
+});
+
+test("the library buckets are the three SDKs, and node is never a client", () => {
+  assert.deepEqual(LIB_BUCKETS, [
+    "posthog-react-native",
+    "web",
+    "posthog-node",
+  ]);
+  assert.equal(CLIENT_LIBS.includes("posthog-node"), false);
+});
+
+test("the funnel covers the six events the audit is asked about", () => {
+  assert.deepEqual(FUNNEL_TARGETS.map((target) => target.name).sort(), [
+    "Create Dog Profile",
+    "Empty Deck Shown",
+    "New Match",
+    "Paywall Viewed",
+    "Reengagement Push Sent",
+    "Swipe",
+  ]);
+});
+
+test("the catalogue name wins whenever it has volume", () => {
+  const resolved = resolveFunnelEvents(["Swipe", "Swiped", "Paywall Viewed"]);
+  const swipe = resolved.find((entry) => entry.target === "Swipe");
+  assert.deepEqual(swipe, { name: "Swipe", target: "Swipe" });
+});
+
+test("an alias is used only when the catalogue name is silent", () => {
+  const resolved = resolveFunnelEvents(["Swiped", "Paywall Shown"]);
+  assert.deepEqual(
+    resolved.find((entry) => entry.target === "Swipe"),
+    { name: "Swiped", target: "Swipe" },
+  );
+  assert.deepEqual(
+    resolved.find((entry) => entry.target === "Paywall Viewed"),
+    { name: "Paywall Shown", target: "Paywall Viewed" },
+  );
+  // Nothing arrived for this one, so it keeps its catalogue name and reports
+  // zero rather than disappearing from the readout.
+  assert.deepEqual(
+    resolved.find((entry) => entry.target === "New Match"),
+    { name: "New Match", target: "New Match" },
+  );
+});
+
+test("every query states its own row limit", () => {
+  // PostHog caps an unbounded HogQL query at 100 rows, and a cut answer reads
+  // as an event with no properties rather than as an error.
+  const window = buildAuditWindow(NOW);
+  assert.ok(MAX_ROWS > 1000);
+  for (const query of [
+    buildEventTotalsQuery(window),
+    buildEventSplitQuery(window),
+    buildPropertyKeysQuery(window, ["Swipe"]),
+  ]) {
+    assert.match(query, new RegExp(`LIMIT ${MAX_ROWS}$`));
+  }
+});

--- a/scripts/metrics/events-audit-report.mjs
+++ b/scripts/metrics/events-audit-report.mjs
@@ -1,0 +1,431 @@
+/**
+ * The audit comment: findings, volume, catalogue coverage, property sanity.
+ *
+ * Pure, so the whole body can be checked against fixtures without a network.
+ * The hidden marker on the first line is what lets a rerun rewrite its own
+ * comment instead of leaving a second one on the tracking issue.
+ */
+
+import { LIB_BUCKETS } from "./events-audit-queries.mjs";
+
+export const COMMENT_MARKER = "<!-- pegada-events-audit -->";
+
+/** Longest table this readout will print before it starts counting the rest. */
+const MAX_TABLE_ROWS = 60;
+
+/** The bucket every `$lib` that is not one of the known three falls into. */
+const OTHER_LIB = "other";
+
+function number(value) {
+  return Number(value ?? 0).toLocaleString("en-US");
+}
+
+function utcStamp(date) {
+  return `${date.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
+
+function percent(part, whole) {
+  return whole === 0 ? "n/a" : `${((part / whole) * 100).toFixed(1)}%`;
+}
+
+/** A markdown table, or a plain line when there is nothing to put in it. */
+function table(headers, rows, empty) {
+  if (rows.length === 0) {
+    return empty;
+  }
+  const shown = rows.slice(0, MAX_TABLE_ROWS);
+  const lines = [
+    `| ${headers.join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...shown.map((row) => `| ${row.join(" | ")} |`),
+  ];
+  if (rows.length > shown.length) {
+    lines.push(
+      "",
+      `${number(rows.length - shown.length)} more rows not shown.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+/** Names in a sentence, as inline code, capped so a list cannot run away. */
+function nameList(names, limit = 12) {
+  const shown = names.slice(0, limit).map((name) => `\`${name}\``);
+  const rest = names.length - shown.length;
+  return rest > 0
+    ? `${shown.join(", ")} and ${number(rest)} more`
+    : shown.join(", ");
+}
+
+/** `1 event`, `3 events`, so a finding does not read like a template. */
+function plural(count, one, many) {
+  return `${number(count)} ${count === 1 ? one : many}`;
+}
+
+/** PostHog's own events, which nobody in this repo writes. */
+function isPosthogInternal(name) {
+  return name.startsWith("$");
+}
+
+/**
+ * Reshapes the three query results into one row per event.
+ *
+ * Everything downstream reads this, so a column added to a query cannot change
+ * what a section prints without passing through here first.
+ */
+export function summarise({
+  auditedEvents = [],
+  catalogue,
+  propertyKeys,
+  splits,
+  totals,
+}) {
+  const byName = new Map();
+  const catalogueByName = new Map(
+    catalogue.map((event) => [event.name, event]),
+  );
+  const audited = new Set(auditedEvents);
+
+  for (const row of totals) {
+    byName.set(row.event, {
+      anonymousEvents: Number(row.anonymous_events ?? 0),
+      catalogue: catalogueByName.get(row.event) ?? null,
+      distinctIds: Number(row.distinct_ids ?? 0),
+      keys: new Map(),
+      keysKnown: audited.has(row.event),
+      libs: new Map(),
+      name: row.event,
+      people: Number(row.people ?? 0),
+      total: Number(row.total ?? 0),
+      versions: new Map(),
+    });
+  }
+
+  for (const row of splits) {
+    const event = byName.get(row.event);
+    if (event) {
+      const bucket = LIB_BUCKETS.includes(row.lib) ? row.lib : OTHER_LIB;
+      const count = Number(row.total ?? 0);
+      event.libs.set(bucket, (event.libs.get(bucket) ?? 0) + count);
+      if (bucket === "posthog-react-native" || bucket === "web") {
+        const version = row.app_version ?? "unknown";
+        event.versions.set(version, (event.versions.get(version) ?? 0) + count);
+      }
+    }
+  }
+
+  for (const row of propertyKeys) {
+    const event = byName.get(row.event);
+    if (event) {
+      event.keys.set(row.key, Number(row.total ?? 0));
+    }
+  }
+
+  const seen = [...byName.values()].sort(
+    (left, right) =>
+      right.total - left.total || left.name.localeCompare(right.name),
+  );
+
+  return {
+    internal: seen.filter((event) => isPosthogInternal(event.name)),
+    seen,
+    unknown: seen.filter(
+      (event) => !event.catalogue && !isPosthogInternal(event.name),
+    ),
+    zeroVolume: catalogue
+      .filter((event) => !byName.has(event.name))
+      .map((event) => event.name),
+  };
+}
+
+/**
+ * The keys the catalogue requires that some of the events did not carry.
+ *
+ * One missing row is enough to list the key. The share is reported alongside
+ * it, so a handful of rows from an older build reads as the small number it is
+ * rather than being hidden by a threshold nobody set on purpose.
+ *
+ * Only events the property query covered can be judged. Without this an event
+ * nobody asked about reads as missing every key it has, because no keys were
+ * ever read back for it.
+ */
+function missingRequired(event) {
+  if (!event.keysKnown) {
+    return [];
+  }
+  const required = event.catalogue?.requiredKeys ?? [];
+  return required
+    .map((key) => {
+      const present = event.keys.get(key) ?? 0;
+      return { key, missing: event.total - present };
+    })
+    .filter((row) => row.missing > 0);
+}
+
+/**
+ * True when every row of the event carries a device id rather than a user id,
+ * on an event the catalogue says a person sends.
+ *
+ * Server events are excluded on purpose: the API captures against whoever the
+ * event is about, and that id is a user id by construction.
+ */
+function anonymousOnly(event) {
+  const surfaces = event.catalogue?.surfaces ?? [];
+  const expectsUser = surfaces.includes("mobile") || surfaces.includes("web");
+  return (
+    expectsUser && event.total > 0 && event.anonymousEvents === event.total
+  );
+}
+
+/** The Findings list, read off the summary rather than written by hand. */
+export function buildFindings(summary, funnelEvents) {
+  const findings = [];
+
+  if (summary.zeroVolume.length > 0) {
+    findings.push(
+      `${plural(summary.zeroVolume.length, "catalogue event has", "catalogue events have")} no volume: ${nameList(summary.zeroVolume)}.`,
+    );
+  }
+
+  if (summary.unknown.length > 0) {
+    findings.push(
+      `${plural(summary.unknown.length, "event name is", "event names are")} not in the catalogue: ${nameList(summary.unknown.map((event) => event.name))}.`,
+    );
+  }
+
+  for (const event of summary.seen) {
+    const missing = missingRequired(event);
+    if (missing.length > 0) {
+      findings.push(
+        `\`${event.name}\` is missing required properties: ${missing
+          .map(
+            (row) => `\`${row.key}\` on ${percent(row.missing, event.total)}`,
+          )
+          .join(", ")}.`,
+      );
+    }
+  }
+
+  for (const event of summary.seen) {
+    if (anonymousOnly(event)) {
+      findings.push(
+        `\`${event.name}\` arrived with anonymous distinct ids only, so ${number(event.total)} events cannot be tied to a signed in user.`,
+      );
+    }
+  }
+
+  for (const entry of funnelEvents) {
+    if (entry.name !== entry.target) {
+      findings.push(
+        `\`${entry.target}\` is sent as \`${entry.name}\`, so anything filtering on the catalogue name reads zero.`,
+      );
+    }
+  }
+
+  return findings.length > 0 ? findings : ["Nothing to flag in this window."];
+}
+
+/** What the catalogue says about an event, for the column of the same name. */
+function catalogueLabel(event) {
+  if (event.catalogue) {
+    return event.catalogue.surfaces.join(", ");
+  }
+  return isPosthogInternal(event.name) ? "autocapture" : "not in catalogue";
+}
+
+function volumeSection(summary) {
+  const rows = summary.seen.map((event) => [
+    `\`${event.name}\``,
+    catalogueLabel(event),
+    number(event.total),
+    number(event.people),
+    ...LIB_BUCKETS.map((lib) => number(event.libs.get(lib) ?? 0)),
+    number(event.libs.get(OTHER_LIB) ?? 0),
+  ]);
+  return [
+    "### 1. Every event seen",
+    "",
+    "People are counted per event, so the library columns, which are event counts, do not add up to them.",
+    "",
+    table(
+      ["Event", "Catalogue", "Events", "People", ...LIB_BUCKETS, OTHER_LIB],
+      rows,
+      "No events at all in the window.",
+    ),
+  ].join("\n");
+}
+
+function versionSection(summary) {
+  const rows = summary.seen.flatMap((event) =>
+    [...event.versions.entries()]
+      .sort(
+        (left, right) => right[1] - left[1] || left[0].localeCompare(right[0]),
+      )
+      .map(([version, count]) => [
+        `\`${event.name}\``,
+        `\`${version}\``,
+        number(count),
+      ]),
+  );
+  return [
+    "",
+    "Client events by app version. `unknown` is a browser or a build that predates the property.",
+    "",
+    table(
+      ["Event", "App version", "Events"],
+      rows,
+      "No client events in the window.",
+    ),
+  ].join("\n");
+}
+
+function coverageSection(summary) {
+  const unknownRows = summary.unknown.map((event) => [
+    `\`${event.name}\``,
+    number(event.total),
+    number(event.people),
+  ]);
+  const internalRows = summary.internal.map((event) => [
+    `\`${event.name}\``,
+    number(event.total),
+    number(event.people),
+  ]);
+  return [
+    "### 2. Catalogue coverage",
+    "",
+    `**Catalogue events with zero volume: ${number(summary.zeroVolume.length)}**`,
+    "",
+    summary.zeroVolume.length === 0
+      ? "Every catalogue event was sent at least once."
+      : summary.zeroVolume.map((name) => `- \`${name}\``).join("\n"),
+    "",
+    `**Seen but not in the catalogue: ${number(summary.unknown.length)}**`,
+    "",
+    table(
+      ["Event", "Events", "People"],
+      unknownRows,
+      "Nothing arrived under a name the catalogue does not have.",
+    ),
+    "",
+    `**PostHog's own events: ${number(summary.internal.length)}**`,
+    "",
+    "Autocapture and session events, listed apart because no code in this repo sends them.",
+    "",
+    table(
+      ["Event", "Events", "People"],
+      internalRows,
+      "No autocapture events in the window.",
+    ),
+  ].join("\n");
+}
+
+/**
+ * The keys the event carried, with PostHog's own counted rather than listed.
+ *
+ * Every event arrives stamped with forty odd `$` properties the SDK adds, and
+ * printing them all buries the handful the app actually sent, which are the
+ * only ones this audit can say anything about.
+ */
+function keysLine(ownKeys, stamped) {
+  if (ownKeys.length === 0 && stamped === 0) {
+    return "No property keys at all, which for an event PostHog stamps with `$lib` means nothing was read back for it.";
+  }
+  const tail =
+    stamped === 0
+      ? ""
+      : `, plus ${plural(stamped, "property", "properties")} PostHog adds itself`;
+  const own =
+    ownKeys.length === 0
+      ? "None of its own"
+      : ownKeys.map((key) => `\`${key}\``).join(", ");
+  return `Keys seen: ${own}${tail}.`;
+}
+
+function funnelEventSection(entry, summary) {
+  const event = summary.seen.find((candidate) => candidate.name === entry.name);
+  const heading =
+    entry.name === entry.target
+      ? `#### \`${entry.name}\``
+      : `#### \`${entry.target}\`, sent as \`${entry.name}\``;
+
+  if (!event) {
+    return [heading, "", "No events in the window."].join("\n");
+  }
+
+  const required = new Set(event.catalogue?.requiredKeys);
+  const keys = [...event.keys.keys()].sort();
+  const ownKeys = keys.filter((key) => !isPosthogInternal(key));
+  const stamped = keys.length - ownKeys.length;
+  const requiredRows = [...required].sort().map((key) => {
+    const present = event.keys.get(key) ?? 0;
+    return [`\`${key}\``, percent(event.total - present, event.total)];
+  });
+
+  const identity = anonymousOnly(event)
+    ? `Every one of the ${number(event.distinctIds)} distinct ids looks anonymous, and the catalogue has this event coming from a signed in user.`
+    : `${percent(event.anonymousEvents, event.total)} of events came from an anonymous distinct id, across ${number(event.distinctIds)} ids.`;
+
+  return [
+    heading,
+    "",
+    `${number(event.total)} events, ${number(event.people)} people.`,
+    "",
+    keysLine(ownKeys, stamped),
+    "",
+    table(
+      ["Required key", "Share of events missing it"],
+      requiredRows,
+      "The catalogue requires no properties on this event.",
+    ),
+    "",
+    identity,
+  ].join("\n");
+}
+
+function propertySection(summary, funnelEvents) {
+  return [
+    "### 3. Property sanity on the funnel events",
+    "",
+    "A key counts as present when it is in the payload, even when its value is null.",
+    "",
+    ...funnelEvents.map((entry) => `${funnelEventSection(entry, summary)}\n`),
+  ].join("\n");
+}
+
+/** The whole comment body. */
+export function buildReport({
+  catalogue,
+  funnelEvents,
+  generatedAt,
+  propertyKeys,
+  splits,
+  totals,
+  window,
+}) {
+  const summary = summarise({
+    auditedEvents: funnelEvents.map((entry) => entry.name),
+    catalogue,
+    propertyKeys,
+    splits,
+    totals,
+  });
+  const findings = buildFindings(summary, funnelEvents);
+
+  return [
+    COMMENT_MARKER,
+    "## Events audit",
+    "",
+    `Seven days, ${utcStamp(window.start)} to ${utcStamp(window.end)}. Catalogue: ${number(catalogue.length)} events. Generated ${utcStamp(generatedAt)}.`,
+    "",
+    "### Findings",
+    "",
+    findings.map((finding) => `- ${finding}`).join("\n"),
+    "",
+    volumeSection(summary),
+    versionSection(summary),
+    "",
+    coverageSection(summary),
+    "",
+    propertySection(summary, funnelEvents),
+  ].join("\n");
+}

--- a/scripts/metrics/events-audit-report.test.mjs
+++ b/scripts/metrics/events-audit-report.test.mjs
@@ -1,0 +1,408 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  COMMENT_MARKER,
+  buildFindings,
+  buildReport,
+  summarise,
+} from "./events-audit-report.mjs";
+
+const WINDOW = {
+  end: new Date("2026-09-04T12:00:00.000Z"),
+  start: new Date("2026-08-28T12:00:00.000Z"),
+};
+
+/**
+ * A catalogue small enough to read, holding one event of each kind the report
+ * has to treat differently: a client event with a required property, a server
+ * event, an event with no properties, and one nobody sent.
+ *
+ * Exported so the fixtures the tests assert on are the same ones the sample in
+ * the pull request was rendered from.
+ */
+export const CATALOGUE = [
+  {
+    name: "Create Dog Profile",
+    optionalKeys: ["gender", "name"],
+    requiredKeys: [],
+    surfaces: ["mobile"],
+  },
+  {
+    name: "Empty Deck Shown",
+    optionalKeys: [],
+    requiredKeys: [],
+    surfaces: ["mobile"],
+  },
+  {
+    name: "New Match",
+    optionalKeys: [],
+    requiredKeys: ["action"],
+    surfaces: ["mobile"],
+  },
+  {
+    name: "Paywall Viewed",
+    optionalKeys: [],
+    requiredKeys: ["trigger"],
+    surfaces: ["mobile"],
+  },
+  {
+    name: "Reengagement Push Sent",
+    optionalKeys: [],
+    requiredKeys: ["dedupe_key", "kind"],
+    surfaces: ["server"],
+  },
+  {
+    name: "Share Tapped",
+    optionalKeys: [],
+    requiredKeys: ["dog_id", "is_own_dog", "source"],
+    surfaces: ["mobile"],
+  },
+  {
+    name: "Swipe",
+    optionalKeys: [],
+    requiredKeys: ["dog_id", "source", "swipe_type"],
+    surfaces: ["mobile"],
+  },
+  {
+    name: "Upgrade",
+    optionalKeys: ["package", "trial"],
+    requiredKeys: ["type"],
+    surfaces: ["mobile"],
+  },
+];
+
+export const TOTALS = [
+  {
+    anonymous_events: 0,
+    distinct_ids: 11,
+    event: "Swipe",
+    people: 11,
+    total: 420,
+  },
+  {
+    anonymous_events: 0,
+    distinct_ids: 9,
+    event: "$screen",
+    people: 9,
+    total: 260,
+  },
+  {
+    anonymous_events: 0,
+    distinct_ids: 4,
+    event: "Reengagement Push Sent",
+    people: 4,
+    total: 80,
+  },
+  {
+    anonymous_events: 12,
+    distinct_ids: 3,
+    event: "Paywall Viewed",
+    people: 3,
+    total: 12,
+  },
+  {
+    anonymous_events: 0,
+    distinct_ids: 5,
+    event: "New Match",
+    people: 5,
+    total: 9,
+  },
+  {
+    anonymous_events: 0,
+    distinct_ids: 2,
+    event: "Empty Deck Shown",
+    people: 2,
+    total: 6,
+  },
+  {
+    anonymous_events: 0,
+    distinct_ids: 2,
+    event: "Dog Shared",
+    people: 2,
+    total: 4,
+  },
+];
+
+export const SPLITS = [
+  {
+    app_version: "1.7.2",
+    event: "Swipe",
+    lib: "posthog-react-native",
+    total: 380,
+  },
+  {
+    app_version: "1.6.2",
+    event: "Swipe",
+    lib: "posthog-react-native",
+    total: 40,
+  },
+  {
+    app_version: "1.7.2",
+    event: "$screen",
+    lib: "posthog-react-native",
+    total: 260,
+  },
+  {
+    app_version: "unknown",
+    event: "Reengagement Push Sent",
+    lib: "posthog-node",
+    total: 80,
+  },
+  {
+    app_version: "1.7.2",
+    event: "Paywall Viewed",
+    lib: "posthog-react-native",
+    total: 12,
+  },
+  {
+    app_version: "1.7.2",
+    event: "New Match",
+    lib: "posthog-react-native",
+    total: 9,
+  },
+  {
+    app_version: "1.7.2",
+    event: "Empty Deck Shown",
+    lib: "posthog-react-native",
+    total: 6,
+  },
+  { app_version: "unknown", event: "Dog Shared", lib: "web", total: 4 },
+];
+
+export const PROPERTY_KEYS = [
+  { event: "Swipe", key: "$lib", total: 420 },
+  { event: "Swipe", key: "dog_id", total: 420 },
+  { event: "Swipe", key: "source", total: 380 },
+  { event: "Swipe", key: "swipe_type", total: 420 },
+  { event: "New Match", key: "$lib", total: 9 },
+  { event: "New Match", key: "action", total: 9 },
+  { event: "Paywall Viewed", key: "$lib", total: 12 },
+  { event: "Paywall Viewed", key: "trigger", total: 12 },
+  { event: "Empty Deck Shown", key: "$lib", total: 6 },
+  { event: "Reengagement Push Sent", key: "dedupe_key", total: 80 },
+  { event: "Reengagement Push Sent", key: "kind", total: 80 },
+];
+
+export const FUNNEL_EVENTS = [
+  { name: "Paywall Viewed", target: "Paywall Viewed" },
+  { name: "Swipe", target: "Swipe" },
+  { name: "New Match", target: "New Match" },
+  { name: "Create Dog Profile", target: "Create Dog Profile" },
+  { name: "Empty Deck Shown", target: "Empty Deck Shown" },
+  { name: "Reengagement Push Sent", target: "Reengagement Push Sent" },
+];
+
+export const FIXTURE = {
+  catalogue: CATALOGUE,
+  funnelEvents: FUNNEL_EVENTS,
+  generatedAt: new Date("2026-09-04T12:03:00.000Z"),
+  propertyKeys: PROPERTY_KEYS,
+  splits: SPLITS,
+  totals: TOTALS,
+  window: WINDOW,
+};
+
+function summary() {
+  return summarise({
+    auditedEvents: FUNNEL_EVENTS.map((entry) => entry.name),
+    catalogue: CATALOGUE,
+    propertyKeys: PROPERTY_KEYS,
+    splits: SPLITS,
+    totals: TOTALS,
+  });
+}
+
+test("events are sorted by volume and matched to the catalogue", () => {
+  const result = summary();
+  assert.deepEqual(
+    result.seen.map((event) => event.name),
+    [
+      "Swipe",
+      "$screen",
+      "Reengagement Push Sent",
+      "Paywall Viewed",
+      "New Match",
+      "Empty Deck Shown",
+      "Dog Shared",
+    ],
+  );
+  assert.equal(result.seen[0].catalogue.name, "Swipe");
+});
+
+test("autocapture is kept apart from names the catalogue simply lacks", () => {
+  const result = summary();
+  assert.deepEqual(
+    result.internal.map((event) => event.name),
+    ["$screen"],
+  );
+  assert.deepEqual(
+    result.unknown.map((event) => event.name),
+    ["Dog Shared"],
+  );
+});
+
+test("catalogue events with no rows at all are listed", () => {
+  assert.deepEqual(summary().zeroVolume, [
+    "Create Dog Profile",
+    "Share Tapped",
+    "Upgrade",
+  ]);
+});
+
+test("library counts land in their own bucket and app versions add up", () => {
+  const swipe = summary().seen.find((event) => event.name === "Swipe");
+  assert.equal(swipe.libs.get("posthog-react-native"), 420);
+  assert.equal(swipe.libs.get("posthog-node") ?? 0, 0);
+  assert.equal(swipe.versions.get("1.7.2"), 380);
+  assert.equal(swipe.versions.get("1.6.2"), 40);
+});
+
+test("server events get no app version rows", () => {
+  const push = summary().seen.find(
+    (event) => event.name === "Reengagement Push Sent",
+  );
+  assert.equal(push.versions.size, 0);
+  assert.equal(push.libs.get("posthog-node"), 80);
+});
+
+test("findings name the zero volume events, the unknown ones and the gaps", () => {
+  const findings = buildFindings(summary(), FUNNEL_EVENTS);
+  assert.ok(
+    findings.some(
+      (line) =>
+        line.includes("3 catalogue events have no volume") &&
+        line.includes("`Share Tapped`"),
+    ),
+  );
+  assert.ok(
+    findings.some(
+      (line) =>
+        line.includes("1 event name is not in the catalogue") &&
+        line.includes("`Dog Shared`"),
+    ),
+  );
+  assert.ok(
+    findings.some(
+      (line) =>
+        line.includes("`Swipe` is missing required properties") &&
+        line.includes("`source` on 9.5%"),
+    ),
+  );
+});
+
+test("an event nobody signed in for is flagged, a server event is not", () => {
+  const findings = buildFindings(summary(), FUNNEL_EVENTS);
+  assert.ok(
+    findings.some((line) =>
+      line.includes(
+        "`Paywall Viewed` arrived with anonymous distinct ids only",
+      ),
+    ),
+  );
+  assert.equal(
+    findings.some((line) => line.includes("`Reengagement Push Sent` arrived")),
+    false,
+  );
+});
+
+test("a renamed funnel event is called out by both names", () => {
+  const findings = buildFindings(summary(), [
+    { name: "Swiped", target: "Swipe" },
+  ]);
+  assert.ok(
+    findings.some((line) => line.includes("`Swipe` is sent as `Swiped`")),
+  );
+});
+
+test("a clean window says so instead of printing an empty list", () => {
+  const findings = buildFindings(
+    {
+      internal: [],
+      seen: [],
+      unknown: [],
+      zeroVolume: [],
+    },
+    [],
+  );
+  assert.deepEqual(findings, ["Nothing to flag in this window."]);
+});
+
+test("the body carries the marker and all four sections", () => {
+  const body = buildReport(FIXTURE);
+  assert.ok(body.startsWith(COMMENT_MARKER));
+  assert.match(body, /## Events audit/);
+  assert.match(body, /### Findings/);
+  assert.match(body, /### 1\. Every event seen/);
+  assert.match(body, /### 2\. Catalogue coverage/);
+  assert.match(body, /### 3\. Property sanity on the funnel events/);
+  assert.match(
+    body,
+    /Seven days, 2026-08-28 12:00 UTC to 2026-09-04 12:00 UTC/,
+  );
+});
+
+test("the volume table splits every event by library", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(
+    body,
+    /\| Event \| Catalogue \| Events \| People \| posthog-react-native \| web \| posthog-node \| other \|/,
+  );
+  assert.match(
+    body,
+    /\| `Swipe` \| mobile \| 420 \| 11 \| 420 \| 0 \| 0 \| 0 \|/,
+  );
+  assert.match(
+    body,
+    /\| `Dog Shared` \| not in catalogue \| 4 \| 2 \| 0 \| 4 \| 0 \| 0 \|/,
+  );
+  assert.match(body, /\| `\$screen` \| autocapture \| 260 \| 9 \|/);
+  assert.match(body, /\| `Swipe` \| `1\.7\.2` \| 380 \|/);
+});
+
+test("the property section reports the share missing each required key", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(
+    body,
+    /Keys seen: `dog_id`, `source`, `swipe_type`, plus 1 property PostHog adds itself\./,
+  );
+  assert.match(body, /\| `source` \| 9\.5% \|/);
+  assert.match(body, /\| `trigger` \| 0\.0% \|/);
+});
+
+test("a funnel event with no rows says so rather than dividing by zero", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(body, /#### `Create Dog Profile`\n\nNo events in the window\./);
+  assert.equal(body.includes("NaN"), false);
+  assert.equal(body.includes("Infinity"), false);
+});
+
+test("an event the catalogue gives no required properties says that too", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(body, /The catalogue requires no properties on this event\./);
+});
+
+test("the body has no em dashes or en dashes", () => {
+  const body = buildReport(FIXTURE);
+  assert.equal(body.includes("—"), false);
+  assert.equal(body.includes("–"), false);
+});
+
+test("an event the property query never covered is not called incomplete", () => {
+  // `Share Tapped` has three required keys and no keys read back for it. Only
+  // the funnel events are queried, so silence about it is not evidence.
+  const findings = buildFindings(
+    summarise({
+      auditedEvents: [],
+      catalogue: CATALOGUE,
+      propertyKeys: [],
+      splits: SPLITS,
+      totals: TOTALS,
+    }),
+    [],
+  );
+  assert.equal(
+    findings.some((line) => line.includes("is missing required properties")),
+    false,
+  );
+});

--- a/scripts/metrics/events-audit.mjs
+++ b/scripts/metrics/events-audit.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * The events audit.
+ *
+ * Reads seven days out of PostHog, compares what arrived against the typed
+ * catalogue in `packages/shared/analytics/events.ts`, and rewrites one comment
+ * on the tracking issue with the result. Run it the way CI does:
+ *
+ *   POSTHOG_PERSONAL_API_KEY=phx_... POSTHOG_PROJECT_ID=66163 \
+ *     pnpm metrics:events-audit --dry-run
+ *
+ * `--dry-run` prints the body instead of posting it. Everything else fails
+ * loudly rather than publishing an audit built on a query that did not run: an
+ * audit that under reports is worse than no audit, because it reads as a clean
+ * bill of health.
+ */
+
+import { loadCatalogue } from "./events-audit-catalogue.mjs";
+import {
+  buildAuditWindow,
+  buildEventSplitQuery,
+  buildEventTotalsQuery,
+  buildPropertyKeysQuery,
+  resolveFunnelEvents,
+} from "./events-audit-queries.mjs";
+import { COMMENT_MARKER, buildReport } from "./events-audit-report.mjs";
+import { upsertMarkedComment } from "./github.mjs";
+import { queryHogql } from "./posthog.mjs";
+
+const DEFAULT_HOST = "https://us.posthog.com";
+const DEFAULT_ISSUE = "188";
+const DEFAULT_REPO = "GSTJ/pegada";
+
+function requireEnv(env, name) {
+  const value = env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is not set. The audit cannot run without it.`);
+  }
+  return value;
+}
+
+/**
+ * Runs the queries, renders the comment, and either posts it or returns it.
+ *
+ * Two round trips rather than one: the property query can only name the funnel
+ * events once the first pair has said which names PostHog actually holds, so a
+ * renamed event is audited under the name it is really sent under.
+ */
+export async function runEventsAudit({
+  argv = [],
+  catalogue = loadCatalogue(),
+  env = process.env,
+  fetchImpl = fetch,
+  now = new Date(),
+} = {}) {
+  const dryRun = argv.includes("--dry-run");
+  const apiKey = requireEnv(env, "POSTHOG_PERSONAL_API_KEY");
+  const projectId = requireEnv(env, "POSTHOG_PROJECT_ID");
+  const host = env.POSTHOG_HOST?.trim() || DEFAULT_HOST;
+  const repo = env.METRICS_REPO?.trim() || DEFAULT_REPO;
+  const issue = env.METRICS_ISSUE?.trim() || DEFAULT_ISSUE;
+
+  const window = buildAuditWindow(now);
+  const run = (name, query) =>
+    queryHogql({ apiKey, fetchImpl, host, name, projectId, query });
+
+  const [totals, splits] = await Promise.all([
+    run("pegada events audit: event totals", buildEventTotalsQuery(window)),
+    run("pegada events audit: event split", buildEventSplitQuery(window)),
+  ]);
+
+  const funnelEvents = resolveFunnelEvents(totals.map((row) => row.event));
+  const funnelNames = [...new Set(funnelEvents.map((entry) => entry.name))];
+  const propertyKeys = await run(
+    "pegada events audit: funnel property keys",
+    buildPropertyKeysQuery(window, funnelNames),
+  );
+
+  const body = buildReport({
+    catalogue,
+    funnelEvents,
+    generatedAt: now,
+    propertyKeys,
+    splits,
+    totals,
+    window,
+  });
+
+  if (dryRun) {
+    return { action: "printed", body };
+  }
+
+  const result = await upsertMarkedComment({
+    body,
+    fetchImpl,
+    issue,
+    marker: COMMENT_MARKER,
+    repo,
+    token: env.GITHUB_TOKEN?.trim(),
+  });
+  return { ...result, body };
+}
+
+if (process.argv[1] === import.meta.filename) {
+  try {
+    const result = await runEventsAudit({ argv: process.argv.slice(2) });
+    process.stdout.write(
+      result.action === "printed"
+        ? `${result.body}\n`
+        : `${result.action} the events audit comment: ${result.url}\n`,
+    );
+  } catch (error) {
+    process.stderr.write(`Events audit failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/metrics/events-audit.test.mjs
+++ b/scripts/metrics/events-audit.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { runEventsAudit } from "./events-audit.mjs";
+
+const NOW = new Date("2026-09-04T12:00:00.000Z");
+const ENV = {
+  GITHUB_TOKEN: "ghs_test",
+  POSTHOG_HOST: "https://us.posthog.com",
+  POSTHOG_PERSONAL_API_KEY: "phx_test",
+  POSTHOG_PROJECT_ID: "66163",
+};
+
+const CATALOGUE = [
+  {
+    name: "Paywall Viewed",
+    optionalKeys: [],
+    requiredKeys: ["trigger"],
+    surfaces: ["mobile"],
+  },
+  {
+    name: "Swipe",
+    optionalKeys: [],
+    requiredKeys: ["dog_id", "source", "swipe_type"],
+    surfaces: ["mobile"],
+  },
+];
+
+function json(payload) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(payload)),
+  });
+}
+
+/** True only for the PostHog host itself, never for a name that merely ends in it. */
+function isPostHog(url) {
+  return new URL(url).host === "us.posthog.com";
+}
+
+/**
+ * One fake standing in for both services, so the test covers the wiring
+ * between them: which name the property query is given is the whole point.
+ */
+function fakeWorld({ existingComment = null, swipeName = "Swipe" } = {}) {
+  const calls = [];
+  const impl = (url, init) => {
+    const body = init.body ? JSON.parse(init.body) : undefined;
+    calls.push({ body, method: init.method, url });
+
+    if (isPostHog(url)) {
+      if (body.name.endsWith("event totals")) {
+        return json({
+          columns: [
+            "event",
+            "total",
+            "people",
+            "distinct_ids",
+            "anonymous_events",
+          ],
+          results: [
+            [swipeName, 420, 11, 11, 0],
+            ["Paywall Viewed", 12, 3, 3, 12],
+          ],
+        });
+      }
+      if (body.name.endsWith("event split")) {
+        return json({
+          columns: ["event", "lib", "app_version", "total"],
+          results: [
+            [swipeName, "posthog-react-native", "1.7.2", 420],
+            ["Paywall Viewed", "posthog-react-native", "1.7.2", 12],
+          ],
+        });
+      }
+      return json({
+        columns: ["event", "key", "total"],
+        results: [
+          [swipeName, "dog_id", 420],
+          [swipeName, "source", 380],
+          [swipeName, "swipe_type", 420],
+          ["Paywall Viewed", "trigger", 12],
+        ],
+      });
+    }
+
+    if (init.method === "GET") {
+      return json(existingComment ? [existingComment] : []);
+    }
+    return json({
+      html_url: "https://github.com/GSTJ/pegada/issues/188#issuecomment-1",
+      id: 7,
+    });
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+test("a dry run prints the body and never touches GitHub", async () => {
+  const fetchImpl = fakeWorld();
+  const result = await runEventsAudit({
+    argv: ["--dry-run"],
+    catalogue: CATALOGUE,
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  assert.equal(result.action, "printed");
+  assert.match(result.body, /### 1\. Every event seen/);
+  assert.match(result.body, /`source` on 9\.5%/);
+  assert.equal(
+    fetchImpl.calls.some((call) => !isPostHog(call.url)),
+    false,
+  );
+});
+
+test("the property query only runs once the event names are known", async () => {
+  const fetchImpl = fakeWorld();
+  await runEventsAudit({
+    argv: ["--dry-run"],
+    catalogue: CATALOGUE,
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  const queries = fetchImpl.calls.map((call) => call.body.query.query);
+  assert.equal(queries.length, 3);
+  assert.match(queries[2], /arrayJoin\(JSONExtractKeys\(properties\)\)/);
+  assert.match(queries[2], /'Paywall Viewed'/);
+  assert.match(queries[2], /'Swipe'/);
+});
+
+test("a funnel event sent under another name is audited under that name", async () => {
+  const fetchImpl = fakeWorld({ swipeName: "Swiped" });
+  const result = await runEventsAudit({
+    argv: ["--dry-run"],
+    catalogue: CATALOGUE,
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  const propertyQuery = fetchImpl.calls[2].body.query.query;
+  assert.match(propertyQuery, /'Swiped'/);
+  assert.match(result.body, /`Swipe` is sent as `Swiped`/);
+  assert.match(result.body, /#### `Swipe`, sent as `Swiped`/);
+});
+
+test("the comment is created the first time and edited after that", async () => {
+  const created = await runEventsAudit({
+    catalogue: CATALOGUE,
+    env: ENV,
+    fetchImpl: fakeWorld(),
+    now: NOW,
+  });
+  assert.equal(created.action, "created");
+
+  const updated = await runEventsAudit({
+    catalogue: CATALOGUE,
+    env: ENV,
+    fetchImpl: fakeWorld({
+      existingComment: { body: "<!-- pegada-events-audit -->\nold", id: 7 },
+    }),
+    now: NOW,
+  });
+  assert.equal(updated.action, "updated");
+});
+
+test("a missing key stops the run instead of publishing an empty audit", async () => {
+  await assert.rejects(
+    runEventsAudit({
+      catalogue: CATALOGUE,
+      env: { ...ENV, POSTHOG_PERSONAL_API_KEY: "" },
+      fetchImpl: fakeWorld(),
+      now: NOW,
+    }),
+    /POSTHOG_PERSONAL_API_KEY is not set/,
+  );
+});


### PR DESCRIPTION
## Summary

Adds a second, on demand readout that checks the analytics tracking itself: what PostHog received over the last seven days, how it lines up with the typed event catalogue, and whether the funnel events carry the properties they are supposed to.

The daily readout answers how the product is doing. This one answers whether the numbers behind it can be trusted.

## Details

- New workflow, dispatch only, that posts or rewrites a single comment on the tracking issue under its own marker, so it never fights the daily readout for the same comment.
- Three queries cover the whole audit: every event name with its count and its distinct users, the same events split by which library sent them and by app version, and the property keys the funnel events actually carried.
- Section one lists every event seen, split across posthog-react-native, web, posthog-node and other, with a second table breaking the client events down by app version.
- Section two compares what arrived against the typed catalogue: catalogue events with no volume at all, names PostHog holds that the catalogue does not have, and PostHog's own autocapture events listed apart from both.
- Section three takes the six funnel events, lists the property keys each one carried, and reports the share of events missing every key the catalogue types as required. It also reports how much of the volume came from an anonymous device id, and flags an event whose ids are all anonymous when the catalogue expects a signed in user.
- A Findings list sits at the top, built from the data rather than written by hand, so the first screen names the zero volume events, the unknown names, the missing required properties and the identity gaps.
- The catalogue is parsed out of the shared analytics module as text rather than copied into a second list. A copy goes stale the first time somebody adds an event, and an audit working from a stale list reports new events as unknown.
- A funnel event that is really sent under an older name is audited under the name it is sent under, and the rename is reported as a finding. The catalogue name always wins when it has volume, so an alias can never displace a live event.
- Every query states its own row limit. PostHog caps an unbounded query at a hundred rows, and a cut answer does not look like an error: it looks like an event with no properties.
- Every new file is separate from the daily readout, which is being changed on another branch at the same time. The only shared line is the new script entry.
- The report rendering, the query builders and the catalogue parser are all covered by unit tests against fixtures, including the awkward catalogue shapes: an event with no properties, a nested value whose inner keys are not event properties, an intersection with a shared type, and one event name sent from two surfaces.
- Already run once against the live project, from a branch, to confirm the queries hold up against real data. The readout it produced is the comment on the tracking issue: https://github.com/GSTJ/pegada/issues/188#issuecomment-5546690046

## Testing steps

1. Open the repository's Actions tab and pick the events audit.
2. Run it with the dry run box ticked. The job log prints the whole readout and nothing is posted anywhere.
3. Read the Findings list at the top, then check that the three numbered sections below it are filled in: every event seen, the catalogue comparison, and the property tables for the six funnel events.
4. Run it again with the box unticked. A single comment appears on the tracking issue with the same content.
5. Run it a third time. The same comment is rewritten in place, and no second comment shows up.

## Screenshots

The readout below is rendered from the test fixtures, so the shape is exactly what the job posts.

<details>
<summary>Sample readout</summary>

````markdown
<!-- pegada-events-audit -->
## Events audit

Seven days, 2026-08-28 12:00 UTC to 2026-09-04 12:00 UTC. Catalogue: 8 events. Generated 2026-09-04 12:03 UTC.

### Findings

- 3 catalogue events have no volume: `Create Dog Profile`, `Share Tapped`, `Upgrade`.
- 1 event name is not in the catalogue: `Dog Shared`.
- `Swipe` is missing required properties: `source` on 9.5%.
- `Paywall Viewed` arrived with anonymous distinct ids only, so 12 events cannot be tied to a signed in user.

### 1. Every event seen

People are counted per event, so the library columns, which are event counts, do not add up to them.

| Event | Catalogue | Events | People | posthog-react-native | web | posthog-node | other |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `Swipe` | mobile | 420 | 11 | 420 | 0 | 0 | 0 |
| `$screen` | autocapture | 260 | 9 | 260 | 0 | 0 | 0 |
| `Reengagement Push Sent` | server | 80 | 4 | 0 | 0 | 80 | 0 |
| `Paywall Viewed` | mobile | 12 | 3 | 12 | 0 | 0 | 0 |
| `New Match` | mobile | 9 | 5 | 9 | 0 | 0 | 0 |
| `Empty Deck Shown` | mobile | 6 | 2 | 6 | 0 | 0 | 0 |
| `Dog Shared` | not in catalogue | 4 | 2 | 0 | 4 | 0 | 0 |

Client events by app version. `unknown` is a browser or a build that predates the property.

| Event | App version | Events |
| --- | --- | --- |
| `Swipe` | `1.7.2` | 380 |
| `Swipe` | `1.6.2` | 40 |
| `$screen` | `1.7.2` | 260 |
| `Paywall Viewed` | `1.7.2` | 12 |
| `New Match` | `1.7.2` | 9 |
| `Empty Deck Shown` | `1.7.2` | 6 |
| `Dog Shared` | `unknown` | 4 |

### 2. Catalogue coverage

**Catalogue events with zero volume: 3**

- `Create Dog Profile`
- `Share Tapped`
- `Upgrade`

**Seen but not in the catalogue: 1**

| Event | Events | People |
| --- | --- | --- |
| `Dog Shared` | 4 | 2 |

**PostHog's own events: 1**

Autocapture and session events, listed apart because no code in this repo sends them.

| Event | Events | People |
| --- | --- | --- |
| `$screen` | 260 | 9 |

### 3. Property sanity on the funnel events

A key counts as present when it is in the payload, even when its value is null.

#### `Paywall Viewed`

12 events, 3 people.

Keys seen: `trigger`, plus 1 property PostHog adds itself.

| Required key | Share of events missing it |
| --- | --- |
| `trigger` | 0.0% |

Every one of the 3 distinct ids looks anonymous, and the catalogue has this event coming from a signed in user.

#### `Swipe`

420 events, 11 people.

Keys seen: `dog_id`, `source`, `swipe_type`, plus 1 property PostHog adds itself.

| Required key | Share of events missing it |
| --- | --- |
| `dog_id` | 0.0% |
| `source` | 9.5% |
| `swipe_type` | 0.0% |

0.0% of events came from an anonymous distinct id, across 11 ids.

#### `New Match`

9 events, 5 people.

Keys seen: `action`, plus 1 property PostHog adds itself.

| Required key | Share of events missing it |
| --- | --- |
| `action` | 0.0% |

0.0% of events came from an anonymous distinct id, across 5 ids.

#### `Create Dog Profile`

No events in the window.

#### `Empty Deck Shown`

6 events, 2 people.

Keys seen: None of its own, plus 1 property PostHog adds itself.

The catalogue requires no properties on this event.

0.0% of events came from an anonymous distinct id, across 2 ids.

#### `Reengagement Push Sent`

80 events, 4 people.

Keys seen: `dedupe_key`, `kind`.

| Required key | Share of events missing it |
| --- | --- |
| `dedupe_key` | 0.0% |
| `kind` | 0.0% |

0.0% of events came from an anonymous distinct id, across 4 ids.
````

</details>
