### PR TITLE
feat(ci): paywall trigger and subscription period breakdowns in the daily readout

### DIFF
--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -155,6 +155,31 @@ export const BREAKDOWNS = [
     property: "type",
     title: "Subscription Event by type",
   },
+  // The three below are the pricing readout. Together they answer which
+  // trigger sends people to the paywall and how well each one converts, how
+  // much of the revenue is a trial that has not become paid yet, and whether a
+  // subscription ended because the person asked for their money back or
+  // because they simply stopped paying. RevenueCat spells a refund
+  // `CUSTOMER_SUPPORT`, a voluntary cancel `UNSUBSCRIBE` and a failed charge
+  // `BILLING_ERROR`, so the three read very differently and cannot share a row.
+  {
+    id: "paywall_trigger",
+    event: EVENTS.PAYWALL_VIEWED,
+    property: "trigger",
+    title: "Paywall Viewed by trigger",
+  },
+  {
+    id: "subscription_period_type",
+    event: EVENTS.SUBSCRIPTION_EVENT,
+    property: "period_type",
+    title: "Subscription Event by period type",
+  },
+  {
+    id: "subscription_cancel_reason",
+    event: EVENTS.SUBSCRIPTION_EVENT,
+    property: "cancel_reason",
+    title: "Subscription Event by cancel reason",
+  },
 ];
 
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -148,6 +148,44 @@ test("every breakdown names an event the totals query also counts", () => {
   assert.equal(new Set(ids).size, ids.length);
 });
 
+test("the pricing breakdowns ask the paywall and the subscription the right thing", () => {
+  const byId = new Map(
+    BREAKDOWNS.map((breakdown) => [breakdown.id, breakdown]),
+  );
+
+  const trigger = byId.get("paywall_trigger");
+  assert.equal(trigger.event, EVENTS.PAYWALL_VIEWED);
+  assert.equal(trigger.property, "trigger");
+
+  const period = byId.get("subscription_period_type");
+  assert.equal(period.event, EVENTS.SUBSCRIPTION_EVENT);
+  assert.equal(period.property, "period_type");
+
+  const reason = byId.get("subscription_cancel_reason");
+  assert.equal(reason.event, EVENTS.SUBSCRIPTION_EVENT);
+  assert.equal(reason.property, "cancel_reason");
+
+  const windows = buildWindows(NOW);
+  assert.match(
+    buildBreakdownQuery(windows, trigger),
+    /ifNull\(nullIf\(toString\(properties\.trigger\), ''\), 'unknown'\) AS bucket/,
+  );
+  assert.match(
+    buildBreakdownQuery(windows, trigger),
+    /AND event = 'Paywall Viewed'/,
+  );
+  // A subscription event that is not a cancel has no reason, so the null side
+  // of this query is most of it and has to stay a bucket rather than vanish.
+  assert.match(
+    buildBreakdownQuery(windows, reason),
+    /ifNull\(nullIf\(toString\(properties\.cancel_reason\), ''\), 'unknown'\) AS bucket/,
+  );
+  assert.match(
+    buildBreakdownQuery(windows, period),
+    /ifNull\(nullIf\(toString\(properties\.period_type\), ''\), 'unknown'\) AS bucket/,
+  );
+});
+
 test("every event name still exists in the shared analytics catalogue", () => {
   const cataloguePath = fileURLToPath(
     new URL("../../packages/shared/analytics/events.ts", import.meta.url),

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -55,6 +55,14 @@ const FIXTURE = {
       ["reject", "previous", 14],
       ["error", "current", 2],
     ]),
+    paywall_trigger: breakdown([
+      ["like_limit", "current", 180],
+      ["like_limit", "previous", 150],
+      ["profile_plan", "current", 90],
+      ["profile_plan", "previous", 60],
+      ["swipe_back", "current", 30],
+      ["unknown", "current", 5],
+    ]),
     push_ticket_status: breakdown([
       ["ok", "current", 90],
       ["error", "current", 10],
@@ -71,6 +79,20 @@ const FIXTURE = {
       ["organic", "current", 50],
       ["organic", "previous", 55],
       ["unknown", "current", 3],
+    ]),
+    subscription_cancel_reason: breakdown([
+      ["UNSUBSCRIBE", "current", 6],
+      ["UNSUBSCRIBE", "previous", 4],
+      ["CUSTOMER_SUPPORT", "current", 2],
+      ["BILLING_ERROR", "current", 1],
+      ["unknown", "current", 28],
+    ]),
+    subscription_period_type: breakdown([
+      ["TRIAL", "current", 14],
+      ["TRIAL", "previous", 9],
+      ["NORMAL", "current", 21],
+      ["NORMAL", "previous", 18],
+      ["INTRO", "current", 3],
     ]),
     subscription_type: breakdown([
       ["INITIAL_PURCHASE", "current", 7],
@@ -254,6 +276,9 @@ test("every breakdown gets its own table, ordered by the current window", () => 
     "Signup Attributed by ref",
     "Image Moderation Result by verdict",
     "Subscription Event by type",
+    "Paywall Viewed by trigger",
+    "Subscription Event by period type",
+    "Subscription Event by cancel reason",
   ]) {
     assert.ok(body.includes(`### ${title}`), `missing ${title}`);
   }
@@ -263,6 +288,30 @@ test("every breakdown gets its own table, ordered by the current window", () => 
       subscriptions.indexOf("| INITIAL_PURCHASE |"),
   );
   assert.match(body, /\| ai_story_video \| 31 \| 12 \| \+19 \(\+158\.3%\) \|/);
+});
+
+test("the pricing tables split the paywall by trigger and the subscription by period", () => {
+  const body = buildReport(FIXTURE);
+  const [, triggers] = body.split("### Paywall Viewed by trigger");
+  assert.match(triggers, /\| like_limit \| 180 \| 150 \| \+30 \(\+20\.0%\) \|/);
+  assert.match(triggers, /\| profile_plan \| 90 \| 60 \| \+30 \(\+50\.0%\) \|/);
+  assert.ok(
+    triggers.indexOf("| like_limit |") < triggers.indexOf("| profile_plan |"),
+  );
+
+  const [, periods] = body.split("### Subscription Event by period type");
+  assert.match(periods, /\| TRIAL \| 14 \| 9 \| \+5 \(\+55\.6%\) \|/);
+  assert.match(periods, /\| NORMAL \| 21 \| 18 \| \+3 \(\+16\.7%\) \|/);
+});
+
+test("the cancel reason table separates a refund from a voluntary cancel", () => {
+  const body = buildReport(FIXTURE);
+  const [, reasons] = body.split("### Subscription Event by cancel reason");
+  assert.match(reasons, /\| UNSUBSCRIBE \| 6 \| 4 \| \+2 \(\+50\.0%\) \|/);
+  assert.match(reasons, /\| CUSTOMER_SUPPORT \| 2 \| 0 \| \+2 \(new\) \|/);
+  assert.match(reasons, /\| BILLING_ERROR \| 1 \| 0 \| \+1 \(new\) \|/);
+  // Every subscription event that is not a cancel carries no reason at all.
+  assert.match(reasons, /\| unknown \| 28 \| 0 \| \+28 \(new\) \|/);
 });
 
 test("an empty breakdown says so instead of rendering an empty table", () => {


### PR DESCRIPTION
## Summary

The daily metrics readout gains three tables: paywall views split by what triggered them, subscription events split by period type, and subscription events split by cancel reason.

## Details

- `paywall_trigger` splits `Paywall Viewed` by `trigger`, so the readout shows like_limit, profile_plan, swipe_back and other side by side against the upgrade counts already in the Core table.
- `subscription_period_type` splits `Subscription Event` by `period_type`, which separates TRIAL from NORMAL, INTRO and PROMOTIONAL.
- `subscription_cancel_reason` splits `Subscription Event` by `cancel_reason`. CUSTOMER_SUPPORT is a refund, UNSUBSCRIBE is a person choosing to stop, BILLING_ERROR is a charge that failed. Events that are not cancels carry no reason, so they land in the existing `unknown` bucket.
- No new query shape and no rendering change. `buildBreakdownQuery` and the report already handle any event plus property pair, so the three entries are the whole feature.
- Tests cover each new id where the existing subscription breakdown is covered, in `queries.test.mjs` and `report.test.mjs`.

## Metric

Hypothesis: instrumentation only. It establishes the baseline the pricing plan on #268 depends on: paywall view to purchase per trigger, trial to paid share, and refunds against voluntary cancels.

Baseline: none readable today without database access.

Readout: the three new tables on the daily metrics comment on issue #188.

## Testing steps

1. Run the daily metrics workflow with dry run.
2. Check the comment preview ends with three new tables: paywall views by trigger, subscription events by period type, and subscription events by cancel reason.
3. Check the existing tables above them are unchanged.

## Screenshots

Not applicable, CI readout only.

