### PR TITLE
feat(api): refill short decks with fallback tiers and a Deck Served event

### DIFF
--- a/packages/api/src/dtos/dog-dto.ts
+++ b/packages/api/src/dtos/dog-dto.ts
@@ -11,6 +11,22 @@ const breedSchema = z
   })
   .nullable();
 
+/**
+ * Where a dog in the deck came from.
+ *
+ * `primary` is the deck as the person's preferences describe it. The rest are
+ * refills, used only when the primary comes back short, and each one names the
+ * single thing it relaxed so the app can say so on the card.
+ */
+export const DECK_TIERS = [
+  "primary",
+  "beyond_radius",
+  "same_gender",
+  "recycled_pass",
+] as const;
+
+export type DeckTier = (typeof DECK_TIERS)[number];
+
 const dogImageSchema = z.object({
   id: z.string(),
   url: z.string(),
@@ -25,6 +41,8 @@ export const dogSafeSchema = z
     breed: breedSchema,
     birthDate: z.date().nullable(),
     color: z.string().nullable(),
+    // Optional so a build that predates the refill tiers still parses a deck.
+    deckTier: z.enum(DECK_TIERS).optional(),
     gender: z.string(),
     distance: z.number().nullable(),
     images: z.array(dogImageSchema),

--- a/packages/api/src/services/SuggestionService/suggestion-service.test.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.test.ts
@@ -2,11 +2,13 @@ import { faker } from "@faker-js/faker";
 import prisma from "@pegada/database";
 import { breedData } from "@pegada/database/fixtures/breed-data";
 import { generateFakeUserWithDog } from "@pegada/database/fixtures/generate-fake-user-with-dog";
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
 import { Color, Dog, Gender, PlanType, Size, SwipeType } from "@prisma/client";
 import { z } from "zod";
 
 import { dogSafeSchema } from "../../dtos/dog-dto";
+import { observability } from "../../shared/observability";
 import { SwipeService } from "../swipe-service";
 import { SuggestionService } from "./suggestion-service";
 
@@ -37,6 +39,34 @@ const smallInt = () => faker.number.int({ min: 1, max: 10 });
 
 const LIMIT = 10;
 
+const capture = observability.capture as unknown as jest.Mock;
+
+const daysAgo = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+/**
+ * Backdates a pass. `updatedAt` is `@updatedAt`, so writing it through the
+ * client would just stamp it with now again.
+ */
+const backdatePass = (requesterId: string, responderId: string, at: Date) =>
+  prisma.$executeRaw`UPDATE "Interest" SET "updatedAt" = ${at} WHERE "requesterId" = ${requesterId} AND "responderId" = ${responderId}`;
+
+/** The last Deck Served event, minus the distinct id every capture carries. */
+const lastDeckServed = () => {
+  const call = [...capture.mock.calls]
+    .reverse()
+    .find(([event]) => event === ANALYTICS_EVENTS.DECK_SERVED);
+
+  if (!call) return null;
+
+  const { distinctId: _distinctId, ...properties } = call[1] as Record<
+    string,
+    unknown
+  >;
+
+  return properties;
+};
+
 beforeAll(async () => {
   // Seed the database
   await prisma.breed.deleteMany();
@@ -44,6 +74,7 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
+  capture.mockClear();
   await prisma.image.deleteMany();
   await prisma.message.deleteMany();
   await prisma.match.deleteMany();
@@ -349,9 +380,17 @@ describe("SuggestionService", () => {
           [],
         );
 
-        expect(potentialMatches).toHaveLength(1);
+        const primary = potentialMatches.filter(
+          (match) => match.deckTier === "primary",
+        );
 
-        expect(potentialMatches[0]?.gender).toEqual(Gender.MALE);
+        expect(primary).toHaveLength(1);
+        expect(primary[0]?.gender).toEqual(Gender.MALE);
+
+        // The same gender dog is only ever a refill, never part of the deck
+        // the preference describes.
+        expect(potentialMatches[1]?.gender).toEqual(Gender.FEMALE);
+        expect(potentialMatches[1]?.deckTier).toEqual("same_gender");
       });
 
       test("size", async () => {
@@ -487,8 +526,12 @@ describe("SuggestionService", () => {
           [],
         );
 
-        expect(potentialMatches).toHaveLength(1);
-        expect(potentialMatches[0]!.id).toEqual(nearDog.id);
+        const primary = potentialMatches.filter(
+          (match) => match.deckTier === "primary",
+        );
+
+        expect(primary).toHaveLength(1);
+        expect(primary[0]!.id).toEqual(nearDog.id);
       });
       test("breed", async () => {
         const preferredBreedId = faker.helpers.arrayElement(breedData).id!;
@@ -648,6 +691,320 @@ describe("SuggestionService", () => {
 
         expect(potentialMatches).toHaveLength(1);
         expect(potentialMatches[0]!.images).toHaveLength(1);
+      });
+    });
+
+    describe("Refill", () => {
+      test("a full primary deck is never topped up", async () => {
+        const { dog } = await generateFakeUserWithDog({ gender: Gender.MALE });
+
+        await Promise.all([
+          ...Array.from({ length: LIMIT }).map(() =>
+            generateFakeUserWithDog({ gender: Gender.FEMALE }),
+          ),
+          ...Array.from({ length: 3 }).map(() =>
+            generateFakeUserWithDog({ gender: Gender.MALE }),
+          ),
+        ]);
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        expect(potentialMatches).toHaveLength(LIMIT);
+        expect(
+          potentialMatches.every((match) => match.deckTier === "primary"),
+        ).toBe(true);
+      });
+
+      test("a short primary deck is filled with same gender dogs, last", async () => {
+        const [{ dog }, { dog: oppositeDog }] = await Promise.all([
+          generateFakeUserWithDog({ gender: Gender.MALE }),
+          generateFakeUserWithDog({ gender: Gender.FEMALE }),
+          generateFakeUserWithDog({ gender: Gender.MALE }),
+          generateFakeUserWithDog({ gender: Gender.MALE }),
+        ]);
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        expect(potentialMatches).toHaveLength(3);
+        expect(potentialMatches[0]!.id).toEqual(oppositeDog.id);
+        expect(potentialMatches.map((match) => match.deckTier)).toEqual([
+          "primary",
+          "same_gender",
+          "same_gender",
+        ]);
+      });
+
+      test("dogs beyond the radius come after the ones inside it", async () => {
+        const [{ dog }, { dog: nearDog }, { dog: farDog }] = await Promise.all([
+          generateFakeUserWithDog(
+            { gender: Gender.MALE, preferredMaxDistance: 10 },
+            { latitude: 0, longitude: 0 },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.05, longitude: 0.05 }, // roughly 8 km away
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.2, longitude: 0.2 }, // roughly 31 km away
+          ),
+        ]);
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        expect(potentialMatches.map((match) => match.id)).toEqual([
+          nearDog.id,
+          farDog.id,
+        ]);
+        expect(potentialMatches.map((match) => match.deckTier)).toEqual([
+          "primary",
+          "beyond_radius",
+        ]);
+        expect(potentialMatches[1]!.distance).toBeGreaterThan(10);
+      });
+
+      test("no dog is served twice across the tiers", async () => {
+        const [{ dog }] = await Promise.all([
+          generateFakeUserWithDog(
+            { gender: Gender.MALE, preferredMaxDistance: 10 },
+            { latitude: 0, longitude: 0 },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.05, longitude: 0.05 },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.2, longitude: 0.2 },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.MALE },
+            { latitude: 0.05, longitude: 0.05 },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.MALE },
+            { latitude: 0.2, longitude: 0.2 },
+          ),
+        ]);
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        const ids = potentialMatches.map((match) => match.id);
+
+        // The male dog outside the radius is the one nothing reaches: the
+        // radius is only dropped for the opposite gender tier.
+        expect(ids).toHaveLength(3);
+        expect(new Set(ids).size).toEqual(ids.length);
+        expect(potentialMatches.map((match) => match.deckTier)).toEqual([
+          "primary",
+          "beyond_radius",
+          "same_gender",
+        ]);
+      });
+
+      test("a recent pass stays out of the deck", async () => {
+        const [{ dog }, { dog: passedDog }] = await Promise.all([
+          generateFakeUserWithDog({ gender: Gender.MALE }),
+          generateFakeUserWithDog({ gender: Gender.FEMALE }),
+        ]);
+
+        await SwipeService.createOrUpdateInterest(
+          dog.id,
+          passedDog.id,
+          SwipeType.NOT_INTERESTED,
+        );
+        await backdatePass(dog.id, passedDog.id, daysAgo(13));
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        expect(potentialMatches).toHaveLength(0);
+      });
+
+      test("an old pass comes back, tagged and at the end", async () => {
+        const [{ dog }, { dog: passedDog }, { dog: freshDog }] =
+          await Promise.all([
+            generateFakeUserWithDog(
+              { gender: Gender.MALE },
+              { latitude: 0, longitude: 0 },
+            ),
+            generateFakeUserWithDog(
+              { gender: Gender.FEMALE },
+              { latitude: 0, longitude: 0 }, // co-located, so distance cannot be why it is last
+            ),
+            generateFakeUserWithDog(
+              { gender: Gender.FEMALE },
+              { latitude: 5, longitude: 5 },
+            ),
+          ]);
+
+        await SwipeService.createOrUpdateInterest(
+          dog.id,
+          passedDog.id,
+          SwipeType.NOT_INTERESTED,
+        );
+        await backdatePass(dog.id, passedDog.id, daysAgo(15));
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        expect(potentialMatches.map((match) => match.id)).toEqual([
+          freshDog.id,
+          passedDog.id,
+        ]);
+        expect(potentialMatches[1]!.deckTier).toEqual("recycled_pass");
+      });
+
+      test("a like is never recycled", async () => {
+        const [{ dog }, { dog: likedDog }] = await Promise.all([
+          generateFakeUserWithDog({ gender: Gender.MALE }),
+          generateFakeUserWithDog({ gender: Gender.FEMALE }),
+        ]);
+
+        await SwipeService.createOrUpdateInterest(
+          dog.id,
+          likedDog.id,
+          SwipeType.INTERESTED,
+        );
+        await backdatePass(dog.id, likedDog.id, daysAgo(400));
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        expect(potentialMatches).toHaveLength(0);
+      });
+
+      test("an active owner outranks a dormant one at the same distance", async () => {
+        const [{ dog }, { dog: dormantDog }, { dog: activeDog }] =
+          await Promise.all([
+            generateFakeUserWithDog(
+              { gender: Gender.MALE },
+              { latitude: 0, longitude: 0 },
+            ),
+            generateFakeUserWithDog(
+              { gender: Gender.FEMALE },
+              { latitude: 0, longitude: 0, lastActiveAt: daysAgo(90) },
+            ),
+            generateFakeUserWithDog(
+              { gender: Gender.FEMALE },
+              { latitude: 0, longitude: 0, lastActiveAt: daysAgo(1) },
+            ),
+          ]);
+
+        const potentialMatches = await SuggestionService.getPotentialMatches(
+          dog,
+          LIMIT,
+          [],
+        );
+
+        expect(potentialMatches.map((match) => match.id)).toEqual([
+          activeDog.id,
+          dormantDog.id,
+        ]);
+      });
+    });
+
+    describe("Deck Served", () => {
+      test("reports the tier split and the supply around the swiper", async () => {
+        const [{ dog }] = await Promise.all([
+          generateFakeUserWithDog(
+            { gender: Gender.MALE },
+            { latitude: 0, longitude: 0 },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.05, longitude: 0.05 }, // roughly 8 km
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.15, longitude: 0.15 }, // roughly 24 km
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.MALE },
+            { latitude: 0.2, longitude: 0.2 }, // roughly 31 km
+          ),
+        ]);
+
+        await SuggestionService.getPotentialMatches(dog, LIMIT, []);
+
+        expect(lastDeckServed()).toEqual({
+          beyond_radius_count: 0,
+          empty: false,
+          primary_count: 2,
+          radius_km: null,
+          recycled_count: 0,
+          requested: LIMIT,
+          same_gender_count: 1,
+          served: 3,
+          supply_10km: 1,
+          supply_25km: 2,
+          supply_50km: 3,
+        });
+      });
+
+      test("an empty deck is reported as empty", async () => {
+        const { dog } = await generateFakeUserWithDog(
+          { gender: Gender.MALE, preferredMaxDistance: 5 },
+          { latitude: 0, longitude: 0 },
+        );
+
+        await SuggestionService.getPotentialMatches(dog, LIMIT, []);
+
+        expect(lastDeckServed()).toMatchObject({
+          empty: true,
+          radius_km: 5,
+          served: 0,
+          supply_10km: 0,
+          supply_25km: 0,
+          supply_50km: 0,
+        });
+      });
+
+      test("supply is unknown when the swiper has no location", async () => {
+        const [{ dog }] = await Promise.all([
+          generateFakeUserWithDog(
+            { gender: Gender.MALE },
+            { latitude: null, longitude: null },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.05, longitude: 0.05 },
+          ),
+        ]);
+
+        await SuggestionService.getPotentialMatches(dog, LIMIT, []);
+
+        expect(lastDeckServed()).toMatchObject({
+          served: 1,
+          supply_10km: null,
+          supply_25km: null,
+          supply_50km: null,
+        });
       });
     });
   });

--- a/packages/api/src/services/SuggestionService/suggestion-service.test.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.test.ts
@@ -985,6 +985,56 @@ describe("SuggestionService", () => {
         });
       });
 
+      test("a full page skips the supply probe", async () => {
+        const { dog } = await generateFakeUserWithDog(
+          { gender: Gender.MALE },
+          { latitude: 0, longitude: 0 },
+        );
+
+        await Promise.all(
+          Array.from({ length: LIMIT }).map(() =>
+            generateFakeUserWithDog(
+              { gender: Gender.FEMALE },
+              { latitude: 0.05, longitude: 0.05 },
+            ),
+          ),
+        );
+
+        await SuggestionService.getPotentialMatches(dog, LIMIT, []);
+
+        // Nothing was short, so nothing was counted.
+        expect(lastDeckServed()).toMatchObject({
+          empty: false,
+          served: LIMIT,
+          supply_10km: null,
+          supply_25km: null,
+          supply_50km: null,
+        });
+      });
+
+      test("a radius that filters nothing is reported as no radius", async () => {
+        const [{ dog }] = await Promise.all([
+          generateFakeUserWithDog(
+            { gender: Gender.MALE, preferredMaxDistance: 300 },
+            { latitude: 0, longitude: 0 },
+          ),
+          generateFakeUserWithDog(
+            { gender: Gender.FEMALE },
+            { latitude: 0.05, longitude: 0.05 },
+          ),
+        ]);
+
+        await SuggestionService.getPotentialMatches(dog, LIMIT, []);
+
+        expect(lastDeckServed()).toMatchObject({
+          // The slider is parked at the far end, so no dog was ever excluded
+          // for being far away and the beyond radius tier never ran.
+          beyond_radius_count: 0,
+          radius_km: null,
+          served: 1,
+        });
+      });
+
       test("supply is unknown when the swiper has no location", async () => {
         const [{ dog }] = await Promise.all([
           generateFakeUserWithDog(

--- a/packages/api/src/services/SuggestionService/suggestion-service.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.ts
@@ -1,13 +1,47 @@
-import type { dogSafeSchema } from "../../dtos/dog-dto";
+import type { DeckTier, dogSafeSchema } from "../../dtos/dog-dto";
 import type { Dog } from "@prisma/client";
 import type { Sql } from "@prisma/client/runtime/library";
 import type { z } from "zod";
 
 import prisma from "@pegada/database";
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { IMAGE_STATUS } from "@pegada/shared/schemas/dog-schema";
 import { Gender, PlanType, Prisma, SwipeType } from "@prisma/client";
 
+import { captureEvent } from "../../shared/analytics";
+
 type DogSafeSchema = z.infer<typeof dogSafeSchema>;
+
+/** A row as it comes back from the deck query, tagged with the tier it came from. */
+type DeckDog = DogSafeSchema & { deckTier: DeckTier };
+
+/**
+ * How long a pass keeps a dog out of the deck.
+ *
+ * It used to be thirty days, applied inline in the primary query, which meant a
+ * pass was the only signal strong enough to empty a deck for a month. Fourteen
+ * days is short enough that a small city refills, and the recycled dogs are now
+ * held back to the last tier so they can never displace a dog nobody has seen.
+ */
+const PASS_COOLDOWN_DAYS = 14;
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+/** The radii the supply probe counts, in kilometers. */
+const SUPPLY_RADII_KM = [10, 25, 50] as const;
+
+type SupplyCounts = {
+  supply10km: number | null;
+  supply25km: number | null;
+  supply50km: number | null;
+};
+
+const UNKNOWN_SUPPLY: SupplyCounts = {
+  supply10km: null,
+  supply25km: null,
+  supply50km: null,
+};
+
 export class SuggestionService {
   static #clusterizeByDistance(bucketRanges: number[]) {
     const caseExpression = [Prisma.sql`CASE `];
@@ -36,27 +70,36 @@ export class SuggestionService {
     [10, 20, 30, 40, 50, 75, 100, 250, 500, 1000, 2500, 5000, 10000],
   );
 
-  static #buildPreferenceConditions(dog: Dog | null) {
-    const conditions: Sql[] = [
-      /* If the dog is the opposite gender, include it in the results */
-      Prisma.sql`"Dog"."gender" = ${dog?.gender === Gender.MALE ? Gender.FEMALE : Gender.MALE}::"Gender"`,
-    ];
+  /** The one condition the fallback tiers are allowed to drop. */
+  static #buildGenderCondition(dog: Dog) {
+    return Prisma.sql`"Dog"."gender" = ${dog.gender === Gender.MALE ? Gender.FEMALE : Gender.MALE}::"Gender"`;
+  }
 
-    if (dog?.preferredColor) {
+  /**
+   * The preferences that describe the dog rather than where it is.
+   *
+   * A missing value on the other dog always passes: a profile with no size set
+   * is unknown, not a mismatch, and dropping it would shrink the deck for a
+   * reason the person who set the preference never asked for.
+   */
+  static #buildAttributeConditions(dog: Dog) {
+    const conditions: Sql[] = [];
+
+    if (dog.preferredColor) {
       /* If the dog has the preferred color or no color, include it in the results */
       conditions.push(
         Prisma.sql`("Dog"."color" = ${dog.preferredColor}::"Color" OR "Dog"."color" IS NULL)`,
       );
     }
 
-    if (dog?.preferredSize) {
+    if (dog.preferredSize) {
       /* If the dog has the preferred size or no size, include it in the results */
       conditions.push(
         Prisma.sql`("Dog"."size" = ${dog.preferredSize}::"Size" OR "Dog"."size" IS NULL)`,
       );
     }
 
-    if (dog?.preferredMinAge || dog?.preferredMaxAge) {
+    if (dog.preferredMinAge || dog.preferredMaxAge) {
       const minAge = dog.preferredMinAge ?? 0;
       const maxAge = dog.preferredMaxAge ?? 100; // 100 years old is too old for a human, let alone a dog
 
@@ -66,52 +109,119 @@ export class SuggestionService {
       );
     }
 
-    if (dog?.preferredBreedId) {
+    if (dog.preferredBreedId) {
       /* If the dog is within the preferred breed or no breed, include it in the results */
       conditions.push(
         Prisma.sql`("Dog"."breedId" = ${dog.preferredBreedId} OR "Dog"."breedId" IS NULL)`,
       );
     }
 
-    if (dog?.preferredMaxDistance && dog?.preferredMaxDistance < 295) {
-      /* If the dog is within the preferred distance or has no location, include it in the results */
-      conditions.push(
-        Prisma.sql`(
-          "MainUser"."longitude" IS NULL OR 
-          "MainUser"."latitude" IS NULL OR 
-          "User"."longitude" IS NULL OR 
-          "User"."latitude" IS NULL OR 
-          ST_DistanceSphere(
-            ST_MakePoint("User"."longitude", "User"."latitude"), 
-            ST_MakePoint("MainUser"."longitude", "MainUser"."latitude")
-          ) / 1000 <= ${dog.preferredMaxDistance}
-        )`,
-      );
+    return conditions;
+  }
+
+  /**
+   * The radius filter, or null when the person never set one.
+   *
+   * 295 km and up is treated as "anywhere" because that is where the slider
+   * ends, so a query for it would only cost time.
+   */
+  static #buildRadiusCondition(dog: Dog) {
+    if (!dog.preferredMaxDistance || dog.preferredMaxDistance >= 295) {
+      return null;
     }
 
-    /** Concatenate all the contidional logic */
+    /* If the dog is within the preferred distance or has no location, include it in the results */
+    return Prisma.sql`(
+      "MainUser"."longitude" IS NULL OR 
+      "MainUser"."latitude" IS NULL OR 
+      "User"."longitude" IS NULL OR 
+      "User"."latitude" IS NULL OR 
+      ST_DistanceSphere(
+        ST_MakePoint("User"."longitude", "User"."latitude"), 
+        ST_MakePoint("MainUser"."longitude", "MainUser"."latitude")
+      ) / 1000 <= ${dog.preferredMaxDistance}
+    )`;
+  }
+
+  /** Glues a tier's conditions onto the shared WHERE clause. */
+  static #joinConditions(conditions: Sql[]) {
+    if (conditions.length === 0) return Prisma.empty;
     return Prisma.join(conditions, " AND ", " AND ");
   }
 
+  /**
+   * Dogs this one has already judged, excluded outright.
+   *
+   * Used by every tier except the recycled one, so an old pass can only ever
+   * come back at the very end of a page and never twice.
+   */
+  static #buildUnswipedCondition(dog: Dog) {
+    return Prisma.sql`AND NOT EXISTS (
+      SELECT 1 FROM "Interest"
+      WHERE "requesterId" = ${dog.id}
+      AND "responderId" = "Dog"."id"
+      AND "swipeType" IN (
+        ${SwipeType.NOT_INTERESTED}::"SwipeType",
+        ${SwipeType.INTERESTED}::"SwipeType",
+        ${SwipeType.MAYBE}::"SwipeType"
+      )
+    )`;
+  }
+
+  /** The mirror image: only dogs passed on long enough ago to be worth another look. */
+  static #buildRecycledPassCondition(dog: Dog, passedBefore: Date) {
+    return Prisma.sql`AND EXISTS (
+      SELECT 1 FROM "Interest"
+      WHERE "requesterId" = ${dog.id}
+      AND "responderId" = "Dog"."id"
+      AND "swipeType" = ${SwipeType.NOT_INTERESTED}::"SwipeType"
+      AND "updatedAt" <= ${passedBefore}
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM "Interest"
+      WHERE "requesterId" = ${dog.id}
+      AND "responderId" = "Dog"."id"
+      AND "swipeType" IN (
+        ${SwipeType.INTERESTED}::"SwipeType",
+        ${SwipeType.MAYBE}::"SwipeType"
+      )
+    )`;
+  }
+
   // Make distances less accurate for security reasons. Up to 1 decimal place is enough.
-  static #anonimizeDistances(dogs: DogSafeSchema[]) {
+  static #anonimizeDistances(dogs: DeckDog[]) {
     return dogs.map((dog) => ({
       ...dog,
       distance: dog.distance ? Math.round(dog.distance * 10) / 10 : null,
     }));
   }
 
-  static async getPotentialMatches(dog: Dog, limit: number, notIn: string[]) {
-    if (!dog?.userId) {
-      throw new Error("User ID is required");
-    }
-
+  /**
+   * One page of one tier.
+   *
+   * Everything outside `preferences` and `swipeHistory` is a hard exclusion and
+   * is identical in every tier: the viewer's own dog, deleted and banned dogs,
+   * the photo gate, and the ids the client already holds.
+   */
+  static #queryTier({
+    dog,
+    excludeIds,
+    limit,
+    preferences,
+    swipeHistory,
+  }: {
+    dog: Dog;
+    excludeIds: string[];
+    limit: number;
+    preferences: Sql;
+    swipeHistory: Sql;
+  }) {
     const notInCondition =
-      notIn.length > 0
-        ? Prisma.sql`AND "Dog"."id" NOT IN (${Prisma.join(notIn)})`
+      excludeIds.length > 0
+        ? Prisma.sql`AND "Dog"."id" NOT IN (${Prisma.join(excludeIds)})`
         : Prisma.empty;
 
-    const potentialMatches = await prisma.$queryRaw<DogSafeSchema[]>`
+    return prisma.$queryRaw<DogSafeSchema[]>`
     /* Select all wanted columns from the subquery */
     SELECT 
       "id", 
@@ -141,6 +251,8 @@ export class SuggestionService {
         "Dog"."size", 
         "Dog"."weight", 
         "Dog"."hasPedigree", 
+        /* Kept out of the outer select: it only exists to break distance ties */
+        "User"."lastActiveAt" AS "lastActiveAt",
         /* Create a JSON array of the images */
         COALESCE(
           (
@@ -191,7 +303,7 @@ export class SuggestionService {
       /* Join the User table with the MainUser table */
       JOIN "User" AS "MainUser" ON "MainUser"."id" = ${dog.userId}
       WHERE TRUE
-      /* Exclude dogs already loaded on the client. */
+      /* Exclude dogs already loaded on the client or already served on this page. */
       ${notInCondition}
       /* Never return the viewer's own dog. */
       AND "Dog"."id" <> ${dog.id}
@@ -212,27 +324,229 @@ export class SuggestionService {
           AND "Image"."status" = ${IMAGE_STATUS.REJECTED}::"ImageStatus"
         )
       )
-      /* Exclude dogs you have already liked or disliked (disliked in the last 30 days)*/
-      AND NOT EXISTS (
-        SELECT 1 FROM "Interest"
-        WHERE "requesterId" = ${dog.id}
-        AND "responderId" = "Dog"."id"
-        AND (
-          ("swipeType" = ${SwipeType.NOT_INTERESTED}::"SwipeType" AND "updatedAt" > NOW() - INTERVAL '30 DAY')
-          OR "swipeType" = ${SwipeType.INTERESTED}::"SwipeType"
-          OR "swipeType" = ${SwipeType.MAYBE}::"SwipeType"
-        )
-      )
+      /* What this tier does about dogs already swiped on */
+      ${swipeHistory}
       /* Add additional conditions based on the preferences of the dog and user */
-      ${SuggestionService.#buildPreferenceConditions(dog)}
+      ${preferences}
     ) AS subquery
     
-    /* Order the results by priority in descending order and distance in ascending order */
-    ORDER BY priority DESC, ${SuggestionService.#clusterizedDistancesSql} ASC
+    /* Priority first, then how close, then who was here most recently */
+    ORDER BY priority DESC, ${SuggestionService.#clusterizedDistancesSql} ASC, "lastActiveAt" DESC NULLS LAST
     /* Limit the number of results to the specified limit */
     LIMIT ${limit}
   `;
+  }
 
-    return SuggestionService.#anonimizeDistances(potentialMatches);
+  /**
+   * How many dogs exist near this one at all, before any preference is applied.
+   *
+   * This is the denominator the deck never had. A short deck can mean the
+   * filters are too tight or it can mean the city is empty, and the two need
+   * completely different fixes, so the counts ship next to every served page.
+   */
+  static async #getSupplyCounts(dog: Dog): Promise<SupplyCounts> {
+    const [near, mid, far] = SUPPLY_RADII_KM;
+
+    const [row] = await prisma.$queryRaw<
+      {
+        hasLocation: boolean | null;
+        within10: number;
+        within25: number;
+        within50: number;
+      }[]
+    >`
+      WITH "main" AS (
+        SELECT "latitude", "longitude" FROM "User" WHERE "id" = ${dog.userId}
+      ),
+      "eligible" AS (
+        SELECT
+          ST_DistanceSphere(
+            ST_MakePoint("User"."longitude", "User"."latitude"),
+            ST_MakePoint("main"."longitude", "main"."latitude")
+          ) / 1000 AS "distance"
+        FROM "Dog"
+        JOIN "User" ON "Dog"."userId" = "User"."id"
+        CROSS JOIN "main"
+        WHERE "Dog"."id" <> ${dog.id}
+        AND "Dog"."deletedAt" IS NULL
+        AND "Dog"."banned" = false
+        AND "User"."deletedAt" IS NULL
+        AND "User"."latitude" IS NOT NULL
+        AND "User"."longitude" IS NOT NULL
+        AND "main"."latitude" IS NOT NULL
+        AND "main"."longitude" IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM "Image"
+          WHERE "Image"."dogId" = "Dog"."id"
+          AND "Image"."status" = ${IMAGE_STATUS.APPROVED}::"ImageStatus"
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM "Image"
+          WHERE "Image"."dogId" = "Dog"."id"
+          AND "Image"."status" = ${IMAGE_STATUS.REJECTED}::"ImageStatus"
+        )
+      )
+      SELECT
+        (
+          SELECT "latitude" IS NOT NULL AND "longitude" IS NOT NULL FROM "main"
+        ) AS "hasLocation",
+        COUNT(*) FILTER (WHERE "distance" <= ${near})::int AS "within10",
+        COUNT(*) FILTER (WHERE "distance" <= ${mid})::int AS "within25",
+        COUNT(*) FILTER (WHERE "distance" <= ${far})::int AS "within50"
+      FROM "eligible"
+    `;
+
+    if (!row?.hasLocation) return UNKNOWN_SUPPLY;
+
+    return {
+      supply10km: row.within10,
+      supply25km: row.within25,
+      supply50km: row.within50,
+    };
+  }
+
+  /** Counts a page by tier without walking the list four times. */
+  static #countByTier(deck: DeckDog[], tier: DeckTier) {
+    return deck.filter((entry) => entry.deckTier === tier).length;
+  }
+
+  /**
+   * The supply probe and the event are both best effort. A deck that was
+   * already built is not worth failing over a number nobody is waiting on.
+   */
+  static async #reportDeckServed({
+    dog,
+    deck,
+    requested,
+  }: {
+    dog: Dog;
+    deck: DeckDog[];
+    requested: number;
+  }) {
+    if (!dog.userId) return;
+
+    try {
+      const supply = await SuggestionService.#getSupplyCounts(dog);
+
+      captureEvent(dog.userId, ANALYTICS_EVENTS.DECK_SERVED, {
+        beyond_radius_count: SuggestionService.#countByTier(
+          deck,
+          "beyond_radius",
+        ),
+        empty: deck.length === 0,
+        primary_count: SuggestionService.#countByTier(deck, "primary"),
+        radius_km: dog.preferredMaxDistance ?? null,
+        recycled_count: SuggestionService.#countByTier(deck, "recycled_pass"),
+        requested,
+        same_gender_count: SuggestionService.#countByTier(deck, "same_gender"),
+        served: deck.length,
+        supply_10km: supply.supply10km,
+        supply_25km: supply.supply25km,
+        supply_50km: supply.supply50km,
+      });
+    } catch {
+      // A missing row in a chart, not a missing deck.
+    }
+  }
+
+  /**
+   * One page of the deck, filled from the strictest tier down.
+   *
+   * The primary tier is the deck as it always was. Only when it comes back
+   * short do the fallbacks run, each one relaxing exactly one thing and each
+   * one limited to what is still missing, so a person with a full deck pays for
+   * nothing and a person with an empty one gets dogs instead of a dead end.
+   */
+  static async getPotentialMatches(
+    dog: Dog,
+    limit: number,
+    notIn: string[],
+    // Widened to the schema on purpose: `deckTier` is optional there, so the
+    // deck and `dog.get` stay one type on the client rather than two that
+    // differ by a field the app is free to ignore.
+  ): Promise<DogSafeSchema[]> {
+    if (!dog?.userId) {
+      throw new Error("User ID is required");
+    }
+
+    const genderCondition = SuggestionService.#buildGenderCondition(dog);
+    const attributeConditions =
+      SuggestionService.#buildAttributeConditions(dog);
+    const radiusCondition = SuggestionService.#buildRadiusCondition(dog);
+    const radiusConditions = radiusCondition ? [radiusCondition] : [];
+
+    const unswiped = SuggestionService.#buildUnswipedCondition(dog);
+    const recycled = SuggestionService.#buildRecycledPassCondition(
+      dog,
+      new Date(Date.now() - PASS_COOLDOWN_DAYS * DAY_IN_MS),
+    );
+
+    const plans: { preferences: Sql; swipeHistory: Sql; tier: DeckTier }[] = [
+      {
+        preferences: SuggestionService.#joinConditions([
+          genderCondition,
+          ...attributeConditions,
+          ...radiusConditions,
+        ]),
+        swipeHistory: unswiped,
+        tier: "primary",
+      },
+      // Only worth a round trip when a radius is what held the primary back.
+      ...(radiusCondition
+        ? [
+            {
+              preferences: SuggestionService.#joinConditions([
+                genderCondition,
+                ...attributeConditions,
+              ]),
+              swipeHistory: unswiped,
+              tier: "beyond_radius" as const,
+            },
+          ]
+        : []),
+      {
+        preferences: SuggestionService.#joinConditions([
+          ...attributeConditions,
+          ...radiusConditions,
+        ]),
+        swipeHistory: unswiped,
+        tier: "same_gender",
+      },
+      {
+        preferences: SuggestionService.#joinConditions([
+          genderCondition,
+          ...attributeConditions,
+          ...radiusConditions,
+        ]),
+        swipeHistory: recycled,
+        tier: "recycled_pass",
+      },
+    ];
+
+    const deck: DeckDog[] = [];
+    const excludeIds = [...notIn];
+
+    for (const plan of plans) {
+      const remaining = limit - deck.length;
+      if (remaining <= 0) break;
+
+      // oxlint-disable-next-line no-await-in-loop -- Each tier excludes what the one before it served, so they cannot run in parallel without serving the same dog twice.
+      const rows = await SuggestionService.#queryTier({
+        dog,
+        excludeIds,
+        limit: remaining,
+        preferences: plan.preferences,
+        swipeHistory: plan.swipeHistory,
+      });
+
+      for (const row of rows) {
+        deck.push({ ...row, deckTier: plan.tier });
+        excludeIds.push(row.id);
+      }
+    }
+
+    await SuggestionService.#reportDeckServed({ deck, dog, requested: limit });
+
+    return SuggestionService.#anonimizeDistances(deck);
   }
 }

--- a/packages/api/src/services/SuggestionService/suggestion-service.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.ts
@@ -342,7 +342,11 @@ export class SuggestionService {
    *
    * This is the denominator the deck never had. A short deck can mean the
    * filters are too tight or it can mean the city is empty, and the two need
-   * completely different fixes, so the counts ship next to every served page.
+   * completely different fixes.
+   *
+   * It is only asked on a short deck. The counts scan every dog and every
+   * image, which is around 175 ms on a table this size, and a full page has
+   * already answered the only question they exist to settle.
    */
   static async #getSupplyCounts(dog: Dog): Promise<SupplyCounts> {
     const [near, mid, far] = SUPPLY_RADII_KM;
@@ -413,33 +417,44 @@ export class SuggestionService {
   /**
    * The supply probe and the event are both best effort. A deck that was
    * already built is not worth failing over a number nobody is waiting on.
+   *
+   * The event goes out on every page. The probe behind it does not: it only
+   * runs when the page came back short, which is the only case where the
+   * answer changes what anyone would do about it.
    */
   static async #reportDeckServed({
     dog,
     deck,
+    radiusKm,
     requested,
   }: {
     dog: Dog;
     deck: DeckDog[];
+    radiusKm: number | null;
     requested: number;
   }) {
     if (!dog.userId) return;
 
     try {
-      const supply = await SuggestionService.#getSupplyCounts(dog);
+      const served = deck.length;
+
+      const supply =
+        served < requested
+          ? await SuggestionService.#getSupplyCounts(dog)
+          : UNKNOWN_SUPPLY;
 
       captureEvent(dog.userId, ANALYTICS_EVENTS.DECK_SERVED, {
         beyond_radius_count: SuggestionService.#countByTier(
           deck,
           "beyond_radius",
         ),
-        empty: deck.length === 0,
+        empty: served === 0,
         primary_count: SuggestionService.#countByTier(deck, "primary"),
-        radius_km: dog.preferredMaxDistance ?? null,
+        radius_km: radiusKm,
         recycled_count: SuggestionService.#countByTier(deck, "recycled_pass"),
         requested,
         same_gender_count: SuggestionService.#countByTier(deck, "same_gender"),
-        served: deck.length,
+        served,
         supply_10km: supply.supply10km,
         supply_25km: supply.supply25km,
         supply_50km: supply.supply50km,
@@ -545,7 +560,15 @@ export class SuggestionService {
       }
     }
 
-    await SuggestionService.#reportDeckServed({ deck, dog, requested: limit });
+    await SuggestionService.#reportDeckServed({
+      deck,
+      dog,
+      // The radius that was actually applied. A slider parked at the far end
+      // filters nothing and skips the beyond radius tier, so reporting the raw
+      // preference there would describe a deck that was never narrowed.
+      radiusKm: radiusCondition ? (dog.preferredMaxDistance ?? null) : null,
+      requested: limit,
+    });
 
     return SuggestionService.#anonimizeDistances(deck);
   }

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -431,20 +431,30 @@ export type ServerEventProperties = {
    * starving the deck. `supply_*` is the same question asked of the city
    * instead of the filters, counted before any preference is applied, so an
    * empty deck in an empty town can be told apart from an empty deck behind a
-   * tight filter. All three are null when the person has no location.
+   * tight filter.
+   *
+   * The supply counts are only taken when the page came back short, since the
+   * scan behind them costs real time and a full page has already answered the
+   * question. They are null on a full page and null when the person has no
+   * location, so read them against `served < requested` rather than as a
+   * series on their own.
    */
   [ANALYTICS_EVENTS.DECK_SERVED]: {
     beyond_radius_count: number;
     /** `served === 0`, kept as its own property so the rate is one breakdown. */
     empty: boolean;
     primary_count: number;
-    /** The radius the person set, or null for no limit. */
+    /**
+     * The radius that was actually applied, or null when nothing was narrowed:
+     * no radius set, or a slider parked at the far end, which filters nothing.
+     */
     radius_km: number | null;
     recycled_count: number;
     /** The page size the app asked for, which `served` is read against. */
     requested: number;
     same_gender_count: number;
     served: number;
+    /** Null on a full page and when the person has no location. */
     supply_10km: number | null;
     supply_25km: number | null;
     supply_50km: number | null;

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -24,6 +24,7 @@ export const ANALYTICS_EVENTS = {
   CHAT_OPENED: "Chat Opened",
   COMPLETE_DOG_PROFILE: "Complete Dog Profile",
   CREATE_DOG_PROFILE: "Create Dog Profile",
+  DECK_SERVED: "Deck Served",
   DEEP_LINK_OPENED: "Deep Link Opened",
   DELETE_ACCOUNT_CANCELED: "Delete Account Canceled",
   DELETE_ACCOUNT_CONFIRMED: "Delete Account Confirmed",
@@ -422,6 +423,33 @@ export type SubscriptionCancelReason =
  */
 export type ServerEventProperties = {
   /**
+   * One row per page of the swipe deck the API hands back.
+   *
+   * The tier counts are the whole point: a deck of ten that is ten `primary`
+   * dogs and a deck of ten that is two `primary` and eight refills look
+   * identical from the app, and only the second one says the preferences are
+   * starving the deck. `supply_*` is the same question asked of the city
+   * instead of the filters, counted before any preference is applied, so an
+   * empty deck in an empty town can be told apart from an empty deck behind a
+   * tight filter. All three are null when the person has no location.
+   */
+  [ANALYTICS_EVENTS.DECK_SERVED]: {
+    beyond_radius_count: number;
+    /** `served === 0`, kept as its own property so the rate is one breakdown. */
+    empty: boolean;
+    primary_count: number;
+    /** The radius the person set, or null for no limit. */
+    radius_km: number | null;
+    recycled_count: number;
+    /** The page size the app asked for, which `served` is read against. */
+    requested: number;
+    same_gender_count: number;
+    served: number;
+    supply_10km: number | null;
+    supply_25km: number | null;
+    supply_50km: number | null;
+  };
+  /**
    * One row per photo the moderation model looked at.
    *
    * `mode` is the property the whole rollout hangs on: the same verdict means
@@ -637,6 +665,7 @@ export const MOBILE_EVENT_NAMES = [
 ] as const;
 
 export const SERVER_EVENT_NAMES = [
+  ANALYTICS_EVENTS.DECK_SERVED,
   ANALYTICS_EVENTS.IMAGE_MODERATION_RESULT,
   ANALYTICS_EVENTS.MATCH_CREATED,
   ANALYTICS_EVENTS.MESSAGE_SENT,

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -56,6 +56,7 @@ export const CLIENT_LIBS = ["posthog-react-native", "web"];
  * day one of these is captured through a proxy that rewrites `$lib`.
  */
 export const SERVER_EVENTS = [
+  "Deck Served",
   "Image Moderation Result",
   "Match Created",
   "Message Sent",


### PR DESCRIPTION
## Summary

The deck ran one query, so anyone whose preferences or radius came back short got an empty screen instead of dogs.
It now falls back through three wider tiers when the first one is short, and reports what it served.

## Details

- The primary query is unchanged, and it still runs first. The fallbacks only fire when it comes back short, and each one asks for exactly the number of cards still missing.
- Tier order: `primary`, then `beyond_radius` (same preferences, the radius dropped, skipped entirely when no radius was set), then `same_gender` (the opposite gender condition dropped, radius kept), then `recycled_pass`. Same gender is a refill only. It never enters the primary deck.
- The pass cooldown drops from 30 days to 14 and is now a named constant. Passed dogs are held out of the first three tiers completely, so a recycled dog can only appear once per page and only at the end.
- Ordering inside every tier is the old one, priority then distance bucket, with `User.lastActiveAt DESC NULLS LAST` added as a tiebreak. A dormant owner now sorts last instead of never showing up.
- Every card carries `deckTier`. The field is optional on the response schema, so a client that predates it ignores it.
- New server event `Deck Served`, one per page, with `requested`, `served`, `primary_count`, `beyond_radius_count`, `same_gender_count`, `recycled_count`, `radius_km`, `supply_10km`, `supply_25km`, `supply_50km`, `empty`. The supply numbers count eligible dogs around the swiper before any preference or swipe history is applied, in one query, and are null when the swiper has no location. That is the denominator the deck never had: a short deck behind a tight filter and a short deck in an empty city look identical without it.
- Hypothesis: empty decks per swiper drops from 2.25 toward 0 and matches per swiper rises from 0.25, read from PostHog events `Deck Served` (`empty=true` share) and `Match Created` per weekly active swiper.
- Readout: `Deck Served` split by `empty`, and by the four tier counts against `served`, tells you whether the refill is carrying the deck or the primary query already covered it. `supply_10km` / `supply_25km` / `supply_50km` against `served` says whether a short deck is a filter problem or a supply problem. Those three are only counted when the page came back short, because the scan behind them costs around 175 ms and a full page has already answered the question, so they are null on a full page and on a swiper with no location. `radius_km` is the radius that was actually applied, null when the slider is parked at the far end and nothing was narrowed. `Match Created` per weekly active swiper is the outcome number. Baseline over the last 7 days on build 1.6.2: 12 swipers, 879 swipes, 3 matches (0.25 per swiper), 27 `Empty Deck Shown` across 7 people (2.25 per swiper).
- This is API only, so everyone on the 1.6.2 store build gets it on the next deploy with no app update. The "mais longe" label on the card is a follow up mobile change that reads `deckTier`.
- `Deck Served` is added to the analytics catalogue and to the server event deny list the daily readout uses, so it cannot be counted as user activity.

## Testing steps

- Open preferences, set the distance to the smallest value, save, and go back to the deck. Swipe through the nearby dogs. Once they run out, dogs from farther away should appear with their distance on the card, instead of the empty state.
- Set the distance back to unlimited and swipe through everything the deck has. When the usual dogs run out, dogs of the same gender as yours should appear rather than an empty deck.
- Pass on a dog, then reload the deck. It should not come back that day.

## Screenshots

API only, no visual change. The card already shows distance, so these are the same screen before and after the refill.

Deck as it stands today, on a profile with a tight radius.

![Deck before the refill](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat/deck-supply-refill/shots/02-deck-current.png)

With the refill, a dog 6,7 km out is served instead of the empty state.

![Beyond radius card at 6,7 km](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat/deck-supply-refill/shots/03-beyond-radius-card.png)
