### PR TITLE
fix(ci): correct the store build coverage note and audit exceptions

### DIFF
--- a/apps/mobile/src/services/analytics/events.test.ts
+++ b/apps/mobile/src/services/analytics/events.test.ts
@@ -79,5 +79,8 @@ describe("analytics catalogue", () => {
     expect(ANALYTICS_EVENTS.UPGRADE).toBe("Upgrade");
     expect(ANALYTICS_EVENTS.NEW_MATCH).toBe("New Match");
     expect(ANALYTICS_EVENTS.SWIPE_BACK).toBe("Swipe Back");
+    // Sent by the `/store` redirect since before the catalogue existed, which
+    // is why the audit reported it as an event nobody could account for.
+    expect(ANALYTICS_EVENTS.STORE_REDIRECT).toBe("Store Redirect");
   });
 });

--- a/apps/nextjs/src/app/store/route.ts
+++ b/apps/nextjs/src/app/store/route.ts
@@ -1,5 +1,8 @@
+import type { ServerEventProperties } from "@pegada/shared/analytics/events";
+
 import { redirect } from "next/navigation";
 
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { getServerClient } from "magic-observability/next";
 
 import {
@@ -25,6 +28,11 @@ import {
  * `https://www.pegada.app/store` is the canonical form. The old
  * `share.pegada.app` host has no DNS record behind it (#211), so anything
  * still pointing there is a dead link, not a slower one.
+ *
+ * The event it sends is in the shared catalogue, and `satisfies` below is what
+ * keeps the payload and the catalogue entry the same shape. The events audit
+ * reads that catalogue, so a name only this file knew about read as an event
+ * nobody could account for.
  */
 export const GET = (request: Request) => {
   const userAgent = request.headers.get("user-agent") ?? "";
@@ -41,14 +49,14 @@ export const GET = (request: Request) => {
     host: posthogHost(),
     environment: deployEnvironment(),
     release: deployRelease(),
-  }).capture("Store Redirect", {
+  }).capture(ANALYTICS_EVENTS.STORE_REDIRECT, {
     store: target,
     ref: campaign.ref ?? null,
     dogId: campaign.dog ?? null,
     utm_source: campaign.utm_source ?? null,
     utm_medium: campaign.utm_medium ?? null,
     utm_campaign: campaign.utm_campaign ?? null,
-  });
+  } satisfies ServerEventProperties[typeof ANALYTICS_EVENTS.STORE_REDIRECT]);
 
   // Desktop has no install to send anyone to. The landing page already shows
   // both store badges, so it is the fallback, with the campaign still attached.

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -71,6 +71,7 @@ export const ANALYTICS_EVENTS = {
   SIGN_IN_EMAIL_SUBMITTED: "Sign In Email Submitted",
   SIGNUP_ATTRIBUTED: "Signup Attributed",
   SKIP_COMPLETE_DOG_PROFILE: "Skip Complete Dog Profile",
+  STORE_REDIRECT: "Store Redirect",
   SUBSCRIPTION_EVENT: "Subscription Event",
   SWIPE: "Swipe",
   SWIPE_BACK: "Swipe Back",
@@ -186,6 +187,19 @@ export type SharePromptPlacement = "empty_deck" | "first_match";
  * tell a prompted share from the profile button.
  */
 export type ShareSource = SharePromptPlacement | "dog_profile" | "own_profile";
+
+/**
+ * Where `/store` sent a visitor, picked from the user agent. Mirrors
+ * `StoreTarget` in `apps/nextjs/src/app/store/store-urls.ts`, restated here for
+ * the same reason the RevenueCat unions below are: `@pegada/shared` is a
+ * dependency of the site, not the other way round.
+ *
+ * `web` is a desktop browser, which has no install to be sent to and lands on
+ * the landing page instead. Splitting the redirect by it is what separates a
+ * link that reached a phone from one that reached a laptop, and only the first
+ * kind can become an install.
+ */
+export type StoreRedirectTarget = "android" | "ios" | "web";
 
 /**
  * A feature the app advertises before it exists, so demand can be measured
@@ -498,6 +512,29 @@ export type ServerEventProperties = {
     referredByUserId: string | null;
     referredDogId: string | null;
   };
+  /**
+   * One hit on `/store`, the printable link that forwards a visitor into the
+   * App Store or Play Store with the campaign attached.
+   *
+   * Captured server side because the redirect is the entire response: there is
+   * no page for a browser event to fire from. Every property except `store` is
+   * read off the query string and is null when the link carried nothing, which
+   * is most of them, so a breakdown by `ref` reads the channels that were
+   * tagged rather than inventing a bucket for the ones that were not.
+   *
+   * `dogId` keeps its camelCase spelling. It is the key `/store` has always
+   * sent and the same one "Referral Captured" and "Signup Attributed" use, and
+   * a share link that spells it one way and the signup it produced another way
+   * is a funnel nobody can join.
+   */
+  [ANALYTICS_EVENTS.STORE_REDIRECT]: {
+    dogId: string | null;
+    ref: string | null;
+    store: StoreRedirectTarget;
+    utm_campaign: string | null;
+    utm_medium: string | null;
+    utm_source: string | null;
+  };
   [ANALYTICS_EVENTS.SUBSCRIPTION_EVENT]: {
     cancel_reason?: SubscriptionCancelReason | null;
     currency?: string | null;
@@ -644,6 +681,7 @@ export const SERVER_EVENT_NAMES = [
   ANALYTICS_EVENTS.PUSH_TICKET_RESULT,
   ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT,
   ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED,
+  ANALYTICS_EVENTS.STORE_REDIRECT,
   ANALYTICS_EVENTS.SUBSCRIPTION_EVENT,
 ] as const;
 

--- a/scripts/metrics/events-audit-queries.mjs
+++ b/scripts/metrics/events-audit-queries.mjs
@@ -185,3 +185,60 @@ export function resolveFunnelEvents(seenEvents, targets = FUNNEL_TARGETS) {
     return { name: alias ?? target.name, target: target.name };
   });
 }
+
+/** How many exception groups the audit prints before it stops. */
+export const MAX_EXCEPTION_GROUPS = 15;
+
+/**
+ * How much of an exception message survives into the table.
+ *
+ * Long enough to tell two failures of the same type apart, short enough that a
+ * stack trace pasted into the message does not push every other column off the
+ * side of the comment.
+ */
+export const EXCEPTION_MESSAGE_LENGTH = 120;
+
+/**
+ * The busiest exception groups in the window, one row per type and message.
+ *
+ * `$exception` is the only autocapture event that is a bug report rather than a
+ * measurement, and it arrives from both the app and the API, so the group alone
+ * does not say who is broken. `libs` and `app_versions` are collected inside the
+ * group instead of being grouped on: splitting a single failure across a row per
+ * library would push the real leader down the table and hide that the same
+ * exception is happening in two places.
+ *
+ * The message is truncated in ClickHouse rather than in the renderer so the
+ * grouping itself is on the truncated value. Two exceptions that differ only in
+ * a trailing id are one fault, and counting them apart is how a fault that is
+ * happening constantly reads as fifteen rare ones.
+ *
+ * `$exception_type` and `$exception_message` are what PostHog's error tracking
+ * writes. A client that sent an exception without them lands in `unknown`,
+ * which is a group worth seeing rather than a row worth dropping.
+ */
+export function buildExceptionGroupsQuery(
+  window,
+  limit = MAX_EXCEPTION_GROUPS,
+) {
+  const lib = `ifNull(nullIf(toString(properties.$lib), ''), 'unknown')`;
+  const version = `ifNull(nullIf(toString(properties.${APP_VERSION_PROPERTY}), ''), 'unknown')`;
+  const type = `ifNull(nullIf(toString(properties.$exception_type), ''), 'unknown')`;
+  const message = `ifNull(nullIf(toString(properties.$exception_message), ''), 'unknown')`;
+  const clientLibs = CLIENT_LIBS.map(quote).join(", ");
+  return [
+    "SELECT",
+    `  ${type} AS exception_type,`,
+    `  substring(${message}, 1, ${EXCEPTION_MESSAGE_LENGTH}) AS message,`,
+    "  count() AS total,",
+    "  count(DISTINCT person_id) AS people,",
+    `  arrayStringConcat(arraySort(groupUniqArray(${lib})), ', ') AS libs,`,
+    `  arrayStringConcat(arraySort(groupUniqArrayIf(${version}, ${lib} IN (${clientLibs}))), ', ') AS app_versions`,
+    "FROM events",
+    `WHERE ${windowFilter(window)}`,
+    "  AND event = '$exception'",
+    "GROUP BY exception_type, message",
+    "ORDER BY total DESC, exception_type, message",
+    `LIMIT ${limit}`,
+  ].join("\n");
+}

--- a/scripts/metrics/events-audit-queries.test.mjs
+++ b/scripts/metrics/events-audit-queries.test.mjs
@@ -4,12 +4,15 @@ import { test } from "node:test";
 import {
   AUDIT_WINDOW_DAYS,
   CLIENT_LIBS,
+  EXCEPTION_MESSAGE_LENGTH,
   FUNNEL_TARGETS,
   LIB_BUCKETS,
+  MAX_EXCEPTION_GROUPS,
   MAX_ROWS,
   buildAuditWindow,
   buildEventSplitQuery,
   buildEventTotalsQuery,
+  buildExceptionGroupsQuery,
   buildPropertyKeysQuery,
   quote,
   resolveFunnelEvents,
@@ -127,4 +130,44 @@ test("every query states its own row limit", () => {
   ]) {
     assert.match(query, new RegExp(`LIMIT ${MAX_ROWS}$`));
   }
+});
+
+test("the exception query asks for fifteen groups of type and message", () => {
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+  assert.equal(MAX_EXCEPTION_GROUPS, 15);
+  assert.match(query, /AND event = '\$exception'/);
+  assert.match(query, /GROUP BY exception_type, message/);
+  assert.match(query, /ORDER BY total DESC, exception_type, message/);
+  assert.match(query, new RegExp(`LIMIT ${MAX_EXCEPTION_GROUPS}$`));
+});
+
+test("the exception query truncates the message before grouping on it", () => {
+  // Truncating in the renderer instead would group on the full message, and
+  // one fault whose message ends in an id would fill the whole table.
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+  assert.equal(EXCEPTION_MESSAGE_LENGTH, 120);
+  assert.match(
+    query,
+    new RegExp(`substring\\(.+, 1, ${EXCEPTION_MESSAGE_LENGTH}\\) AS message`),
+  );
+  assert.equal(query.indexOf("substring(") < query.indexOf("GROUP BY"), true);
+});
+
+test("the exception query keeps the libraries and versions inside the group", () => {
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+  assert.match(query, /groupUniqArray\(.+\$lib.+\) AS libs/);
+  assert.match(query, /groupUniqArrayIf\(.+\) AS app_versions/);
+  for (const lib of CLIENT_LIBS) {
+    assert.ok(query.includes(quote(lib)));
+  }
+  assert.equal(query.includes("GROUP BY exception_type, message, lib"), false);
+});
+
+test("the exception query stays inside its own seven days", () => {
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+  assert.match(
+    query,
+    /timestamp >= toDateTime\('2026-08-28 12:00:00', 'UTC'\)/,
+  );
+  assert.match(query, /timestamp < toDateTime\('2026-09-04 12:00:00', 'UTC'\)/);
 });

--- a/scripts/metrics/events-audit-report.mjs
+++ b/scripts/metrics/events-audit-report.mjs
@@ -6,7 +6,11 @@
  * comment instead of leaving a second one on the tracking issue.
  */
 
-import { LIB_BUCKETS } from "./events-audit-queries.mjs";
+import {
+  EXCEPTION_MESSAGE_LENGTH,
+  LIB_BUCKETS,
+  MAX_EXCEPTION_GROUPS,
+} from "./events-audit-queries.mjs";
 
 export const COMMENT_MARKER = "<!-- pegada-events-audit -->";
 
@@ -392,9 +396,95 @@ function propertySection(summary, funnelEvents) {
   ].join("\n");
 }
 
+/**
+ * `$lib` in the words the readout uses everywhere else.
+ *
+ * The raw values are SDK names, and an exception table is read by whoever is
+ * about to go and fix it: "mobile" and "server" say which half of the codebase
+ * to open, "posthog-node" does not. Anything unmapped is passed through as it
+ * arrived rather than swept into a bucket, since a `$lib` nobody recognises on
+ * a crash is itself the finding.
+ */
+const LIB_LABELS = {
+  "posthog-node": "server",
+  "posthog-react-native": "mobile",
+  web: "web",
+};
+
+function libLabel(libs) {
+  const values = String(libs ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (values.length === 0) {
+    return "unknown";
+  }
+  return [...new Set(values.map((value) => LIB_LABELS[value] ?? value))].join(
+    ", ",
+  );
+}
+
+/**
+ * Text in a table cell, as a code span that the text cannot break out of.
+ *
+ * Exception messages arrive with whatever the thrower put in them: pipes, which
+ * end a cell, newlines, which end a row, and backticks, which end a code span.
+ * The fence grows past the longest run of backticks in the content, which is
+ * what CommonMark asks for, and a value that starts or ends with one is padded
+ * so the fence is still readable.
+ */
+export function codeCell(value) {
+  const text = String(value ?? "")
+    .replaceAll(/\s+/gu, " ")
+    .trim();
+  if (text === "") {
+    return "";
+  }
+  const escaped = text.replaceAll("|", String.raw`\|`);
+  const longest = Math.max(
+    0,
+    ...[...escaped.matchAll(/`+/gu)].map((match) => match[0].length),
+  );
+  const fence = "`".repeat(longest + 1);
+  const pad = escaped.startsWith("`") || escaped.endsWith("`") ? " " : "";
+  return `${fence}${pad}${escaped}${pad}${fence}`;
+}
+
+/**
+ * The exception table.
+ *
+ * Last on purpose: everything above it is about whether the instrumentation is
+ * telling the truth, and this is the one section about whether the product is
+ * working. Grouped by type and message rather than listed one by one, because
+ * the number that matters is how many people a single fault reached, and that
+ * is the column a fix gets prioritised on.
+ */
+function exceptionSection(exceptions) {
+  const rows = exceptions.map((row) => [
+    codeCell(row.exception_type),
+    codeCell(row.message),
+    number(row.total),
+    number(row.people),
+    libLabel(row.libs),
+    codeCell(row.app_versions) || "n/a",
+  ]);
+  return [
+    "### 5. Exceptions",
+    "",
+    `The ${number(MAX_EXCEPTION_GROUPS)} busiest \`$exception\` groups in the window, by exception type and message. Messages are cut at ${number(EXCEPTION_MESSAGE_LENGTH)} characters, and the grouping is on the cut value, so two failures that differ only in a trailing id count as one. App version is the build the phone was running, and \`n/a\` on anything the server threw.`,
+    "",
+    table(
+      ["Type", "Message", "Events", "People", "Library", "App version"],
+      rows,
+      "No exceptions in the window.",
+    ),
+  ].join("\n");
+}
+
 /** The whole comment body. */
 export function buildReport({
   catalogue,
+  exceptions = [],
   funnelEvents,
   generatedAt,
   propertyKeys,
@@ -427,5 +517,7 @@ export function buildReport({
     coverageSection(summary),
     "",
     propertySection(summary, funnelEvents),
+    "",
+    exceptionSection(exceptions),
   ].join("\n");
 }

--- a/scripts/metrics/events-audit-report.test.mjs
+++ b/scripts/metrics/events-audit-report.test.mjs
@@ -5,6 +5,7 @@ import {
   COMMENT_MARKER,
   buildFindings,
   buildReport,
+  codeCell,
   summarise,
 } from "./events-audit-report.mjs";
 
@@ -184,6 +185,47 @@ export const PROPERTY_KEYS = [
   { event: "Reengagement Push Sent", key: "kind", total: 80 },
 ];
 
+/**
+ * Exception groups, one of each shape the table has to survive: an app crash
+ * with a version behind it, a server throw with none, a message carrying the
+ * two characters that break a markdown table, and a client that sent no type
+ * at all.
+ */
+export const EXCEPTIONS = [
+  {
+    app_versions: "1.6.2, 1.7.2",
+    exception_type: "TypeError",
+    libs: "posthog-react-native",
+    message: "undefined is not an object (evaluating 'dog.photos[0].url')",
+    people: 14,
+    total: 31,
+  },
+  {
+    app_versions: "",
+    exception_type: "PrismaClientKnownRequestError",
+    libs: "posthog-node",
+    message: "Timed out fetching a new connection from the connection pool",
+    people: 6,
+    total: 12,
+  },
+  {
+    app_versions: "1.6.2",
+    exception_type: "Error",
+    libs: "posthog-node, posthog-react-native",
+    message: "Request failed | GET /api/trpc/dog.list\nstatus `500`",
+    people: 3,
+    total: 5,
+  },
+  {
+    app_versions: "unknown",
+    exception_type: "",
+    libs: "",
+    message: "",
+    people: 1,
+    total: 1,
+  },
+];
+
 export const FUNNEL_EVENTS = [
   { name: "Paywall Viewed", target: "Paywall Viewed" },
   { name: "Swipe", target: "Swipe" },
@@ -195,6 +237,7 @@ export const FUNNEL_EVENTS = [
 
 export const FIXTURE = {
   catalogue: CATALOGUE,
+  exceptions: EXCEPTIONS,
   funnelEvents: FUNNEL_EVENTS,
   generatedAt: new Date("2026-09-04T12:03:00.000Z"),
   propertyKeys: PROPERTY_KEYS,
@@ -328,7 +371,7 @@ test("a clean window says so instead of printing an empty list", () => {
   assert.deepEqual(findings, ["Nothing to flag in this window."]);
 });
 
-test("the body carries the marker and all four sections", () => {
+test("the body carries the marker and every section", () => {
   const body = buildReport(FIXTURE);
   assert.ok(body.startsWith(COMMENT_MARKER));
   assert.match(body, /## Events audit/);
@@ -336,6 +379,7 @@ test("the body carries the marker and all four sections", () => {
   assert.match(body, /### 1\. Every event seen/);
   assert.match(body, /### 2\. Catalogue coverage/);
   assert.match(body, /### 3\. Property sanity on the funnel events/);
+  assert.match(body, /### 5\. Exceptions/);
   assert.match(
     body,
     /Seven days, 2026-08-28 12:00 UTC to 2026-09-04 12:00 UTC/,
@@ -404,5 +448,61 @@ test("an event the property query never covered is not called incomplete", () =>
   assert.equal(
     findings.some((line) => line.includes("is missing required properties")),
     false,
+  );
+});
+
+test("the exception table reports counts, library and app version", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(
+    body,
+    /\| Type \| Message \| Events \| People \| Library \| App version \|/,
+  );
+  assert.match(
+    body,
+    /\| `TypeError` \| `undefined is not an object \(evaluating 'dog\.photos\[0\]\.url'\)` \| 31 \| 14 \| mobile \| `1\.6\.2, 1\.7\.2` \|/,
+  );
+});
+
+test("a server exception is labelled server and has no app version", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(
+    body,
+    /\| `PrismaClientKnownRequestError` \| .+ \| 12 \| 6 \| server \| n\/a \|/,
+  );
+});
+
+test("an exception seen from both sides names both", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(body, /\| 5 \| 3 \| server, mobile \| `1\.6\.2` \|/);
+});
+
+test("a message cannot break the row it sits in", () => {
+  const body = buildReport(FIXTURE);
+  const row = body.split("\n").find((line) => line.includes("Request failed"));
+  // Six columns means seven pipes. A raw pipe or a newline in the message
+  // would silently shift every column after it.
+  assert.equal(row.split(/(?<!\\)\|/u).length - 1, 7);
+  assert.equal(row.includes("\n"), false);
+  assert.match(row, /Request failed \\\| GET/);
+});
+
+test("a code cell survives backticks, pipes and blank values", () => {
+  assert.equal(codeCell("plain"), "`plain`");
+  assert.equal(codeCell("a | b"), "`a \\| b`");
+  assert.equal(codeCell("`quoted`"), "`` `quoted` ``");
+  assert.equal(codeCell(""), "");
+  assert.equal(codeCell(null), "");
+});
+
+test("an exception with nothing on it still gets a row", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(body, /\| 1 \| 1 \| unknown \| `unknown` \|/);
+});
+
+test("no exceptions in the window says so", () => {
+  const body = buildReport({ ...FIXTURE, exceptions: [] });
+  assert.match(
+    body,
+    /### 5\. Exceptions\n\n.+\n\nNo exceptions in the window\./s,
   );
 });

--- a/scripts/metrics/events-audit.mjs
+++ b/scripts/metrics/events-audit.mjs
@@ -20,6 +20,7 @@ import {
   buildAuditWindow,
   buildEventSplitQuery,
   buildEventTotalsQuery,
+  buildExceptionGroupsQuery,
   buildPropertyKeysQuery,
   resolveFunnelEvents,
 } from "./events-audit-queries.mjs";
@@ -43,8 +44,9 @@ function requireEnv(env, name) {
  * Runs the queries, renders the comment, and either posts it or returns it.
  *
  * Two round trips rather than one: the property query can only name the funnel
- * events once the first pair has said which names PostHog actually holds, so a
- * renamed event is audited under the name it is really sent under.
+ * events once the first round has said which names PostHog actually holds, so a
+ * renamed event is audited under the name it is really sent under. The
+ * exception query depends on nothing, so it goes out with that first round.
  */
 export async function runEventsAudit({
   argv = [],
@@ -64,9 +66,13 @@ export async function runEventsAudit({
   const run = (name, query) =>
     queryHogql({ apiKey, fetchImpl, host, name, projectId, query });
 
-  const [totals, splits] = await Promise.all([
+  const [totals, splits, exceptions] = await Promise.all([
     run("pegada events audit: event totals", buildEventTotalsQuery(window)),
     run("pegada events audit: event split", buildEventSplitQuery(window)),
+    run(
+      "pegada events audit: exception groups",
+      buildExceptionGroupsQuery(window),
+    ),
   ]);
 
   const funnelEvents = resolveFunnelEvents(totals.map((row) => row.event));
@@ -78,6 +84,7 @@ export async function runEventsAudit({
 
   const body = buildReport({
     catalogue,
+    exceptions,
     funnelEvents,
     generatedAt: now,
     propertyKeys,

--- a/scripts/metrics/events-audit.test.mjs
+++ b/scripts/metrics/events-audit.test.mjs
@@ -65,6 +65,28 @@ function fakeWorld({ existingComment = null, swipeName = "Swipe" } = {}) {
           ],
         });
       }
+      if (body.name.endsWith("exception groups")) {
+        return json({
+          columns: [
+            "exception_type",
+            "message",
+            "total",
+            "people",
+            "libs",
+            "app_versions",
+          ],
+          results: [
+            [
+              "TypeError",
+              "undefined is not an object",
+              6,
+              4,
+              "posthog-react-native",
+              "1.6.2",
+            ],
+          ],
+        });
+      }
       if (body.name.endsWith("event split")) {
         return json({
           columns: ["event", "lib", "app_version", "total"],
@@ -110,10 +132,32 @@ test("a dry run prints the body and never touches GitHub", async () => {
   assert.equal(result.action, "printed");
   assert.match(result.body, /### 1\. Every event seen/);
   assert.match(result.body, /`source` on 9\.5%/);
+  assert.match(result.body, /### 5\. Exceptions/);
+  assert.match(
+    result.body,
+    /\| `TypeError` \| `undefined is not an object` \| 6 \| 4 \| mobile \| `1\.6\.2` \|/,
+  );
   assert.equal(
     fetchImpl.calls.some((call) => !isPostHog(call.url)),
     false,
   );
+});
+
+test("the exception query goes out with the first round", async () => {
+  const fetchImpl = fakeWorld();
+  await runEventsAudit({
+    argv: ["--dry-run"],
+    catalogue: CATALOGUE,
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  const exceptionQuery = fetchImpl.calls.find((call) =>
+    call.body.name.endsWith("exception groups"),
+  ).body.query.query;
+  assert.match(exceptionQuery, /AND event = '\$exception'/);
+  assert.match(exceptionQuery, /LIMIT 15/);
 });
 
 test("the property query only runs once the event names are known", async () => {
@@ -127,10 +171,10 @@ test("the property query only runs once the event names are known", async () => 
   });
 
   const queries = fetchImpl.calls.map((call) => call.body.query.query);
-  assert.equal(queries.length, 3);
-  assert.match(queries[2], /arrayJoin\(JSONExtractKeys\(properties\)\)/);
-  assert.match(queries[2], /'Paywall Viewed'/);
-  assert.match(queries[2], /'Swipe'/);
+  assert.equal(queries.length, 4);
+  assert.match(queries[3], /arrayJoin\(JSONExtractKeys\(properties\)\)/);
+  assert.match(queries[3], /'Paywall Viewed'/);
+  assert.match(queries[3], /'Swipe'/);
 });
 
 test("a funnel event sent under another name is audited under that name", async () => {
@@ -143,7 +187,7 @@ test("a funnel event sent under another name is audited under that name", async 
     now: NOW,
   });
 
-  const propertyQuery = fetchImpl.calls[2].body.query.query;
+  const propertyQuery = fetchImpl.calls[3].body.query.query;
   assert.match(propertyQuery, /'Swiped'/);
   assert.match(result.body, /`Swipe` is sent as `Swiped`/);
   assert.match(result.body, /#### `Swipe`, sent as `Swiped`/);

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -70,28 +70,31 @@ export const SERVER_EVENTS = [
  * The build most people are actually running, and the readout events it has no
  * code to send.
  *
- * Checked against the app at tag v1.6.2. The list is only client events: the
- * API emits `Message Sent`, `Reengagement Push Sent`, `Push Ticket Result` and
- * the rest of `SERVER_EVENTS` from the deployed server, so those rows are real
- * whatever build a person is on. `Create Dog Profile`, `New Match` and
- * `Upgrade` do exist in 1.6.2, which is why they are not here.
+ * Checked against the live events audit on issue #188, not against the v1.6.2
+ * tag. `runtimeVersion` follows `appVersion`, so a phone reporting
+ * `$app_version` 1.6.2 runs whatever JavaScript was last published to the 1.6.2
+ * runtime, which is the backport branch rather than the tag. Reading the tag is
+ * what put `Swipe`, `Paywall Viewed` and `Empty Deck Shown` on this list while
+ * PostHog was receiving all three from 1.6.2 phones, and a coverage note that
+ * excuses a live row is worse than no note: it explains away the number someone
+ * needed to act on.
  *
- * `Swipe` covers both the swipe count and the distinct swiper count, since one
- * missing event empties both rows.
+ * The list is only client events: the API emits `Message Sent`,
+ * `Reengagement Push Sent`, `Push Ticket Result` and the rest of
+ * `SERVER_EVENTS` from the deployed server, so those rows are real whatever
+ * build a person is on.
  *
- * Keep this in step with what is in the store, not with what is on main. The
- * point of the note is to stop a reach gap from reading as a dead product.
+ * Keep this in step with what the audit sees from 1.6.2, not with what is on
+ * main. The point of the note is to stop a reach gap from reading as a dead
+ * product, and it only works while every name on it is a genuine gap.
  */
 export const STORE_BUILD_COVERAGE = {
   missingEvents: [
-    EVENTS.EMPTY_DECK_SHOWN,
     EVENTS.FAKE_DOOR_TAPPED,
-    EVENTS.PAYWALL_VIEWED,
     EVENTS.PUSH_NOTIFICATION_OPENED,
     EVENTS.SHARE_COMPLETED,
     EVENTS.SHARE_PROMPT_TAPPED,
     EVENTS.SHARE_TAPPED,
-    EVENTS.SWIPE,
   ],
   version: "1.6.2",
 };

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -230,10 +230,17 @@ test("the coverage list holds real event names and no server event", () => {
   assert.ok(STORE_BUILD_COVERAGE.missingEvents.length > 0);
 });
 
+// Every name here has arrived from an `$app_version` of 1.6.2 in the events
+// audit on issue #188. Excusing one of them in the coverage note would tell a
+// reader that a row is zero for reach reasons when it is really zero because
+// nobody did the thing.
 test("the coverage list leaves out the events the store build does send", () => {
   for (const event of [
     EVENTS.CREATE_DOG_PROFILE,
+    EVENTS.EMPTY_DECK_SHOWN,
     EVENTS.NEW_MATCH,
+    EVENTS.PAYWALL_VIEWED,
+    EVENTS.SWIPE,
     EVENTS.UPGRADE,
   ]) {
     assert.equal(STORE_BUILD_COVERAGE.missingEvents.includes(event), false);

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -344,6 +344,17 @@ test("the coverage note lists every event the store build cannot send", () => {
   }
 });
 
+test("the coverage note does not excuse an event 1.6.2 is really sending", () => {
+  const note = coverageNote();
+  for (const event of ["Swipe", "Paywall Viewed", "Empty Deck Shown"]) {
+    assert.equal(
+      note.includes(event),
+      false,
+      `${event} arrives from 1.6.2, so the note must not blame the build`,
+    );
+  }
+});
+
 test("the coverage note says so plainly once the store build sends everything", () => {
   const note = coverageNote({ missingEvents: [], version: "1.8.0" });
   assert.match(note, /build 1\.8\.0 emits every event in this readout/);


### PR DESCRIPTION
## Summary

The daily readout was blaming the store build for three events the store build sends, and the events audit could not see the one server event nobody had catalogued. This corrects both and adds an exceptions table to the audit.

## Details

- The coverage note in the daily readout listed `Swipe`, `Paywall Viewed` and `Empty Deck Shown` as events build 1.6.2 cannot send. The live audit on issue #188 has all three arriving from 1.6.2 phones in the last seven days: 879, 9 and 27 events. The list was checked against the v1.6.2 tag, but the runtime version policy is the app version, so a 1.6.2 phone runs whatever JavaScript was last published to the 1.6.2 runtime rather than the tag. The note now names only the five events that really are missing: `Fake Door Tapped`, `Push Notification Opened`, `Share Completed`, `Share Prompt Tapped`, `Share Tapped`.
- Why it matters: the note is read as permission to ignore a zero. Excusing `Swipe` would have hidden the swipe count, which is the busiest event the product has.
- `Store Redirect` is now in the typed catalogue as a server event with the six properties the `/store` route actually captures, and the route sends the catalogue constant with a `satisfies` check so the payload and the entry cannot drift. The audit reported it as the only event name in PostHog nobody could account for.
- New section 5 of the events audit: the fifteen busiest `$exception` groups in the window, by exception type and message, with events, people, whether it came from mobile or the server, and the app version behind it. Messages are cut at 120 characters in ClickHouse so the grouping happens on the cut value, which keeps one fault whose message ends in an id from filling the table.
- The message is rendered into a code span the message cannot break out of, so a pipe, a newline or a backtick in an exception cannot shift the columns of the comment.
- One extra HogQL query, sent in the same round as the two that already run, so the audit is no slower.

## Testing steps

1. Open the daily readout comment on issue #188 and read the coverage note under the push table. It should name five events, and none of them should be swipes, the paywall or the empty deck.
2. Open the events audit comment on the same issue. There should be a new exceptions section at the end, listing the most common errors of the last seven days with how many people each one reached.
3. Check that the audit no longer says an event name is missing from the catalogue.

## Screenshots

The new section, rendered from the test fixture:

```markdown
### 5. Exceptions

The 15 busiest `$exception` groups in the window, by exception type and message. Messages are cut at 120 characters, and the grouping is on the cut value, so two failures that differ only in a trailing id count as one. App version is the build the phone was running, and `n/a` on anything the server threw.

| Type | Message | Events | People | Library | App version |
| --- | --- | --- | --- | --- | --- |
| `TypeError` | `undefined is not an object (evaluating 'dog.photos[0].url')` | 31 | 14 | mobile | `1.6.2, 1.7.2` |
| `PrismaClientKnownRequestError` | `Timed out fetching a new connection from the connection pool` | 12 | 6 | server | n/a |
| `Error` | `` Request failed \| GET /api/trpc/dog.list status `500` `` | 5 | 3 | server, mobile | `1.6.2` |
```

And the corrected coverage note:

```markdown
Coverage note: the store build 1.6.2 cannot emit Fake Door Tapped, Push Notification Opened, Share Completed, Share Prompt Tapped, Share Tapped, so those rows read zero for anyone still on it. They measure reach, not the product.
```
