### PR TITLE
fix(api): let the moderation mode alone decide whether photos are checked

### DIFF
--- a/packages/api/src/queue/handlers/process-image.test.ts
+++ b/packages/api/src/queue/handlers/process-image.test.ts
@@ -226,6 +226,37 @@ describe("handleProcessImage", () => {
     expect(push?.body).toBeTruthy();
   });
 
+  it.each(["shadow", "enforce"])(
+    "publishes the photo and counts the failure when moderation errors in %s",
+    async (mode) => {
+      moderateImage.mockResolvedValue({
+        status: "APPROVED",
+        result: { ...REJECTION, verdict: "error", reason: "provider_error" },
+        mode: mode as "shadow" | "enforce",
+      });
+
+      await expect(
+        handleProcessImage({ id: "image-id", url: `${BUCKET_URL}/dogs/6` }),
+      ).resolves.toBeDefined();
+
+      expect(updateImage).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "APPROVED" }),
+      );
+      // Without this the failure is invisible and a broken provider looks the
+      // same as a quiet week.
+      expect(captureEvent).toHaveBeenCalledWith(
+        "user-id",
+        "Image Moderation Result",
+        expect.objectContaining({
+          verdict: "error",
+          reason: "provider_error",
+          mode,
+        }),
+      );
+      expect(enqueuePushNotification).not.toHaveBeenCalled();
+    },
+  );
+
   it("skips the push when the owner has no device to send it to", async () => {
     moderateImage.mockResolvedValue({
       status: "REJECTED",

--- a/packages/api/src/services/flag-service.ts
+++ b/packages/api/src/services/flag-service.ts
@@ -17,7 +17,6 @@ const cachedIsFeatureEnabled = cacheFunctionResultFor(
 );
 
 export const FEATURES = {
-  PROFANITY_CHECK: "profanity_check",
   IMAGE_BLURHASH: "image_blurhash",
 } as const;
 

--- a/packages/api/src/services/image-moderation-service.test.ts
+++ b/packages/api/src/services/image-moderation-service.test.ts
@@ -205,6 +205,78 @@ describe("ImageModerationService.moderate", () => {
     expect(sendError).not.toHaveBeenCalled();
   });
 
+  it("fails open on a key that is set to an empty string", async () => {
+    config.GOOGLE_GENERATIVE_AI_API_KEY = "";
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "error",
+      reason: "missing_api_key",
+    });
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it("fails open when the provider refuses on quota", async () => {
+    generateText.mockRejectedValue(
+      Object.assign(new Error("429 RESOURCE_EXHAUSTED"), { statusCode: 429 }),
+    );
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "error",
+      reason: "provider_error",
+    });
+    expect(sendError).toHaveBeenCalled();
+  });
+
+  it("fails open when the model answers with prose instead of the object", async () => {
+    generateText.mockResolvedValue(answer("looks fine to me" as never));
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result).toMatchObject({
+      verdict: "error",
+      reason: "invalid_output",
+      score: null,
+    });
+    expect(sendError).toHaveBeenCalled();
+  });
+
+  it("fails open when the answer is missing half its fields", async () => {
+    generateText.mockResolvedValue(answer({ verdict: "reject" }));
+
+    const result = await ImageModerationService.moderate(photo);
+
+    // A half answer that mentions a rejection must not become one.
+    expect(result.verdict).toBe("error");
+    expect(result.reason).toBe("invalid_output");
+  });
+
+  it("fails open when the answer invents a verdict of its own", async () => {
+    generateText.mockResolvedValue(
+      answer({ ...APPROVAL, verdict: "maybe_reject" }),
+    );
+
+    const result = await ImageModerationService.moderate(photo);
+
+    expect(result.verdict).toBe("error");
+    expect(result.reason).toBe("invalid_output");
+  });
+
+  it("fails open when the upload is not a picture the resizer can read", async () => {
+    const notAPhoto = Buffer.from("this is not an image");
+
+    const result = await ImageModerationService.moderate(notAPhoto);
+
+    expect(result).toMatchObject({
+      verdict: "error",
+      reason: "provider_error",
+    });
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
   it("fails open on a model string no provider claims", async () => {
     config.IMAGE_MODERATION_MODEL = "anthropic/claude";
 

--- a/packages/api/src/services/image-moderation-service.ts
+++ b/packages/api/src/services/image-moderation-service.ts
@@ -248,14 +248,29 @@ export class ImageModerationService {
         abortSignal: AbortSignal.timeout(TIMEOUT_MS),
       });
 
+      // The SDK is asked for a typed object, but a model can still answer with
+      // prose or half a field, and the types here say otherwise. Re-checking the
+      // shape turns that into the `error` verdict the readout can count instead
+      // of a result with an empty verdict in it.
+      const answer = moderationSchema.safeParse(result.output);
+      if (!answer.success) {
+        sendError(
+          new Error("Image moderation answer did not match the schema"),
+          {
+            image_moderation_model: setting,
+          },
+        );
+        return failure("invalid_output");
+      }
+
       const inputTokens = finiteOrNull(result.usage?.inputTokens);
       const outputTokens = finiteOrNull(result.usage?.outputTokens);
 
       return {
-        verdict: result.output.verdict,
-        score: result.output.score,
-        reason: result.output.reason,
-        containsDog: result.output.containsDog,
+        verdict: answer.data.verdict,
+        score: answer.data.score,
+        reason: answer.data.reason,
+        containsDog: answer.data.containsDog,
         model: setting,
         latencyMs: Date.now() - startedAt,
         costUsdEstimate: estimateCostUsd({

--- a/packages/api/src/services/image-processing-service.test.ts
+++ b/packages/api/src/services/image-processing-service.test.ts
@@ -1,19 +1,28 @@
 /**
- * The gate in front of the provider. Two switches have to agree before a photo
- * costs anything, and only one of the three modes is allowed to reject, so
- * these are the cases that decide whether a rollout is reversible.
+ * The gate in front of the provider. The mode is the whole gate: it decides
+ * whether a photo costs anything and it is the only thing allowed to reject,
+ * so these are the cases that decide whether a rollout is reversible.
  */
-const config = { IMAGE_MODERATION_MODE: "off" as string };
+const config = {
+  IMAGE_MODERATION_MODE: "off" as string,
+  IMAGE_MODERATION_MODEL: "google/gemini-2.5-flash-lite",
+};
 
 jest.mock("../shared/config", () => ({
   config,
   isMagicEmail: () => false,
 }));
 
+const sendError = jest.fn();
+jest.mock("../errors/errors", () => ({
+  sendError: (...args: unknown[]) => sendError(...args),
+  logDebug: () => undefined,
+  errorDebug: () => undefined,
+}));
+
 const isFeatureEnabled = jest.fn();
 jest.mock("./flag-service", () => ({
   FEATURES: {
-    PROFANITY_CHECK: "profanity_check",
     IMAGE_BLURHASH: "image_blurhash",
   },
   FlagService: {
@@ -54,13 +63,14 @@ const verdict = (value: "approve" | "error" | "reject") => ({
 });
 
 beforeEach(() => {
+  sendError.mockClear();
   isFeatureEnabled.mockResolvedValue(true);
   moderate.mockResolvedValue(verdict("approve"));
   getStoredModerationVerdict.mockResolvedValue({ moderationVerdict: null });
 });
 
 describe("ImageProcessingService.moderateImage", () => {
-  it("calls nobody while the mode is off, whatever the flag says", async () => {
+  it("calls nobody while the mode is off", async () => {
     config.IMAGE_MODERATION_MODE = "off";
 
     const outcome = await ImageProcessingService.moderateImage({
@@ -70,11 +80,10 @@ describe("ImageProcessingService.moderateImage", () => {
 
     expect(outcome).toEqual({ status: "APPROVED", result: null, mode: "off" });
     expect(moderate).not.toHaveBeenCalled();
-    expect(isFeatureEnabled).not.toHaveBeenCalled();
   });
 
-  it("calls nobody while the flag is off, whatever the mode says", async () => {
-    config.IMAGE_MODERATION_MODE = "enforce";
+  it("moderates on the mode alone, with no flag left to consult", async () => {
+    config.IMAGE_MODERATION_MODE = "shadow";
     isFeatureEnabled.mockResolvedValue(false);
 
     const outcome = await ImageProcessingService.moderateImage({
@@ -82,23 +91,26 @@ describe("ImageProcessingService.moderateImage", () => {
       imageId,
     });
 
-    expect(outcome).toEqual({
-      status: "APPROVED",
-      result: null,
-      mode: "enforce",
-    });
-    expect(moderate).not.toHaveBeenCalled();
+    // A disabled flag used to swallow every call here, which is why shadow ran
+    // in production for a week without producing a single verdict.
+    expect(isFeatureEnabled).not.toHaveBeenCalled();
+    expect(moderate).toHaveBeenCalledWith(arrayBuffer);
+    expect(outcome.result?.verdict).toBe("approve");
   });
 
-  it("defaults the flag to off, so an unreachable PostHog spends nothing", async () => {
+  it("records an approval in shadow without touching the status", async () => {
     config.IMAGE_MODERATION_MODE = "shadow";
 
-    await ImageProcessingService.moderateImage({ arrayBuffer, imageId });
-
-    expect(isFeatureEnabled).toHaveBeenCalledWith({
-      feature: "profanity_check",
-      defaultValue: false,
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
     });
+
+    expect(outcome.status).toBe("APPROVED");
+    // A non null result is what makes the handler emit the verdict event, so
+    // shadow reports as loudly as enforce does.
+    expect(outcome.result).toMatchObject({ verdict: "approve" });
+    expect(outcome.mode).toBe("shadow");
   });
 
   it("keeps a rejection out of the status in shadow, but keeps the verdict", async () => {
@@ -128,9 +140,57 @@ describe("ImageProcessingService.moderateImage", () => {
     expect(outcome.result?.verdict).toBe("reject");
   });
 
-  it("publishes on a provider error even in enforce", async () => {
+  // Every way the provider can let us down arrives here as the same `error`
+  // verdict, so the property worth pinning is that none of them, in either
+  // mode that calls anyone, can hold a photo back.
+  it.each(["shadow", "enforce"])(
+    "publishes the photo on a provider failure in %s",
+    async (mode) => {
+      config.IMAGE_MODERATION_MODE = mode;
+      moderate.mockResolvedValue({
+        ...verdict("error"),
+        reason: "provider_error",
+      });
+
+      const outcome = await ImageProcessingService.moderateImage({
+        arrayBuffer,
+        imageId,
+      });
+
+      expect(outcome.status).toBe("APPROVED");
+      // The failure still travels back as a result, which is what puts it in
+      // the readout rather than leaving the week looking quiet.
+      expect(outcome.result).toMatchObject({
+        verdict: "error",
+        reason: "provider_error",
+      });
+      expect(outcome.mode).toBe(mode);
+    },
+  );
+
+  it.each(["shadow", "enforce"])(
+    "publishes the photo when the call itself blows up in %s",
+    async (mode) => {
+      config.IMAGE_MODERATION_MODE = mode;
+      moderate.mockRejectedValue(new Error("socket hang up"));
+
+      const outcome = await ImageProcessingService.moderateImage({
+        arrayBuffer,
+        imageId,
+      });
+
+      expect(outcome.status).toBe("APPROVED");
+      expect(outcome.result).toMatchObject({
+        verdict: "error",
+        reason: "unexpected_error",
+      });
+      expect(sendError).toHaveBeenCalled();
+    },
+  );
+
+  it("publishes the photo when the stored verdict lookup fails", async () => {
     config.IMAGE_MODERATION_MODE = "enforce";
-    moderate.mockResolvedValue(verdict("error"));
+    getStoredModerationVerdict.mockRejectedValue(new Error("database is away"));
 
     const outcome = await ImageProcessingService.moderateImage({
       arrayBuffer,
@@ -139,6 +199,7 @@ describe("ImageProcessingService.moderateImage", () => {
 
     expect(outcome.status).toBe("APPROVED");
     expect(outcome.result?.verdict).toBe("error");
+    expect(moderate).not.toHaveBeenCalled();
   });
 
   it("publishes an approval in enforce", async () => {

--- a/packages/api/src/services/image-processing-service.ts
+++ b/packages/api/src/services/image-processing-service.ts
@@ -6,6 +6,7 @@ import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
 import { encode as encodeBlurhash } from "blurhash";
 import sharp from "sharp";
 
+import { sendError } from "../errors/errors";
 import { config } from "../shared/config";
 import { FEATURES, FlagService } from "./flag-service";
 import { ImageModerationService } from "./image-moderation-service";
@@ -34,11 +35,11 @@ export class ImageProcessingService {
   /**
    * Decide whether a freshly uploaded photo can be published.
    *
-   * Two independent switches have to agree before a provider is called: the
-   * `IMAGE_MODERATION_MODE` environment variable, which is a deploy-time
-   * decision about how far the feature is turned up, and the `profanity_check`
-   * PostHog flag, which is the runtime kill switch. Either one off means no
-   * call, no cost, and the same APPROVED the old path produced.
+   * `IMAGE_MODERATION_MODE` is the only switch. `off` calls nobody and costs
+   * nothing, `shadow` buys a verdict and records it without letting it change
+   * the status, and `enforce` is the one mode allowed to reject. Turning the
+   * feature down is a change of that variable, which is also the level the
+   * cost lives at.
    *
    * An `error` verdict approves in every mode: a provider outage must not be
    * able to hold back everyone's photos at once.
@@ -59,13 +60,49 @@ export class ImageProcessingService {
 
     if (mode === "off") return skipped;
 
-    const isModerationEnabled = await FlagService.isFeatureEnabled({
-      feature: FEATURES.PROFANITY_CHECK,
-      defaultValue: false,
-    });
+    const startedAt = Date.now();
 
-    if (!isModerationEnabled) return skipped;
+    try {
+      return await ImageProcessingService.runModeration({
+        arrayBuffer,
+        imageId,
+        mode,
+      });
+    } catch (error) {
+      // The moderation service is written never to throw, so anything landing
+      // here came from below it, such as the verdict lookup losing the
+      // database. Publishing is still the right answer, and reporting it as an
+      // `error` verdict keeps the failure in the same chart as every other one
+      // instead of dropping it.
+      sendError(error, { image_id: imageId });
 
+      return {
+        status: IMAGE_STATUS.APPROVED,
+        result: {
+          verdict: "error",
+          score: null,
+          reason: "unexpected_error",
+          containsDog: null,
+          model: config.IMAGE_MODERATION_MODEL,
+          latencyMs: Date.now() - startedAt,
+          costUsdEstimate: null,
+          inputTokens: null,
+          outputTokens: null,
+        },
+        mode,
+      };
+    }
+  };
+
+  private static runModeration = async ({
+    arrayBuffer,
+    imageId,
+    mode,
+  }: {
+    arrayBuffer: ArrayBuffer;
+    imageId: string;
+    mode: ImageModerationMode;
+  }): Promise<ImageModerationOutcome> => {
     // The queue delivers at least once, and the job can also be retried after
     // the write that follows this call fails. A row that already carries a
     // verdict has already been paid for, so the redelivery re-derives the


### PR DESCRIPTION
## Summary

Photo moderation never ran in production because a leftover PostHog flag sat in front of it. `IMAGE_MODERATION_MODE` is now the only switch, and a moderation failure can no longer hold a photo back.

## Details

- `moderateImage` asked for the `profanity_check` PostHog flag on top of the mode, and that flag has been off since the old on device check was removed. Production has been set to shadow all along and produced zero verdicts, including for the 14 profiles created this week.
- The flag check is gone. `off` calls nobody and costs nothing, `shadow` buys a verdict and records it without letting it change the status, `enforce` is the only mode that can reject. `profanity_check` had no other reader, so the constant and its mapping were deleted.
- Production already has `IMAGE_MODERATION_MODE=shadow`, so after deploy the `Image Moderation Result` event starts flowing at roughly US$0.04 per 1000 photos. The readout on issue #188 shows the verdict split.
- A failure of the moderation service never blocks a photo. A missing or empty key, a provider error, a quota refusal, a timeout, an answer that does not match the expected shape, and an unexpected exception all end with the photo approved, in shadow and in enforce alike.
- Each of those failures is now reported as an `error` verdict instead of disappearing, so a broken provider shows up in the same readout rather than looking like a quiet week.
- An answer that was not the object we asked for used to pass through with an empty verdict. It is now checked against the schema and counted as a failure.
- Tests cover the three modes, the removed gate, and every failure path in both modes that call a provider.

## Testing steps

1. Upload a photo to a dog profile as usual.
2. The photo appears in the profile grid as it always did.
3. In the analytics dashboard, a moderation result is now recorded for that photo with the verdict the model gave.
4. If the moderation provider is unavailable, the photo still appears and the failure is recorded as an error result.

## Screenshots

Not applicable
