### PR TITLE
feat(mobile): support a weekly plan and price aware savings copy

### DIFF
--- a/apps/mobile/src/services/payments/index.ts
+++ b/apps/mobile/src/services/payments/index.ts
@@ -127,6 +127,7 @@ const logIn = async () => {
 const buildMaestroSyntheticOfferings = (): PurchasesOffering => {
   const monthlyPrice = 9.99;
   const yearlyPrice = 49.99;
+  const weeklyPrice = 4.99;
 
   const baseProduct = {
     description: "Pegada Premium",
@@ -143,7 +144,7 @@ const buildMaestroSyntheticOfferings = (): PurchasesOffering => {
   };
 
   // String literals (not ProductIdentifier.*) because the enum is declared
-  // further down in this file — both values match the enum exactly.
+  // further down in this file, and these are the ids the stores publish.
   const monthlyProduct = {
     ...baseProduct,
     identifier: "premium_monthly",
@@ -172,6 +173,20 @@ const buildMaestroSyntheticOfferings = (): PurchasesOffering => {
     subscriptionPeriod: "P1Y",
   };
 
+  const weeklyProduct = {
+    ...baseProduct,
+    identifier: "premium_weekly",
+    price: weeklyPrice,
+    priceString: `$${weeklyPrice.toFixed(2)}`,
+    pricePerWeek: weeklyPrice,
+    pricePerMonth: weeklyPrice * 4,
+    pricePerYear: weeklyPrice * 52,
+    pricePerWeekString: `$${weeklyPrice.toFixed(2)}`,
+    pricePerMonthString: `$${(weeklyPrice * 4).toFixed(2)}`,
+    pricePerYearString: `$${(weeklyPrice * 52).toFixed(2)}`,
+    subscriptionPeriod: "P1W",
+  };
+
   const monthlyPackage = {
     identifier: "$rc_monthly",
     packageType: "MONTHLY",
@@ -188,18 +203,26 @@ const buildMaestroSyntheticOfferings = (): PurchasesOffering => {
     presentedOfferingContext: { offeringIdentifier: "default" },
   };
 
+  const weeklyPackage = {
+    identifier: "$rc_weekly",
+    packageType: "WEEKLY",
+    product: weeklyProduct,
+    offeringIdentifier: "default",
+    presentedOfferingContext: { offeringIdentifier: "default" },
+  };
+
   return {
     identifier: "default",
     serverDescription: "Pegada Premium (Maestro/Sim fallback)",
     metadata: {},
-    availablePackages: [monthlyPackage, yearlyPackage],
+    availablePackages: [monthlyPackage, yearlyPackage, weeklyPackage],
     lifetime: null,
     annual: yearlyPackage,
     sixMonth: null,
     threeMonth: null,
     twoMonth: null,
     monthly: monthlyPackage,
-    weekly: null,
+    weekly: weeklyPackage,
   } as unknown as PurchasesOffering;
 };
 

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/index.tsx
@@ -15,6 +15,7 @@ import { styles as planPackagesStyles } from "@/views/UpgradeWall/components/Pla
 
 import { PlanCard } from "./plan-card";
 import { getYearlySavingPercent } from "./saving-percent";
+import { sortPlanPackages } from "./sort-packages";
 
 type OfferingsProps = {
   selectedPackage: PurchasesPackage | null | undefined;
@@ -42,10 +43,7 @@ const PlanPackages: React.FC<OfferingsProps> = ({
   }, [isError, router, t]);
 
   const packageList = offeringsData
-    ? [...offeringsData.availablePackages].sort(
-        // Highest price first
-        (a, b) => b.product.price - a.product.price,
-      )
+    ? sortPlanPackages(offeringsData.availablePackages)
     : [];
 
   const annualPackage =
@@ -56,8 +54,12 @@ const PlanPackages: React.FC<OfferingsProps> = ({
     offeringsData?.monthly ??
     packageList.find((pkg) => pkg.packageType === "MONTHLY");
 
+  const weeklyPackage =
+    offeringsData?.weekly ??
+    packageList.find((pkg) => pkg.packageType === "WEEKLY");
+
   // Yearly first: preselect the annual package when the offering has one, and
-  // otherwise fall back to the most expensive package (the previous default).
+  // otherwise fall back to the first row in the list.
   // Both are stable references from the offerings query, so the effect below
   // does not re-run on every render even though `packageList` is rebuilt.
   const defaultPackage = annualPackage ?? packageList[0];
@@ -68,11 +70,12 @@ const PlanPackages: React.FC<OfferingsProps> = ({
     }
   }, [defaultPackage, selectedPackage, setSelectedPackage]);
 
-  // What a year of the monthly plan would cost against the yearly price.
-  const yearlySavingPercent = getYearlySavingPercent(
-    monthlyPackage?.product.price,
-    annualPackage?.product.price,
-  );
+  // What a year of paying as you go would cost against the yearly price.
+  const yearlySavingPercent = getYearlySavingPercent({
+    monthlyPrice: monthlyPackage?.product.price,
+    weeklyPrice: weeklyPackage?.product.price,
+    yearlyPrice: annualPackage?.product.price,
+  });
 
   return (
     <View style={planPackagesStyles.container}>

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/plan-card.tsx
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/plan-card.tsx
@@ -72,7 +72,20 @@ export const PlanCard: React.FC<PlanCardProps> = ({
   // A single month already reads as "X/mo", so the total would just repeat it.
   const showTotalPrice = !(periodUnit === "M" && periodValue === 1);
 
+  // Keyed off the package type, not the product id: on Google Play a
+  // RevenueCat product identifier is `subscriptionId:basePlanId`, so matching
+  // on the bare id sent every Android row to the raw store title. The product
+  // ids stay as a fallback for offerings that arrive with a custom type.
   const translatedPlanName = (() => {
+    switch (pkg.packageType) {
+      case "ANNUAL":
+        return t("plans.yearly");
+      case "MONTHLY":
+        return t("plans.monthly");
+      case "WEEKLY":
+        return t("plans.weekly");
+    }
+
     switch (identifier) {
       case "premium_monthly":
         return t("plans.monthly");

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.test.ts
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.test.ts
@@ -2,16 +2,101 @@ import { getYearlySavingPercent } from "./saving-percent";
 
 test("rounds the yearly saving down so the badge never overstates", () => {
   // 9.99 x 12 = 119.88, saving 58.31% against 49.99.
-  expect(getYearlySavingPercent(9.99, 49.99)).toBe(58);
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 9.99,
+      weeklyPrice: undefined,
+      yearlyPrice: 49.99,
+    }),
+  ).toBe(58);
   // 10 x 12 = 120, saving 58.33% against 50.
-  expect(getYearlySavingPercent(10, 50)).toBe(58);
-  expect(getYearlySavingPercent(10, 60)).toBe(50);
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 10,
+      weeklyPrice: undefined,
+      yearlyPrice: 50,
+    }),
+  ).toBe(58);
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 10,
+      weeklyPrice: undefined,
+      yearlyPrice: 60,
+    }),
+  ).toBe(50);
+});
+
+test("falls back to a year of weekly charges when there is no monthly plan", () => {
+  // 4.99 x 52 = 259.48, saving 80.73% against 49.99.
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: undefined,
+      weeklyPrice: 4.99,
+      yearlyPrice: 49.99,
+    }),
+  ).toBe(80);
+  // 5 x 52 = 260, saving 50% against 130.
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: undefined,
+      weeklyPrice: 5,
+      yearlyPrice: 130,
+    }),
+  ).toBe(50);
+});
+
+test("compares against the monthly plan when the offering has both", () => {
+  // 10 x 12 = 120 rather than 5 x 52 = 260, so the badge reads 50 not 76.
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 10,
+      weeklyPrice: 5,
+      yearlyPrice: 60,
+    }),
+  ).toBe(50);
 });
 
 test("hides the badge when there is nothing to save", () => {
-  expect(getYearlySavingPercent(10, 120)).toBeUndefined();
-  expect(getYearlySavingPercent(10, 130)).toBeUndefined();
-  expect(getYearlySavingPercent(0, 50)).toBeUndefined();
-  expect(getYearlySavingPercent(undefined, 50)).toBeUndefined();
-  expect(getYearlySavingPercent(10, undefined)).toBeUndefined();
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 10,
+      weeklyPrice: undefined,
+      yearlyPrice: 120,
+    }),
+  ).toBeUndefined();
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 10,
+      weeklyPrice: undefined,
+      yearlyPrice: 130,
+    }),
+  ).toBeUndefined();
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: undefined,
+      weeklyPrice: 2,
+      yearlyPrice: 104,
+    }),
+  ).toBeUndefined();
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 0,
+      weeklyPrice: undefined,
+      yearlyPrice: 50,
+    }),
+  ).toBeUndefined();
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: undefined,
+      weeklyPrice: undefined,
+      yearlyPrice: 50,
+    }),
+  ).toBeUndefined();
+  expect(
+    getYearlySavingPercent({
+      monthlyPrice: 10,
+      weeklyPrice: undefined,
+      yearlyPrice: undefined,
+    }),
+  ).toBeUndefined();
 });

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.ts
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/saving-percent.ts
@@ -1,22 +1,51 @@
 const MONTHS_IN_A_YEAR = 12;
+const WEEKS_IN_A_YEAR = 52;
 
 /**
- * Percent saved by paying a year up front instead of twelve monthly charges.
- * Rounded down so the badge never promises more than the plans deliver.
- * Returns undefined when either price is missing or the yearly plan is not
- * actually cheaper, in which case no badge should be shown.
+ * What a year of paying as you go costs. Monthly wins when the offering has
+ * both, because it is the plan a buyer is most likely weighing the year up
+ * against.
  */
-export const getYearlySavingPercent = (
+const getPayAsYouGoYear = (
   monthlyPrice: number | undefined,
-  yearlyPrice: number | undefined,
+  weeklyPrice: number | undefined,
 ) => {
-  if (monthlyPrice === undefined || yearlyPrice === undefined) return;
+  if (monthlyPrice !== undefined) return monthlyPrice * MONTHS_IN_A_YEAR;
+  if (weeklyPrice !== undefined) return weeklyPrice * WEEKS_IN_A_YEAR;
 
-  const twelveMonths = monthlyPrice * MONTHS_IN_A_YEAR;
-  if (twelveMonths <= 0) return;
+  return undefined;
+};
+
+type YearlySavingPrices = {
+  /** Preferred comparison base: what a year of monthly charges would cost. */
+  monthlyPrice: number | undefined;
+  /** Fallback base for offerings that ship yearly and weekly but no monthly. */
+  weeklyPrice: number | undefined;
+  yearlyPrice: number | undefined;
+};
+
+/**
+ * Percent saved by paying a year up front instead of paying as you go.
+ * The monthly plan is the comparison base whenever the offering has one, and
+ * the weekly plan stands in when it does not, so the badge still appears on a
+ * yearly plus weekly ladder.
+ * Rounded down so the badge never promises more than the plans deliver.
+ * Returns undefined when there is no base price, no yearly price, or the
+ * yearly plan is not actually cheaper, in which case no badge should be shown.
+ */
+export const getYearlySavingPercent = ({
+  monthlyPrice,
+  weeklyPrice,
+  yearlyPrice,
+}: YearlySavingPrices) => {
+  if (yearlyPrice === undefined) return;
+
+  const payAsYouGoYear = getPayAsYouGoYear(monthlyPrice, weeklyPrice);
+
+  if (payAsYouGoYear === undefined || payAsYouGoYear <= 0) return;
 
   const percent = Math.floor(
-    ((twelveMonths - yearlyPrice) / twelveMonths) * 100,
+    ((payAsYouGoYear - yearlyPrice) / payAsYouGoYear) * 100,
   );
 
   return percent > 0 ? percent : undefined;

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/sort-packages.test.ts
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/sort-packages.test.ts
@@ -1,0 +1,44 @@
+import { sortPlanPackages } from "./sort-packages";
+
+const planPackage = (packageType: string, price: number) => ({
+  packageType,
+  product: { price },
+});
+
+const yearly = planPackage("ANNUAL", 49.99);
+const monthly = planPackage("MONTHLY", 9.99);
+const weekly = planPackage("WEEKLY", 4.99);
+
+test("puts yearly first, then monthly, then weekly", () => {
+  expect(sortPlanPackages([weekly, monthly, yearly])).toStrictEqual([
+    yearly,
+    monthly,
+    weekly,
+  ]);
+  expect(sortPlanPackages([monthly, weekly, yearly])).toStrictEqual([
+    yearly,
+    monthly,
+    weekly,
+  ]);
+});
+
+test("keeps the offering's own list untouched", () => {
+  const offered = [weekly, monthly, yearly];
+  sortPlanPackages(offered);
+  expect(offered).toStrictEqual([weekly, monthly, yearly]);
+});
+
+test("sends an unknown package type to the end, highest price first", () => {
+  const lifetime = planPackage("LIFETIME", 199.99);
+  const custom = planPackage("CUSTOM", 24.99);
+
+  expect(
+    sortPlanPackages([custom, weekly, lifetime, yearly, monthly]),
+  ).toStrictEqual([yearly, monthly, weekly, lifetime, custom]);
+});
+
+test("orders an offering that only has two plans", () => {
+  expect(sortPlanPackages([weekly, yearly])).toStrictEqual([yearly, weekly]);
+  expect(sortPlanPackages([monthly, yearly])).toStrictEqual([yearly, monthly]);
+  expect(sortPlanPackages([weekly, monthly])).toStrictEqual([monthly, weekly]);
+});

--- a/apps/mobile/src/views/UpgradeWall/components/PlanPackages/sort-packages.ts
+++ b/apps/mobile/src/views/UpgradeWall/components/PlanPackages/sort-packages.ts
@@ -1,0 +1,37 @@
+type SortablePlanPackage = {
+  packageType: string;
+  product: { price: number };
+};
+
+/**
+ * Where each plan sits in the list. Yearly leads because it is the plan we
+ * want picked, then monthly, then the weekly impulse plan. Anything the
+ * offering adds later lands after the three we render on purpose.
+ */
+const PACKAGE_TYPE_ORDER: Record<string, number> = {
+  ANNUAL: 0,
+  MONTHLY: 1,
+  WEEKLY: 2,
+};
+
+const UNRANKED = Object.keys(PACKAGE_TYPE_ORDER).length;
+
+const rankOf = (packageType: string) =>
+  PACKAGE_TYPE_ORDER[packageType] ?? UNRANKED;
+
+/**
+ * Orders the plan rows by billing period rather than by absolute price, so a
+ * price change cannot silently reshuffle the list. Packages that share a rank,
+ * including every unrecognised type, keep the previous rule of highest price
+ * first. Returns a new array; the offering's own list is left untouched.
+ */
+export const sortPlanPackages = <T extends SortablePlanPackage>(
+  packages: readonly T[],
+): T[] =>
+  [...packages].sort((a, b) => {
+    const rankDifference = rankOf(a.packageType) - rankOf(b.packageType);
+
+    if (rankDifference !== 0) return rankDifference;
+
+    return b.product.price - a.product.price;
+  });

--- a/apps/mobile/src/views/UpgradeWall/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/index.tsx
@@ -53,6 +53,8 @@ const usePriceLine = (offering: PurchasesPackage | null | undefined) => {
       return t("plans.upgradeWall.priceYearly", { price });
     case "MONTHLY":
       return t("plans.upgradeWall.priceMonthly", { price });
+    case "WEEKLY":
+      return t("plans.upgradeWall.priceWeekly", { price });
     default:
       return t("plans.upgradeWall.price", { price });
   }

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -295,6 +295,7 @@
     "W": "wk",
     "monthly": "Monthly",
     "yearly": "Yearly",
+    "weekly": "Weekly",
     "save": "Save {{percent}}%",
     "benefits": {
       "priorityQueue": "Priority on the Queue",
@@ -319,7 +320,8 @@
       "subscribe": "Get Premium",
       "price": "{{price}}, cancel anytime",
       "priceMonthly": "{{price}} per month, cancel anytime",
-      "priceYearly": "{{price}} per year, cancel anytime"
+      "priceYearly": "{{price}} per year, cancel anytime",
+      "priceWeekly": "{{price}} per week, cancel anytime"
     }
   },
   "links": {

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -330,6 +330,7 @@
     "W": "semana",
     "monthly": "Mensal",
     "yearly": "Anual",
+    "weekly": "Semanal",
     "save": "Economize {{percent}}%",
     "benefits": {
       "priorityQueue": "Prioridade na fila",
@@ -354,7 +355,8 @@
       "subscribe": "Assinar Premium",
       "price": "{{price}}, cancele quando quiser",
       "priceMonthly": "{{price}} por mês, cancele quando quiser",
-      "priceYearly": "{{price}} por ano, cancele quando quiser"
+      "priceYearly": "{{price}} por ano, cancele quando quiser",
+      "priceWeekly": "{{price}} por semana, cancele quando quiser"
     }
   },
   "networkBoundary": {


### PR DESCRIPTION
## Summary

Adds the app side of a weekly subscription so the paywall can offer a third plan alongside yearly and monthly.
Nothing about pricing is hardcoded here; the amounts still come from the store at runtime.

## Details

- Plan names are now read from the package type (annual, monthly, weekly) instead of the product id. On Google Play a product id is `subscriptionId:basePlanId`, so every Android row was falling through to the raw store title. The product ids stay as a fallback.
- New price line for a weekly selection, so the text under the plans says the charge renews weekly instead of only naming the amount. Added `plans.weekly` and `plans.upgradeWall.priceWeekly` in English and Portuguese.
- Plan rows are ordered by billing period (yearly, monthly, weekly) rather than by absolute price, so a price change cannot reshuffle the list. The ordering moved into its own module with unit tests.
- The saving badge now falls back to comparing the yearly price against 52 weeks of the weekly price when an offering has no monthly plan. Monthly stays the preferred comparison base when both exist, and the badge still hides when the yearly plan is not actually cheaper.
- The simulator and Maestro fallback offering gained a weekly package so the three row paywall can be exercised without a store account. That path never runs for real users.
- Metric this serves: it unblocks the R$9,90 weekly impulse plan in the price cut on #268, read as purchases per 100 paywall views and yearly share on the #188 readout.

Refs #268

## Testing steps

1. Open the app and go to the premium screen.
2. Check that three plans are listed, yearly at the top, then monthly, then weekly, with yearly picked for you.
3. Confirm each row shows its own name (Anual, Mensal, Semanal) and its own price.
4. Confirm the yearly row still carries the savings badge.
5. Tap the weekly plan and confirm the line under the list changes to say the price is per week and can be cancelled at any time.
6. Switch the phone language between Portuguese and English and confirm both read naturally.

## Screenshots

Three plans on the paywall in Portuguese, yearly preselected:

![Paywall with three plans](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-weekly-plan-paywall/shots/paywall-three-plans.png)

Weekly plan selected, with the per week price line:

![Weekly plan selected](https://raw.githubusercontent.com/GSTJ/pegada/shots/feat-weekly-plan-paywall/shots/paywall-weekly-selected.png)
