### PR TITLE
feat(api): back off reengagement pushes progressively per user

### DIFF
--- a/packages/api/src/services/reengagement-cadence.ts
+++ b/packages/api/src/services/reengagement-cadence.ts
@@ -1,0 +1,258 @@
+import type { ReengagementSuppressionReason } from "@pegada/shared/analytics/events";
+
+import prisma from "@pegada/database";
+import { Prisma } from "@prisma/client";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The whole cadence, in one block.
+ *
+ * The numbers come from what the rules they replace actually did: 800 pushes
+ * to 529 users in seven days, so a person could collect four or five nudges in
+ * a week off three kinds that each believed they were being restrained. Pegada
+ * is used weekly rather than daily, so the floor is a week and the ceiling is a
+ * month, and how often someone hears from us is driven by whether the last
+ * push worked rather than by how long they have been gone.
+ *
+ * A push worked when the person came back after it. `Push Notification Opened`
+ * is the honest signal and is what this should read once the build that reports
+ * it is in the store; until then `User.lastActiveAt` moving to after the send
+ * is the proxy. It is a conservative proxy: it credits the push with a return
+ * it may have had nothing to do with, and every one of those errs towards
+ * nudging less.
+ */
+
+/** How long someone has to have been gone before the first nudge. */
+const FIRST_PUSH_AFTER_INACTIVE_DAYS = 5;
+
+/**
+ * The wait after a push nobody answered, by how many have gone unanswered.
+ *
+ * The third rung is here for the shape rather than because it is reached: the
+ * long pause below trips first. It stays so that raising
+ * {@link UNANSWERED_PUSHES_BEFORE_PAUSE} has a value to use rather than
+ * silently falling back to six months.
+ */
+const UNANSWERED_GAP_DAYS = [10, 20, 40] as const;
+
+/** Unanswered pushes that end the schedule and start the long pause. */
+const UNANSWERED_PUSHES_BEFORE_PAUSE = 3;
+
+/**
+ * The pause once the schedule runs out, and again after every unanswered push
+ * that follows it.
+ *
+ * Six months. Somebody who has ignored three nudges hears from the app twice a
+ * year at most, which is the line between a product that is still there and one
+ * that is pestering. "Seis meses, um ano" was the ask and this is the floor of
+ * that range.
+ */
+const LONG_PAUSE_DAYS = 180;
+
+/** Hard floor between two pushes, whatever the schedule works out to. */
+export const MIN_GAP_DAYS = 7;
+
+/** Rolling ceiling, whatever the schedule works out to. */
+const MONTHLY_WINDOW_DAYS = 30;
+const MAX_PUSHES_PER_MONTH = 2;
+
+/**
+ * Slack on the scheduled gaps so a gap counted in whole days still lands inside
+ * the two hour evening slot.
+ *
+ * A push stamped at 19:03 is three minutes short of ten days old at 19:00 ten
+ * days later, so without this the nudge slips a day at every rung and the
+ * schedule walks away from itself. The two hard caps are deliberately left
+ * exact: they are ceilings rather than appointments, so nothing is owed to
+ * them.
+ */
+const SLOT_SLACK_HOURS = 2;
+
+/** Expo's code for a token that no longer belongs to an install. */
+const DEAD_TOKEN_ERROR = "DeviceNotRegistered";
+
+/**
+ * When a suppression is worth an event.
+ *
+ * The cron runs hourly and a held back user is held back at every one of those
+ * runs, so emitting on each would count passes over a person rather than
+ * people. A cadence decision is reported at the close of the send window, when
+ * the day's answer is final; a missed window at the hour after it, which is the
+ * first moment "the slot came and went" is a fact rather than a guess.
+ */
+export const POLICY_REPORT_HOUR = 19;
+export const WINDOW_REPORT_HOUR = 20;
+
+/**
+ * Everything the cadence needs to know about one user, none of it stored.
+ *
+ * `NotificationLog` plus `User.lastActiveAt` already say all of it, so there is
+ * no counter to keep in sync and no column that can drift away from the rows it
+ * summarises. A backfill is not needed either: the history is the history.
+ */
+export type CadenceFacts = {
+  userId: string;
+  lastActiveAt: Date | null;
+  /**
+   * Pushes sent since the user was last seen, which is the same thing as
+   * pushes in a row that did not bring them back. Zero the moment they return,
+   * whether they returned because of a push or on their own.
+   */
+  unanswered: number;
+  /** Pushes inside the rolling monthly window. */
+  monthly: number;
+  lastPushAt: Date | null;
+  lastTicketError: string | null;
+  lastReceiptError: string | null;
+};
+
+/**
+ * The three facts per user in one round trip.
+ *
+ * Lateral subqueries rather than three reads: the row count is bounded by the
+ * candidate limit, and each of them is a lookup on an index `NotificationLog`
+ * already carries. `unanswered` deliberately has no time floor. Somebody who
+ * was given up on eight months ago and never came back has to still read as
+ * given up on, and a window would quietly forget them and start the schedule
+ * over.
+ *
+ * Every row in `NotificationLog` is a scheduled nudge today, which is why no
+ * kind is filtered out: the cadence is one budget for the whole cron. The day a
+ * transactional push starts logging here, this is the query that has to learn
+ * the difference, or a single "you have a new message" will mute the win-back
+ * schedule for a week.
+ */
+export const readCadence = async (
+  userIds: string[],
+  now: Date,
+): Promise<Map<string, CadenceFacts>> => {
+  const monthlyFloor = new Date(now.getTime() - MONTHLY_WINDOW_DAYS * DAY_MS);
+
+  const rows = await prisma.$queryRaw<CadenceFacts[]>`
+    SELECT
+      "User"."id" AS "userId",
+      "User"."lastActiveAt" AS "lastActiveAt",
+      "unanswered"."count"::int AS "unanswered",
+      "monthly"."count"::int AS "monthly",
+      "last"."sentAt" AS "lastPushAt",
+      "last"."ticketError" AS "lastTicketError",
+      "last"."receiptError" AS "lastReceiptError"
+    FROM "User"
+    CROSS JOIN LATERAL (
+      SELECT COUNT(*) AS "count"
+      FROM "NotificationLog"
+      WHERE "NotificationLog"."userId" = "User"."id"
+      /* A null lastActiveAt is unknown rather than active, so every push
+         counts. It is the same reading the selectors take. */
+      AND (
+        "User"."lastActiveAt" IS NULL
+        OR "NotificationLog"."sentAt" > "User"."lastActiveAt"
+      )
+    ) AS "unanswered"
+    CROSS JOIN LATERAL (
+      SELECT COUNT(*) AS "count"
+      FROM "NotificationLog"
+      WHERE "NotificationLog"."userId" = "User"."id"
+      AND "NotificationLog"."sentAt" > ${monthlyFloor}
+    ) AS "monthly"
+    LEFT JOIN LATERAL (
+      SELECT "sentAt", "ticketError", "receiptError"
+      FROM "NotificationLog"
+      WHERE "NotificationLog"."userId" = "User"."id"
+      ORDER BY "sentAt" DESC
+      LIMIT 1
+    ) AS "last" ON true
+    WHERE "User"."id" IN (${Prisma.join(userIds)})
+  `;
+
+  return new Map(rows.map((row) => [row.userId, row]));
+};
+
+/** Every reason except the send window, which is not a cadence decision. */
+type PolicyReason = Exclude<ReengagementSuppressionReason, "window">;
+
+const daysBetween = (from: Date, to: Date) =>
+  (to.getTime() - from.getTime()) / DAY_MS;
+
+/**
+ * The gap owed after an unanswered push, in days.
+ *
+ * Reads as the schedule it implements: 10 days after the first unanswered
+ * push, 20 after the second, and then the app stops asking for half a year at
+ * a time. Anything past the pause threshold stays on the pause, so a nudge
+ * sent at the end of one six month wait that also goes unanswered buys another.
+ */
+const gapAfterUnanswered = (unanswered: number) =>
+  unanswered >= UNANSWERED_PUSHES_BEFORE_PAUSE
+    ? LONG_PAUSE_DAYS
+    : (UNANSWERED_GAP_DAYS[unanswered - 1] ?? LONG_PAUSE_DAYS);
+
+/**
+ * May this user be interrupted today?
+ *
+ * The order is the order the reasons are worth knowing in. A dead token is a
+ * fact about the device and outranks anything about timing; the two hard caps
+ * come next because they hold whatever the schedule says; the schedule itself
+ * is last, and it is the only part that depends on whether the last push
+ * worked.
+ */
+export const cadenceDecision = (
+  facts: CadenceFacts,
+  now: Date,
+): { allowed: true } | { allowed: false; reason: PolicyReason } => {
+  const { lastActiveAt, lastPushAt, monthly, unanswered } = facts;
+
+  const awayLongEnough =
+    lastActiveAt === null ||
+    daysBetween(lastActiveAt, now) >= FIRST_PUSH_AFTER_INACTIVE_DAYS;
+
+  if (lastPushAt === null) {
+    // Nobody has ever nudged this person, so the only question is how long
+    // they have been gone.
+    return awayLongEnough
+      ? { allowed: true }
+      : { allowed: false, reason: "cooldown" };
+  }
+
+  // A token Expo rejected is a push that cannot land, and re-sending to it
+  // burns the cap on nothing. The `unanswered` guard is what stops this being
+  // a life sentence: registering a new token means opening the app, which
+  // moves `lastActiveAt` past the failed send and clears the streak, so a
+  // reinstall is back in the schedule rather than muted forever.
+  const deadToken =
+    facts.lastTicketError === DEAD_TOKEN_ERROR ||
+    facts.lastReceiptError === DEAD_TOKEN_ERROR;
+
+  if (unanswered > 0 && deadToken) {
+    return { allowed: false, reason: "dead_token" };
+  }
+
+  if (monthly >= MAX_PUSHES_PER_MONTH) {
+    return { allowed: false, reason: "monthly_cap" };
+  }
+
+  const sinceLastPush = daysBetween(lastPushAt, now);
+
+  if (sinceLastPush < MIN_GAP_DAYS) {
+    return { allowed: false, reason: "cooldown" };
+  }
+
+  if (unanswered === 0) {
+    // They came back after the last push, so the schedule starts over and the
+    // only question is the same one it was the first time.
+    return awayLongEnough
+      ? { allowed: true }
+      : { allowed: false, reason: "cooldown" };
+  }
+
+  const owed = gapAfterUnanswered(unanswered) - SLOT_SLACK_HOURS / 24;
+
+  if (sinceLastPush >= owed) return { allowed: true };
+
+  return {
+    allowed: false,
+    reason:
+      unanswered >= UNANSWERED_PUSHES_BEFORE_PAUSE ? "gave_up" : "cooldown",
+  };
+};

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -2,6 +2,7 @@ import prisma from "@pegada/database";
 import { breedData } from "@pegada/database/fixtures/breed-data";
 import { generateFakeUserWithDog } from "@pegada/database/fixtures/generate-fake-user-with-dog";
 
+import { cadenceDecision, readCadence } from "./reengagement-cadence";
 import {
   isWithinSendWindow,
   localHourFromLongitude,
@@ -635,76 +636,39 @@ describe("ReengagementService.run", () => {
     expect(await prisma.notificationLog.count()).toBe(2);
   });
 
-  it("holds a user to one push a day across different kinds", async () => {
-    const { requester, responder } = await seedSilentMatch(25);
-
-    // A waiting like for the same user, so there is a second kind queued.
-    const { dog: admirer } = await seedUserWithDog(
-      { gender: "MALE" },
-      reachableUser({ pushToken: null }),
-    );
-    await seedInterest(
-      {
-        requesterId: admirer.id,
-        responderId: responder.id,
-        swipeType: "INTERESTED",
-        lastPositiveAt: hoursAgo(30),
-      },
-      hoursAgo(30),
-    );
+  it("holds a user to one push whatever else they qualify for", async () => {
+    const { responder } = await seedSilentMatch(25);
 
     expect((await ReengagementService.run(NOW)).sent).toBe(2);
 
-    // An hour later, still in the window: the match keys are claimed but the
-    // like key is not, and the daily cap is what has to stop it.
+    // A second silent match for the same person, so an hour later there is a
+    // candidate whose key has never been claimed. The cadence is the only
+    // thing left that can stop it.
+    const { dog: other } = await seedUserWithDog(
+      { gender: "MALE" },
+      reachableUser({ pushToken: null }),
+    );
+    const second = await prisma.match.create({
+      data: { requesterId: other.id, responderId: responder.id },
+    });
+    await prisma.match.update({
+      where: { id: second.id },
+      data: { createdAt: hoursAgo(25) },
+    });
+
     const summary = await ReengagementService.run(
       new Date(NOW.getTime() + 60 * 60 * 1000),
     );
 
     expect(summary.sent).toBe(0);
-    expect(summary.skippedCooldown).toBe(1);
-    expect(requester.id).not.toBe(responder.id);
+    expect(summary.suppressed.cooldown).toBe(1);
+    // The two from the first run and nothing since.
+    expect(
+      PushNotificationService.enqueuePushNotification,
+    ).toHaveBeenCalledTimes(2);
   });
 
-  it("does not let the daily cap drift out of the evening slot", async () => {
-    // 18:00 in Sao Paulo, the first of the two fallback hours.
-    const eveningSlot = new Date("2026-09-01T21:00:00.000Z");
-    const { requester } = await seedSilentMatch(25, eveningSlot);
-
-    // No coordinates, so this user only ever gets the evening slot.
-    await prisma.user.updateMany({
-      data: { latitude: null, longitude: null },
-    });
-
-    /** Nudged at yesterday's 19:00 slot, then run at today's 18:00 one. */
-    const runAfterPreviousNudge = async (hoursSince: number) => {
-      await prisma.notificationLog.deleteMany();
-      await prisma.notificationLog.create({
-        data: {
-          userId: requester.userId,
-          kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
-          dedupeKey: `yesterday:${hoursSince}`,
-          sentAt: hoursBefore(eveningSlot, hoursSince),
-        },
-      });
-
-      return ReengagementService.run(eveningSlot);
-    };
-
-    // An hour earlier in the evening than yesterday's send is exactly the
-    // case a 24 hour window pushed into the following day.
-    const onTime = await runAfterPreviousNudge(23);
-
-    expect(onTime.skippedCooldown).toBe(0);
-    expect(onTime.sent).toBe(2);
-
-    // Well inside the same day, still held back.
-    const tooSoon = await runAfterPreviousNudge(2);
-
-    expect(tooSoon.skippedCooldown).toBe(1);
-  });
-
-  it("falls through to the next kind once the cap expires", async () => {
+  it("falls through to the next kind once the schedule comes round", async () => {
     const { responder } = await seedSilentMatch(25);
 
     const { dog: admirer } = await seedUserWithDog(
@@ -723,10 +687,10 @@ describe("ReengagementService.run", () => {
 
     await ReengagementService.run(NOW);
 
-    // Age the log past the daily cap. The match nudge is still claimed, so a
-    // user whose best candidate is spent has to reach their next one rather
-    // than lose the day to it.
-    await prisma.notificationLog.updateMany({ data: { sentAt: hoursAgo(30) } });
+    // Age the log past the first unanswered gap. The match nudge is still
+    // claimed, so a user whose best candidate is spent has to reach their next
+    // one rather than lose the slot to it.
+    await prisma.notificationLog.updateMany({ data: { sentAt: daysAgo(11) } });
 
     const summary = await ReengagementService.run(NOW);
 
@@ -746,7 +710,7 @@ describe("ReengagementService.run", () => {
     const burst = await ReengagementService.run(AFTERNOON_BURST);
 
     expect(burst.sent).toBe(0);
-    expect(burst.skippedOutsideWindow).toBe(2);
+    expect(burst.suppressed.window).toBe(2);
     expect(
       PushNotificationService.enqueuePushNotification,
     ).not.toHaveBeenCalled();
@@ -759,15 +723,15 @@ describe("ReengagementService.run", () => {
     expect(evening.sent).toBe(2);
   });
 
-  it("nudges about waiting likes once a week, not once a day", async () => {
+  it("nudges about waiting likes on the schedule, not once a day", async () => {
     const { user, dog: liked } = await seedUserWithDog(
       { gender: "FEMALE" },
       reachableUser(),
     );
 
-    /** Seven admirers, oldest like first, all of them waiting over a day. */
+    /** Eleven admirers, oldest like first, all of them waiting over a day. */
     const likes: { id: string }[] = [];
-    for (const index of [0, 1, 2, 3, 4, 5, 6]) {
+    for (const index of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
       // oxlint-disable-next-line no-await-in-loop -- Fixture rows are created in order so their timestamps stay distinct.
       const { dog: admirer } = await seedUserWithDog(
         { gender: "MALE", name: `Admirer ${index}` },
@@ -780,9 +744,9 @@ describe("ReengagementService.run", () => {
           requesterId: admirer.id,
           responderId: liked.id,
           swipeType: "INTERESTED",
-          lastPositiveAt: hoursAgo(40 - index),
+          lastPositiveAt: hoursAgo(60 - index),
         },
-        hoursAgo(40 - index),
+        hoursAgo(60 - index),
       );
 
       likes.push(like);
@@ -796,8 +760,8 @@ describe("ReengagementService.run", () => {
      * The next evening slot, with the like that was announced taken off the
      * board. A swipe back does exactly this, and it is what moves the anchor
      * the dedupe key is built from: every one of these days offers a key that
-     * has never been claimed, so the weekly floor is the only thing left
-     * holding the nudge back.
+     * has never been claimed, so the cadence is the only thing left holding
+     * the nudge back.
      */
     const runOnDay = async (day: number) => {
       await prisma.interest.update({
@@ -810,7 +774,7 @@ describe("ReengagementService.run", () => {
       );
     };
 
-    for (const day of [1, 2, 3, 4, 5, 6]) {
+    for (const day of [1, 2, 3, 4, 5, 6, 7, 8, 9]) {
       // oxlint-disable-next-line no-await-in-loop -- Each day has to see the log the previous day wrote.
       const summary = await runOnDay(day);
 
@@ -823,13 +787,11 @@ describe("ReengagementService.run", () => {
       }),
     ).resolves.toBe(1);
 
-    // A week on, the floor has passed and the likes still sitting there are
-    // worth one more nudge.
-    const nextWeek = await ReengagementService.run(
-      new Date(NOW.getTime() + 8 * 24 * 60 * 60 * 1000),
-    );
+    // Ten days on, the gap owed after one unanswered push has passed and the
+    // likes still sitting there are worth one more nudge.
+    const later = await runOnDay(10);
 
-    expect(nextWeek.byKind[REENGAGEMENT_KINDS.LIKES_WAITING]).toBe(1);
+    expect(later.byKind[REENGAGEMENT_KINDS.LIKES_WAITING]).toBe(1);
   });
 
   it("sends nothing outside the evening window", async () => {
@@ -838,7 +800,7 @@ describe("ReengagementService.run", () => {
     const summary = await ReengagementService.run(NIGHT);
 
     expect(summary.sent).toBe(0);
-    expect(summary.skippedOutsideWindow).toBe(2);
+    expect(summary.suppressed.window).toBe(2);
     expect(
       PushNotificationService.enqueuePushNotification,
     ).not.toHaveBeenCalled();
@@ -849,7 +811,7 @@ describe("ReengagementService.run", () => {
     const evening = await ReengagementService.run(NOW);
 
     expect(evening.sent).toBe(2);
-    expect(evening.skippedOutsideWindow).toBe(0);
+    expect(evening.suppressed.window).toBe(0);
     expect(
       PushNotificationService.enqueuePushNotification,
     ).toHaveBeenCalledTimes(2);
@@ -927,5 +889,367 @@ describe("ReengagementService.run", () => {
     expect(
       PushNotificationService.enqueuePushNotification,
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe("reengagement cadence", () => {
+  /**
+   * The cadence reads two things: the log rows and `lastActiveAt`. Seeding
+   * both directly is what lets one test span six months without inventing six
+   * months of matches, and it is the same pair the service reads in
+   * production.
+   */
+  const seedDormantUser = async (lastActiveAt: Date | null) => {
+    const { user } = await seedUserWithDog(
+      { gender: "MALE" },
+      reachableUser({ lastActiveAt }),
+    );
+
+    return user;
+  };
+
+  let sequence = 0;
+
+  const seedPush = (
+    userId: string,
+    sentAt: Date,
+    overrides: { receiptError?: string; ticketError?: string } = {},
+  ) => {
+    sequence += 1;
+
+    return prisma.notificationLog.create({
+      data: {
+        userId,
+        kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+        dedupeKey: `seeded:${sequence}`,
+        sentAt,
+        ...overrides,
+      },
+    });
+  };
+
+  /** The decision the run would make, derived the way the run derives it. */
+  const decide = async (userId: string, now: Date) => {
+    const facts = await readCadence([userId], now);
+    const found = facts.get(userId);
+
+    if (!found) throw new Error(`no cadence row for ${userId}`);
+
+    return cadenceDecision(found, now);
+  };
+
+  const setLastActiveAt = (userId: string, lastActiveAt: Date | null) =>
+    prisma.user.update({ where: { id: userId }, data: { lastActiveAt } });
+
+  it("waits five days of dormancy before the first push", async () => {
+    const user = await seedDormantUser(daysAgo(4));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+
+    await setLastActiveAt(user.id, daysAgo(5));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("treats a user it has never seen as away", async () => {
+    // The column is only written for people who have made a request since it
+    // shipped, so null has to mean unknown rather than here.
+    const user = await seedDormantUser(null);
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("waits ten days after one unanswered push and twenty after two", async () => {
+    const user = await seedDormantUser(daysAgo(60));
+
+    await seedPush(user.id, daysAgo(9));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+
+    await prisma.notificationLog.updateMany({ data: { sentAt: daysAgo(10) } });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+
+    // Two unanswered now, and the same ten days is no longer enough.
+    await prisma.notificationLog.deleteMany();
+    await seedPush(user.id, daysAgo(50));
+    await seedPush(user.id, daysAgo(19));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+
+    await prisma.notificationLog.updateMany({
+      where: { sentAt: daysAgo(19) },
+      data: { sentAt: daysAgo(20) },
+    });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("stops for six months after three unanswered pushes", async () => {
+    const user = await seedDormantUser(daysAgo(120));
+
+    await seedPush(user.id, daysAgo(60));
+    await seedPush(user.id, daysAgo(50));
+    await seedPush(user.id, daysAgo(40));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "gave_up",
+    });
+
+    // Still nothing at four months, which is where a schedule that kept
+    // doubling would have started again.
+    const fourMonths = new Date(NOW.getTime() + 80 * 24 * 60 * 60 * 1000);
+
+    await expect(decide(user.id, fourMonths)).resolves.toEqual({
+      allowed: false,
+      reason: "gave_up",
+    });
+
+    // Six months after the last one, one more try.
+    const sixMonths = new Date(NOW.getTime() + 141 * 24 * 60 * 60 * 1000);
+
+    await expect(decide(user.id, sixMonths)).resolves.toEqual({
+      allowed: true,
+    });
+
+    // Which also goes unanswered, so it buys another six months.
+    await seedPush(user.id, sixMonths);
+
+    const later = new Date(sixMonths.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    await expect(decide(user.id, later)).resolves.toEqual({
+      allowed: false,
+      reason: "gave_up",
+    });
+  });
+
+  it("puts somebody who came back on the normal schedule again", async () => {
+    const user = await seedDormantUser(daysAgo(10));
+
+    // Pushed twenty days ago, back in the app ten days ago, quiet since.
+    await seedPush(user.id, daysAgo(20));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+
+    // Back three days ago instead, which is not dormant yet.
+    await setLastActiveAt(user.id, daysAgo(3));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+  });
+
+  it("resets to the first gap when a response follows the second push", async () => {
+    const user = await seedDormantUser(daysAgo(29));
+
+    await seedPush(user.id, daysAgo(40));
+    await seedPush(user.id, daysAgo(31));
+    // The first push after they came back, itself unanswered.
+    await seedPush(user.id, daysAgo(8));
+
+    // Three pushes on the row, but only one of them since they were last seen,
+    // so the wait is the first rung and not the six month pause.
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+
+    await prisma.notificationLog.updateMany({
+      where: { sentAt: daysAgo(8) },
+      data: { sentAt: daysAgo(10) },
+    });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("counts a response that lands after the next push went out", async () => {
+    const user = await seedDormantUser(daysAgo(11));
+
+    await seedPush(user.id, daysAgo(40));
+    await seedPush(user.id, daysAgo(9));
+
+    // Last seen before the second push, so that push is unanswered and the
+    // ten day gap is still running.
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+
+    // Same rows, but they turned up the day after that push. The streak is
+    // cleared even though the return was late.
+    await setLastActiveAt(user.id, daysAgo(8));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("never sends two pushes inside seven days", async () => {
+    const user = await seedDormantUser(daysAgo(5));
+
+    // Answered, dormant five days again, and the schedule would allow it. The
+    // hard floor is the only thing in the way.
+    await seedPush(user.id, daysAgo(6));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+
+    await prisma.notificationLog.updateMany({ data: { sentAt: daysAgo(8) } });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("never sends more than two pushes inside thirty days", async () => {
+    const user = await seedDormantUser(daysAgo(14));
+
+    await seedPush(user.id, daysAgo(25));
+    await seedPush(user.id, daysAgo(15));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "monthly_cap",
+    });
+
+    // The older of the two drops out of the window and the third is allowed.
+    await prisma.notificationLog.updateMany({
+      where: { sentAt: daysAgo(25) },
+      data: { sentAt: daysAgo(35) },
+    });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("stops pushing a token the device no longer answers for", async () => {
+    const user = await seedDormantUser(daysAgo(60));
+
+    const dead = await seedPush(user.id, daysAgo(30), {
+      ticketError: "DeviceNotRegistered",
+    });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "dead_token",
+    });
+
+    // The receipt says it half an hour later rather than the ticket saying it
+    // straight away, and it means the same thing.
+    await prisma.notificationLog.update({
+      where: { id: dead.id },
+      data: { ticketError: null, receiptError: "DeviceNotRegistered" },
+    });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "dead_token",
+    });
+  });
+
+  it("lets a reinstall back in after a dead token", async () => {
+    const user = await seedDormantUser(daysAgo(60));
+
+    await seedPush(user.id, daysAgo(30), {
+      receiptError: "DeviceNotRegistered",
+    });
+
+    // Registering a new token means opening the app, which is the same event
+    // that clears the streak. Without this the reinstall would be muted for
+    // good.
+    await setLastActiveAt(user.id, daysAgo(20));
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({ allowed: true });
+  });
+
+  it("counts every kind against the same schedule", async () => {
+    const user = await seedDormantUser(daysAgo(60));
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: user.id,
+        kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+        dedupeKey: "a-different-kind",
+        sentAt: daysAgo(3),
+      },
+    });
+
+    await expect(decide(user.id, NOW)).resolves.toEqual({
+      allowed: false,
+      reason: "cooldown",
+    });
+  });
+});
+
+describe("Reengagement Push Suppressed", () => {
+  /** One hour past {@link NOW}, so 19:00 local: the close of the window. */
+  const WINDOW_CLOSE = new Date(NOW.getTime() + 60 * 60 * 1000);
+  /** Two hours past, so 20:00 local: the first hour the slot is spent. */
+  const AFTER_WINDOW = new Date(NOW.getTime() + 2 * 60 * 60 * 1000);
+
+  const suppressedCalls = () =>
+    observability.capture.mock.calls.filter(
+      ([event]) => event === "Reengagement Push Suppressed",
+    );
+
+  it("reports a cadence decision once, at the close of the window", async () => {
+    const { requester } = await seedSilentMatch(25);
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: requester.userId,
+        kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+        dedupeKey: "yesterday",
+        sentAt: hoursAgo(2),
+      },
+    });
+
+    // 18:00 local. The push is held back and counted, but the day is not over
+    // so nothing is reported yet.
+    const early = await ReengagementService.run(NOW);
+
+    expect(early.suppressed.cooldown).toBe(1);
+    expect(suppressedCalls()).toHaveLength(0);
+
+    const close = await ReengagementService.run(WINDOW_CLOSE);
+
+    expect(close.suppressed.cooldown).toBe(1);
+    expect(suppressedCalls()).toEqual([
+      [
+        "Reengagement Push Suppressed",
+        expect.objectContaining({
+          kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+          reason: "cooldown",
+        }),
+      ],
+    ]);
+  });
+
+  it("reports a missed window at the hour after it closed", async () => {
+    await seedSilentMatch(25, AFTER_WINDOW);
+
+    const spent = await ReengagementService.run(AFTER_WINDOW);
+
+    expect(spent.sent).toBe(0);
+    expect(spent.suppressed.window).toBe(2);
+    expect(suppressedCalls()).toHaveLength(2);
+    expect(suppressedCalls()[0]?.[1]).toMatchObject({ reason: "window" });
+
+    // The middle of the night is the same suppression and not worth a second
+    // row for the same person on the same day.
+    const night = await ReengagementService.run(
+      new Date(AFTER_WINDOW.getTime() + 7 * 60 * 60 * 1000),
+    );
+
+    expect(night.suppressed.window).toBe(2);
+    expect(suppressedCalls()).toHaveLength(2);
   });
 });

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -1,4 +1,7 @@
-import type { ReengagementPushKind } from "@pegada/shared/analytics/events";
+import type {
+  ReengagementPushKind,
+  ReengagementSuppressionReason,
+} from "@pegada/shared/analytics/events";
 
 import { Expo } from "expo-server-sdk";
 
@@ -10,6 +13,13 @@ import { Prisma } from "@prisma/client";
 import { sendError } from "../errors/errors";
 import { captureEvent } from "../shared/analytics";
 import { PushNotificationService } from "./push-notification-service";
+import {
+  cadenceDecision,
+  MIN_GAP_DAYS,
+  POLICY_REPORT_HOUR,
+  readCadence,
+  WINDOW_REPORT_HOUR,
+} from "./reengagement-cadence";
 import { TranslationService } from "./translation-service";
 
 /**
@@ -103,43 +113,6 @@ const SEND_WINDOW_HOURS = new Set([18, 19]);
 const FALLBACK_OFFSET_HOURS = -3;
 
 /**
- * One re-engagement push per user per rolling day, whatever the kind.
- *
- * 23 hours rather than 24, and strictly greater than rather than inclusive,
- * because the job runs hourly and the cap is measured against the previous
- * send. At exactly 24 a user nudged at 19:00 is still inside the window at
- * 18:00 the next day, so their slot slides an hour later each time until it
- * falls out of the evening entirely and they end up on every other day.
- */
-const USER_COOLDOWN_HOURS = 23;
-
-/**
- * How long one kind waits before it may nudge the same user again.
- *
- * `likes_waiting` is the outlier and the reason this map exists. Its dedupe
- * key names one pending like, so a dormant user collecting a like a day was
- * eligible again every day under a key that had never been claimed: same
- * person, same "you have likes waiting", every evening. A week between two of
- * them makes it a nudge rather than a drip, and it costs nothing when the
- * likes really are new, because the copy never counted them.
- *
- * The other two are already self limiting (a match is nudged at 24h and 72h
- * and never again, new dogs are keyed on an anchor that only the user can
- * move), so they sit at the shared floor.
- */
-const KIND_COOLDOWN_HOURS = {
-  [REENGAGEMENT_KINDS.UNANSWERED_MATCH]: USER_COOLDOWN_HOURS,
-  [REENGAGEMENT_KINDS.NEW_DOGS_NEARBY]: USER_COOLDOWN_HOURS,
-  [REENGAGEMENT_KINDS.LIKES_WAITING]: 7 * 24,
-} as const satisfies Record<ReengagementKind, number>;
-
-/** How far back the cooldown lookup has to read to answer every kind. */
-const MAX_COOLDOWN_HOURS = Math.max(...Object.values(KIND_COOLDOWN_HOURS));
-
-/** Set membership key for "this user has had this kind recently". */
-const kindKey = (userId: string, kind: string) => `${userId}:${kind}`;
-
-/**
  * Bounds one invocation so a backlog cannot outrun the function budget.
  *
  * Worth reading next to {@link SEND_WINDOW_HOURS}: a user is only eligible in
@@ -171,12 +144,12 @@ export type ReengagementRunSummary = {
   sent: number;
   byKind: Record<ReengagementKind, number>;
   candidates: number;
-  /** Users whose local hour was not 18:00 or 19:00 when the run started. */
-  skippedOutsideWindow: number;
-  /** Users inside {@link USER_COOLDOWN_HOURS} of their last push, any kind. */
-  skippedCooldown: number;
-  /** Candidates dropped by their own kind's cooldown. */
-  skippedKindCooldown: number;
+  /**
+   * Users who had a nudge waiting and did not get it, by reason. Counted once
+   * per user per run, which is not the same as the events: those are reported
+   * once a day so they count people rather than passes.
+   */
+  suppressed: Record<ReengagementSuppressionReason, number>;
   skippedAlreadySent: number;
   skippedUnreachable: number;
 };
@@ -240,14 +213,17 @@ export const localHourFromLongitude = (
  * comes from the user's longitude when there is one, and from
  * America/Sao_Paulo when there is not. See {@link SEND_WINDOW_HOURS}.
  */
+export const localHourFor = (
+  longitude: number | null | undefined,
+  now: Date,
+): number =>
+  localHourFromLongitude(longitude, now) ??
+  hourInOffset(now, FALLBACK_OFFSET_HOURS);
+
 export const isWithinSendWindow = (
   longitude: number | null | undefined,
   now: Date,
-): boolean =>
-  SEND_WINDOW_HOURS.has(
-    localHourFromLongitude(longitude, now) ??
-      hourInOffset(now, FALLBACK_OFFSET_HOURS),
-  );
+): boolean => SEND_WINDOW_HOURS.has(localHourFor(longitude, now));
 
 type ReengagementCopyKey =
   | "server:notification.reengagement.unansweredMatch.title"
@@ -606,18 +582,15 @@ type LikesWaitingRow = {
  * until that particular like is dealt with. On its own that was not enough:
  * a new like arriving is a new oldest-unannounced like, so a popular dormant
  * dog produced one of these every evening. The weekly floor below is the cap
- * that actually holds, and it is applied here as well as in the run so those
- * users do not sit in the candidate limit for nothing.
+ * that actually holds, and it is mirrored here as well as enforced in the run
+ * so those users do not sit in the candidate limit for nothing.
  */
 export const selectLikesWaitingCandidates = async (
   now: Date,
 ): Promise<Candidate[]> => {
   const olderThan = new Date(now.getTime() - LIKES_WAITING_HOURS * HOUR_MS);
 
-  const cooldownFloor = new Date(
-    now.getTime() -
-      KIND_COOLDOWN_HOURS[REENGAGEMENT_KINDS.LIKES_WAITING] * HOUR_MS,
-  );
+  const cooldownFloor = new Date(now.getTime() - MIN_GAP_DAYS * DAY_MS);
 
   const rows = await prisma.$queryRaw<LikesWaitingRow[]>`
     WITH "waiting" AS (
@@ -679,12 +652,12 @@ export const selectLikesWaitingCandidates = async (
       WHERE "NotificationLog"."dedupeKey" =
         ${`${REENGAGEMENT_KINDS.LIKES_WAITING}:`} || "waiting"."userId" || ':' || "waiting"."anchorId"
     )
-    /* The weekly per-user floor for this kind, mirrored from the run so the
-       users it holds back never take a slot in the limit below. */
+    /* The weekly per-user floor, mirrored from the run so the users it holds
+       back never take a slot in the limit below. Every kind counts, because
+       the floor in the run counts every kind. */
     AND NOT EXISTS (
       SELECT 1 FROM "NotificationLog"
       WHERE "NotificationLog"."userId" = "waiting"."userId"
-      AND "NotificationLog"."kind" = ${REENGAGEMENT_KINDS.LIKES_WAITING}
       AND "NotificationLog"."sentAt" > ${cooldownFloor}
     )
     ORDER BY "waiting"."newestLikeAt" DESC
@@ -750,9 +723,13 @@ export class ReengagementService {
         [REENGAGEMENT_KINDS.LIKES_WAITING]: 0,
       },
       candidates: candidates.length,
-      skippedOutsideWindow: 0,
-      skippedCooldown: 0,
-      skippedKindCooldown: 0,
+      suppressed: {
+        cooldown: 0,
+        dead_token: 0,
+        gave_up: 0,
+        monthly_cap: 0,
+        window: 0,
+      },
       skippedAlreadySent: 0,
       skippedUnreachable: 0,
     };
@@ -795,74 +772,57 @@ export class ReengagementService {
         });
     }
 
-    const due = [...perUser.entries()].filter(([, { longitude }]) => {
-      if (isWithinSendWindow(longitude, now)) return true;
-      summary.skippedOutsideWindow += 1;
-      return false;
-    });
+    if (perUser.size === 0) return summary;
 
-    if (due.length === 0) return summary;
+    const cadence = await readCadence([...perUser.keys()], now);
 
-    // One read covers both caps: the widest kind window is a superset of the
-    // per-user one, so the rows are filtered in memory rather than queried
-    // once per kind.
-    const recentLogs = await prisma.notificationLog.findMany({
-      where: {
-        userId: { in: due.map(([userId]) => userId) },
-        sentAt: { gt: new Date(now.getTime() - MAX_COOLDOWN_HOURS * HOUR_MS) },
-      },
-      select: { userId: true, kind: true, sentAt: true },
-    });
+    /**
+     * Count it always, report it once a day.
+     *
+     * See {@link POLICY_REPORT_HOUR}. The summary is per run because the cron
+     * response is read per run; the event is per person because that is the
+     * number the readout is being asked for.
+     */
+    const suppress = (
+      userId: string,
+      kind: ReengagementKind,
+      reason: ReengagementSuppressionReason,
+      localHour: number,
+    ) => {
+      summary.suppressed[reason] += 1;
 
-    const recentlyNudged = new Set(
-      recentLogs
-        .filter(
-          ({ sentAt }) =>
-            sentAt.getTime() > now.getTime() - USER_COOLDOWN_HOURS * HOUR_MS,
-        )
-        .map(({ userId }) => userId),
-    );
+      const reportAt =
+        reason === "window" ? WINDOW_REPORT_HOUR : POLICY_REPORT_HOUR;
 
-    // The selectors mirror their own kind's floor in SQL so a cooled down user
-    // never takes a slot in MAX_CANDIDATES_PER_QUERY. This is the same rule
-    // stated once more where the decision is actually made: it is what a new
-    // kind gets for free, and `skippedKindCooldown` reading anything but zero
-    // is the signal that a selector has stopped mirroring it.
-    const kindOnCooldown = new Set(
-      recentLogs
-        .filter(({ kind, sentAt }) => {
-          const hours = KIND_COOLDOWN_HOURS[kind as ReengagementKind];
+      if (localHour !== reportAt) return;
 
-          // An unknown kind is a row this service did not write, so it holds
-          // nobody back beyond the per-user cap above.
-          return (
-            hours !== undefined &&
-            sentAt.getTime() > now.getTime() - hours * HOUR_MS
-          );
-        })
-        .map(({ userId, kind }) => kindKey(userId, kind)),
-    );
+      captureEvent(userId, ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SUPPRESSED, {
+        kind,
+        reason,
+      });
+    };
 
-    for (const [userId, { queue }] of due) {
+    for (const [userId, { longitude, queue }] of perUser) {
       if (summary.sent >= MAX_PUSHES_PER_RUN) break;
 
-      if (recentlyNudged.has(userId)) {
-        summary.skippedCooldown += 1;
-      } else {
-        const allowed = queue.filter((candidate) => {
-          if (!kindOnCooldown.has(kindKey(userId, candidate.kind))) return true;
-          summary.skippedKindCooldown += 1;
-          return false;
-        });
+      const facts = cadence.get(userId);
+      const [best] = queue;
 
-        // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cooldown they enforce on each other.
-        const sent = await ReengagementService.#sendFirstAvailable(
-          allowed,
-          summary,
-          now,
-        );
+      // A missing row means the user was deleted between the selector and here.
+      if (facts && best) {
+        const localHour = localHourFor(longitude, now);
+        const decision = cadenceDecision(facts, now);
 
-        if (sent) recentlyNudged.add(userId);
+        // The cadence is decided before the clock, so somebody held back for a
+        // month is not also counted as "wrong hour" twenty-two times a day.
+        if (!decision.allowed) {
+          suppress(userId, best.kind, decision.reason, localHour);
+        } else if (SEND_WINDOW_HOURS.has(localHour)) {
+          // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cadence they enforce on each other.
+          await ReengagementService.#sendFirstAvailable(queue, summary, now);
+        } else {
+          suppress(userId, best.kind, "window", localHour);
+        }
       }
     }
 

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -56,6 +56,7 @@ export const ANALYTICS_EVENTS = {
   PROFILE_PHOTO_ADDED: "Profile Photo Added",
   PUSH_NOTIFICATION_OPENED: "Push Notification Opened",
   REENGAGEMENT_PUSH_SENT: "Reengagement Push Sent",
+  REENGAGEMENT_PUSH_SUPPRESSED: "Reengagement Push Suppressed",
   PUSH_PERMISSION: "Push Permission",
   PUSH_RECEIPT_RESULT: "Push Receipt Result",
   PUSH_TICKET_RESULT: "Push Ticket Result",
@@ -122,6 +123,20 @@ export type ReengagementPushKind =
   | "likes_waiting"
   | "new_dogs_nearby"
   | "unanswered_match";
+
+/**
+ * Why a re-engagement push that had something to say was not sent.
+ *
+ * Restated here rather than imported for the same reason the kinds above are.
+ * `window` is the only one that is not a cadence decision: the candidate was
+ * due but the run caught the user outside their evening slot.
+ */
+export type ReengagementSuppressionReason =
+  | "cooldown"
+  | "dead_token"
+  | "gave_up"
+  | "monthly_cap"
+  | "window";
 
 /**
  * What a push was for, across every path that sends one: the three scheduled
@@ -487,6 +502,21 @@ export type ServerEventProperties = {
     dedupe_key: string;
     kind: ReengagementPushKind;
   };
+  /**
+   * One row per user the cron had a nudge for and deliberately did not send.
+   *
+   * The counterweight to the event above: sends alone cannot tell a quiet week
+   * from a broken cron. `reason` is what makes the cadence auditable, and
+   * `kind` is the nudge that was withheld, so the cost of the cadence can be
+   * read per kind rather than only in aggregate.
+   *
+   * Emitted at most once per user per day rather than once per hourly run, so
+   * the counts are people held back rather than passes over the same person.
+   */
+  [ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SUPPRESSED]: {
+    kind: ReengagementPushKind;
+    reason: ReengagementSuppressionReason;
+  };
   // Keys stay camelCase for the same reason "Referral Captured" keeps them:
   // the two events are joined on `ref` and `referredByUserId`, and a capture
   // that spells a key one way and the signup it produced another way is a
@@ -643,6 +673,7 @@ export const SERVER_EVENT_NAMES = [
   ANALYTICS_EVENTS.PUSH_RECEIPT_RESULT,
   ANALYTICS_EVENTS.PUSH_TICKET_RESULT,
   ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT,
+  ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SUPPRESSED,
   ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED,
   ANALYTICS_EVENTS.SUBSCRIPTION_EVENT,
 ] as const;


### PR DESCRIPTION
## Summary

The re-engagement cron now spaces its pushes per person instead of per kind, so nobody collects several of them in a week. How often somebody hears from the app depends on whether the last push brought them back.

## Details

- One schedule per person across all three nudges. The first push goes out after five days without opening the app. If it does not bring the person back, the next one waits ten days, then twenty. Three unanswered pushes in a row and the app goes quiet for a hundred and eighty days before trying once more, and another hundred and eighty if that one is ignored too.
- Coming back resets everything. Somebody who was pushed, came back, and went quiet again is treated as new: five days dormant and the schedule starts at the first gap again. A response that arrives late, after the following push already went out, still resets it.
- A response today means the person opened the app after the push landed, read off the last activity column. `Push Notification Opened` is the honest signal and this should read that once the build reporting it is in the store. Until then the activity proxy errs towards pushing less, because it credits the push with returns it may have had nothing to do with.
- Two ceilings hold whatever the schedule works out to: at most one push per person per seven days, and at most two per rolling thirty days, counting every kind together.
- A push that comes back from Expo as `DeviceNotRegistered` stops the schedule for that person. Registering a new token means opening the app, which is the same event that clears the unanswered streak, so a reinstall lands back on the normal schedule rather than staying muted.
- `Reengagement Push Suppressed` is a new server event carrying why a push was withheld (`cooldown`, `monthly_cap`, `gave_up`, `dead_token`, `window`) and which nudge was held back. It is reported once a day per person rather than once per hourly run, so the counts are people rather than passes over the same person.
- All of the state comes from the notification log plus the last activity column, so there is no migration and no counter that can drift away from the rows it summarises.
- The evening send window and every piece of push copy are unchanged.
- All three nudges are concrete (a match nobody spoke on, likes waiting, new dogs nearby), so there is no generic "come back" reminder to drop first when a cap is hit. If one is ever added, it should be the one the caps skip first.

How this gets read after it ships:

- Baseline from the readout on issue #188: 800 sends to 529 users over seven days, so 1.5 pushes per person per week on average and several people well above that.
- Pushes per person per week, from the send event over distinct users. Target under 1.5, expected nearer 0.5 once the schedule takes hold.
- Share of pushed people who open the app again within twenty four hours, which the readout is adding.
- Dead token rate, from the error codes on the ticket and receipt events.
- Push open rate, once the 1.6.2 backport carries the open event to people on the store build.

## Testing steps

- Nothing to do in the app. This runs on the server, on a timer, once an hour.
- After release, check the daily readout. The number of reminder notifications each person gets in a week should fall, and a new count of reminders deliberately held back should appear with the reason next to it.
- Somebody who has not opened the app for five days can still get one reminder in the early evening. Somebody who got one two days ago should not get another.
- Somebody who ignores three reminders in a row should hear nothing for about six months.

## Screenshots

Not applicable, server side.
