### PR TITLE
feat: minimum app version per platform

### DIFF
--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -96,7 +96,14 @@ const AppLayout = () => {
           animation: "default",
         }}
       />
-      <Stack.Screen name="force-update" />
+      <Stack.Screen
+        name="force-update"
+        options={{
+          // There is no way off this screen except the store, so it does not
+          // get the back gesture either.
+          gestureEnabled: false,
+        }}
+      />
       <Stack.Screen
         name="new-match"
         options={{

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -21,6 +21,7 @@ import { useProtectedRoute } from "@/hooks/use-protected-route";
 import { useTrackScreens } from "@/hooks/use-track-screens";
 import { config } from "@/services/config";
 import { sendError } from "@/services/error-tracking";
+import { useForceUpdateOnForeground } from "@/services/force-update";
 import {
   useGetInitialNotifications,
   usePendingDogProfile,
@@ -79,6 +80,10 @@ const App = () => {
 
   useTrackScreens();
   useGetInitialNotifications();
+  // The launch check only ever runs once. This is the same check on the way
+  // back from the background, for the phones that go weeks without a cold
+  // start and would otherwise never see a raised floor.
+  useForceUpdateOnForeground();
   // Ahead of the auth gate on purpose: the link that carries a referral is
   // usually opened by someone with no account, and the referral has to be on
   // disk before they reach the sign in screen.

--- a/apps/mobile/src/contexts/trpc-provider.tsx
+++ b/apps/mobile/src/contexts/trpc-provider.tsx
@@ -2,7 +2,7 @@ import type { AppRouter } from "@pegada/api";
 
 import { useEffect } from "react";
 import * as React from "react";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 
 import Constants from "expo-constants";
 
@@ -73,6 +73,10 @@ export const trpcQueryClient = api.createClient({
         const appVersion = Constants.expoConfig?.version ?? "0.0.0";
 
         headers.set(RequestHeaders.XAppVersion, appVersion);
+        // Which store this build came from, so the update floor can be raised
+        // on the platform a release is already live on without locking out the
+        // one still waiting on review.
+        headers.set(RequestHeaders.XAppPlatform, Platform.OS);
         headers.set(RequestHeaders.XTRPCSource, "expo-react");
         headers.set(RequestHeaders.AcceptLanguage, i18n.language);
 

--- a/apps/mobile/src/services/force-update.ts
+++ b/apps/mobile/src/services/force-update.ts
@@ -38,9 +38,10 @@ export const rememberMinimumSupportedVersion = (version?: string) => {
  * the check on `getInitialRouteName` never runs again. This re-asks on the way
  * back to the foreground.
  *
- * Once it has sent someone to the update screen it stops asking. There is no
- * route off that screen except the store, so a second answer cannot change
- * anything, and a failed re-check must not quietly let a gated build back in.
+ * Once the wall is up it stops asking, so a later foreground does not navigate
+ * again and report a second `Update Required Shown` for one wall. That flag is
+ * only ever set after the navigation succeeds: latching it on an attempt that
+ * threw would leave the app both ungated and no longer asking.
  */
 let blocked = false;
 
@@ -66,8 +67,13 @@ export const useForceUpdateOnForeground = () => {
 
           if (!forceUpdate) return;
 
-          blocked = true;
+          // `replace` alone only swaps the top of the stack: everything the
+          // user had pushed stays underneath, and one back gesture puts them
+          // straight back into the app the floor just locked them out of.
+          // Clearing the stack first leaves the wall with nothing behind it.
+          if (router.canDismiss()) router.dismissAll();
           router.replace(SceneName.ForceUpdate);
+          blocked = true;
         } catch (error) {
           // Fail open. This runs on every foreground, so a flaky network or an
           // API that is briefly down would otherwise wall off an app that is

--- a/apps/mobile/src/services/force-update.ts
+++ b/apps/mobile/src/services/force-update.ts
@@ -1,0 +1,86 @@
+import type { AppStateStatus } from "react-native";
+
+import { useEffect } from "react";
+import { AppState } from "react-native";
+
+import Constants from "expo-constants";
+import { router } from "expo-router";
+
+import { getTrcpContext } from "@/contexts/trcp-context";
+import { sendError } from "@/services/error-tracking";
+import { SceneName } from "@/types/scene-name";
+
+/** The build the user is on, in the same shape the API compares against. */
+export const getAppVersion = () => Constants.expoConfig?.version ?? "0.0.0";
+
+/**
+ * The floor the API last reported, kept so the update screen can name it in
+ * its analytics without a second round trip on a screen that has no network
+ * state of its own.
+ *
+ * It starts at the running version, which reads as "no gate" until an answer
+ * arrives, and an older API that does not send the floor yet leaves it there.
+ */
+let minimumSupportedVersion = getAppVersion();
+
+export const getMinimumSupportedVersion = () => minimumSupportedVersion;
+
+export const rememberMinimumSupportedVersion = (version?: string) => {
+  if (version) minimumSupportedVersion = version;
+};
+
+/**
+ * A launch is not the only moment a build can fall below the floor.
+ *
+ * The floor is raised by hand, hours after a store approval, and the phones
+ * that matter most at that moment are the ones that never cold start: the app
+ * sits in the background for days and comes back to the same JS context, so
+ * the check on `getInitialRouteName` never runs again. This re-asks on the way
+ * back to the foreground.
+ *
+ * Once it has sent someone to the update screen it stops asking. There is no
+ * route off that screen except the store, so a second answer cannot change
+ * anything, and a failed re-check must not quietly let a gated build back in.
+ */
+let blocked = false;
+
+/** Long enough that flicking between apps does not turn into a request each time. */
+const RECHECK_INTERVAL_MS = 60_000;
+let lastCheckedAt = 0;
+
+export const useForceUpdateOnForeground = () => {
+  useEffect(() => {
+    const onChange = (status: AppStateStatus) => {
+      if (status !== "active" || blocked) return;
+
+      const now = Date.now();
+      if (now - lastCheckedAt < RECHECK_INTERVAL_MS) return;
+      lastCheckedAt = now;
+
+      const check = async () => {
+        try {
+          const { forceUpdate, minimumSupportedVersion: minimum } =
+            await getTrcpContext().client.echo.get.query();
+
+          rememberMinimumSupportedVersion(minimum);
+
+          if (!forceUpdate) return;
+
+          blocked = true;
+          router.replace(SceneName.ForceUpdate);
+        } catch (error) {
+          // Fail open. This runs on every foreground, so a flaky network or an
+          // API that is briefly down would otherwise wall off an app that is
+          // perfectly up to date.
+          sendError(error);
+        }
+      };
+
+      void check();
+    };
+
+    const subscription = AppState.addEventListener("change", onChange);
+
+    return () => subscription.remove();
+  }, []);
+};

--- a/apps/mobile/src/services/get-initial-route-name.ts
+++ b/apps/mobile/src/services/get-initial-route-name.ts
@@ -6,6 +6,7 @@ import Constants from "expo-constants";
 
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
+import { rememberMinimumSupportedVersion } from "@/services/force-update";
 import { getLoggedUserID } from "@/services/get-logged-user-id";
 import { SceneName } from "@/types/scene-name";
 
@@ -58,8 +59,10 @@ export const trackUser = () => {
 
 export const getInitialRouteName = async () => {
   try {
-    const { authenticated, forceUpdate } =
+    const { authenticated, forceUpdate, minimumSupportedVersion } =
       await getTrcpContext().client.echo.get.query();
+
+    rememberMinimumSupportedVersion(minimumSupportedVersion);
 
     if (forceUpdate) {
       return SceneName.ForceUpdate;

--- a/apps/mobile/src/views/ForceUpdate/index.tsx
+++ b/apps/mobile/src/views/ForceUpdate/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Linking } from "react-native";
 
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { useTranslation } from "react-i18next";
 import { useUnistyles } from "react-native-unistyles";
 
@@ -35,7 +36,7 @@ const ForceUpdate: React.FC = () => {
   // off it is the store.
   React.useEffect(() => {
     analytics.track({
-      event_type: "Update Required Shown",
+      event_type: ANALYTICS_EVENTS.UPDATE_REQUIRED_SHOWN,
       event_properties: versionProperties(),
     });
   }, []);
@@ -64,7 +65,7 @@ const ForceUpdate: React.FC = () => {
           testID="force-update-button"
           onPress={() => {
             analytics.track({
-              event_type: "Update Required Store Tapped",
+              event_type: ANALYTICS_EVENTS.UPDATE_REQUIRED_STORE_TAPPED,
               event_properties: versionProperties(),
             });
             // Store automatically redirects to the app store or play store

--- a/apps/mobile/src/views/ForceUpdate/index.tsx
+++ b/apps/mobile/src/views/ForceUpdate/index.tsx
@@ -8,13 +8,37 @@ import Logo from "@/assets/images/logo";
 import { BottomAction } from "@/components/BottomAction";
 import { Button } from "@/components/Button";
 import { APP_SHARE_LINK_BASE } from "@/constants";
+import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
+import {
+  getAppVersion,
+  getMinimumSupportedVersion,
+} from "@/services/force-update";
 
 import { CenterText, Container, styles } from "./styles";
+
+/**
+ * Both events carry the running build and the floor that rejected it, which is
+ * what turns "people are stuck" into "people on 1.6.2 are stuck behind 1.7.2"
+ * without joining anything.
+ */
+const versionProperties = () => ({
+  app_version: getAppVersion(),
+  minimum_version: getMinimumSupportedVersion(),
+});
 
 const ForceUpdate: React.FC = () => {
   const { theme } = useUnistyles();
   const { t } = useTranslation();
+
+  // Mount is the whole event: this screen replaces the app, and the only way
+  // off it is the store.
+  React.useEffect(() => {
+    analytics.track({
+      event_type: "Update Required Shown",
+      event_properties: versionProperties(),
+    });
+  }, []);
 
   return (
     <Container testID="force-update-screen" style={styles.container}>
@@ -39,6 +63,10 @@ const ForceUpdate: React.FC = () => {
         <Button
           testID="force-update-button"
           onPress={() => {
+            analytics.track({
+              event_type: "Update Required Store Tapped",
+              event_properties: versionProperties(),
+            });
             // Store automatically redirects to the app store or play store
             Linking.openURL(`${APP_SHARE_LINK_BASE}/store`).catch(sendError);
           }}

--- a/packages/api/src/routes/echo.test.ts
+++ b/packages/api/src/routes/echo.test.ts
@@ -1,0 +1,148 @@
+import type { NextRequest } from "next/server";
+
+import { config } from "../shared/config";
+import { createInnerTRPCContext } from "../trpc";
+import { echoRouter } from "./echo";
+
+jest.mock("../shared/observability", () => ({
+  observability: {
+    enabled: false,
+    disabledReason: "explicitly-disabled",
+    capture: jest.fn(),
+    captureError: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    register: jest.fn(),
+    flush: jest.fn(),
+    shutdown: jest.fn(),
+  },
+  getPostHogNode: jest.fn(() => null),
+}));
+
+jest.mock("superjson", () => ({
+  __esModule: true,
+  default: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value,
+  },
+}));
+
+/**
+ * The floors are read off `config` at call time, so a test sets them the same
+ * way an operator sets an environment variable, and puts them back afterwards.
+ */
+const floors = {
+  MIN_APP_VERSION: config.MIN_APP_VERSION,
+  MIN_APP_VERSION_IOS: config.MIN_APP_VERSION_IOS,
+  MIN_APP_VERSION_ANDROID: config.MIN_APP_VERSION_ANDROID,
+};
+
+beforeEach(() => {
+  config.MIN_APP_VERSION = "1.5.0";
+  config.MIN_APP_VERSION_IOS = undefined;
+  config.MIN_APP_VERSION_ANDROID = undefined;
+});
+
+afterEach(() => {
+  Object.assign(config, floors);
+});
+
+/** An anonymous call carrying whatever headers a client chose to send. */
+const echo = (headers: Record<string, string>) =>
+  echoRouter
+    .createCaller(
+      createInnerTRPCContext({
+        session: null,
+        req: { headers: new Headers(headers) } as unknown as NextRequest,
+      }),
+    )
+    .get();
+
+describe("echo.get force update", () => {
+  it("gates a build below the shared floor", async () => {
+    const result = await echo({ "x-app-version": "1.4.9" });
+
+    expect(result.forceUpdate).toBe(true);
+    expect(result.minimumSupportedVersion).toBe("1.5.0");
+  });
+
+  it("lets the floor itself and anything above it through", async () => {
+    await expect(echo({ "x-app-version": "1.5.0" })).resolves.toMatchObject({
+      forceUpdate: false,
+    });
+    await expect(echo({ "x-app-version": "2.0.0" })).resolves.toMatchObject({
+      forceUpdate: false,
+    });
+  });
+
+  describe("with a release live on one store and in review on the other", () => {
+    beforeEach(() => {
+      config.MIN_APP_VERSION_IOS = "1.7.2";
+    });
+
+    it("gates the platform the release shipped on", async () => {
+      const result = await echo({
+        "x-app-version": "1.6.2",
+        "x-app-platform": "ios",
+      });
+
+      expect(result.forceUpdate).toBe(true);
+      expect(result.minimumSupportedVersion).toBe("1.7.2");
+    });
+
+    it("leaves the platform with nothing to install alone", async () => {
+      const result = await echo({
+        "x-app-version": "1.6.2",
+        "x-app-platform": "android",
+      });
+
+      expect(result.forceUpdate).toBe(false);
+      expect(result.minimumSupportedVersion).toBe("1.5.0");
+    });
+
+    it("holds a client that does not say which platform it is on to the shared floor", async () => {
+      const result = await echo({ "x-app-version": "1.6.2" });
+
+      expect(result.forceUpdate).toBe(false);
+      expect(result.minimumSupportedVersion).toBe("1.5.0");
+    });
+  });
+
+  it("applies an Android floor to Android only", async () => {
+    config.MIN_APP_VERSION_ANDROID = "1.7.2";
+
+    await expect(
+      echo({ "x-app-version": "1.6.2", "x-app-platform": "android" }),
+    ).resolves.toMatchObject({ forceUpdate: true });
+    await expect(
+      echo({ "x-app-version": "1.6.2", "x-app-platform": "ios" }),
+    ).resolves.toMatchObject({ forceUpdate: false });
+  });
+
+  // The wall has no way out except the store, so every unreadable input has to
+  // resolve to "let them in". A throw here would 500 the one query a launch
+  // waits on, and a `true` would lock people out on a header we misread.
+  describe("failing open", () => {
+    it("does not gate a client that sends no version", async () => {
+      await expect(echo({})).resolves.toMatchObject({ forceUpdate: false });
+    });
+
+    it("does not gate, or throw on, a version it cannot parse", async () => {
+      await expect(
+        echo({ "x-app-version": "not-a-version" }),
+      ).resolves.toMatchObject({ forceUpdate: false });
+    });
+
+    it("falls back to the shared floor on an unknown platform", async () => {
+      config.MIN_APP_VERSION_IOS = "1.7.2";
+
+      const result = await echo({
+        "x-app-version": "1.6.2",
+        "x-app-platform": "windows-phone",
+      });
+
+      expect(result.forceUpdate).toBe(false);
+      expect(result.minimumSupportedVersion).toBe("1.5.0");
+    });
+  });
+});

--- a/packages/api/src/routes/echo.ts
+++ b/packages/api/src/routes/echo.ts
@@ -1,6 +1,6 @@
 import { RequestHeaders } from "@pegada/shared/types/types";
 
-import { EchoService } from "../services/echo-service";
+import { appPlatformSchema, EchoService } from "../services/echo-service";
 import { semverSchema } from "../shared/config";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 
@@ -8,14 +8,25 @@ export const echoRouter = createTRPCRouter({
   get: publicProcedure.query(async ({ ctx }) => {
     if (!ctx.req) throw new Error("Missing request data");
 
-    const appVersionHeader = ctx.req.headers.get(RequestHeaders.XAppVersion);
-    const currentAppVersion = semverSchema.parse(appVersionHeader);
+    // Both headers are read leniently. They come off a client, and an old
+    // build that predates the platform header, or a version string a store
+    // rewrote, must not turn the one query every launch waits on into a 500.
+    // Unreadable means unset, and unset means no gate.
+    const currentAppVersion = semverSchema.safeParse(
+      ctx.req.headers.get(RequestHeaders.XAppVersion),
+    ).data;
 
-    const { authenticated, forceUpdate } = await EchoService.get(
-      currentAppVersion,
-      ctx.session?.user.id,
-    );
+    const platform = appPlatformSchema.safeParse(
+      ctx.req.headers.get(RequestHeaders.XAppPlatform),
+    ).data;
 
-    return { authenticated, forceUpdate };
+    const { authenticated, forceUpdate, minimumSupportedVersion } =
+      await EchoService.get({
+        currentAppVersion,
+        platform,
+        userId: ctx.session?.user.id,
+      });
+
+    return { authenticated, forceUpdate, minimumSupportedVersion };
   }),
 });

--- a/packages/api/src/services/echo-service.ts
+++ b/packages/api/src/services/echo-service.ts
@@ -1,16 +1,60 @@
 import semver from "semver";
+import { z } from "zod";
 
 import { config } from "../shared/config";
 import { UserService } from "./user-service";
 
+/**
+ * The two platforms that have a store to send someone to, and so the only two
+ * that can carry a floor of their own. Anything else falls back to the shared
+ * floor.
+ */
+export const appPlatformSchema = z.enum(["android", "ios"]);
+
+export type AppPlatform = z.infer<typeof appPlatformSchema>;
+
 export class EchoService {
+  /**
+   * The floor this caller has to clear.
+   *
+   * The platform override wins when it is set, so a release that is live on
+   * one store and still in review on the other can be enforced on the store
+   * that shipped without locking out the platform that has nothing to install.
+   * A caller that does not say which platform it is on falls back to the
+   * shared floor, which is also what every client built before the platform
+   * header existed does.
+   */
+  static minimumVersionFor(platform?: AppPlatform) {
+    const perPlatform: Record<AppPlatform, string | undefined> = {
+      android: config.MIN_APP_VERSION_ANDROID,
+      ios: config.MIN_APP_VERSION_IOS,
+    };
+
+    return (platform && perPlatform[platform]) ?? config.MIN_APP_VERSION;
+  }
+
   /**
    * Returns whether the user is authenticated and whether or not
    * they need to update their app version.
    */
-  static async get(currentAppVersion: string, userId?: string) {
-    const minAppVersion = config.MIN_APP_VERSION;
-    const forceUpdate = semver.gt(minAppVersion, currentAppVersion);
+  static async get({
+    currentAppVersion,
+    platform,
+    userId,
+  }: {
+    currentAppVersion?: string;
+    platform?: AppPlatform;
+    userId?: string;
+  }) {
+    const minimumSupportedVersion = EchoService.minimumVersionFor(platform);
+
+    // A version we cannot read is never a version we lock out. This is the
+    // only query standing between a launch and the app, so an unfamiliar or
+    // missing header has to mean "let them in" rather than "show the wall":
+    // the wall has no way out except the store.
+    const forceUpdate = currentAppVersion
+      ? semver.gt(minimumSupportedVersion, currentAppVersion)
+      : false;
 
     let authenticated = false;
     if (userId) {
@@ -18,6 +62,6 @@ export class EchoService {
       authenticated = Boolean(user);
     }
 
-    return { authenticated, forceUpdate };
+    return { authenticated, forceUpdate, minimumSupportedVersion };
   }
 }

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -1,12 +1,30 @@
 import semver from "semver";
 import { z } from "zod";
 
-export const semverSchema = z.string().refine((version) => {
-  const isValid = semver.valid(version);
-  if (!isValid) throw new Error("Invalid version");
+/**
+ * Throwing inside `refine` was never caught by `safeParse`: zod lets an
+ * exception from a refinement escape, so the "safe" call was only safe for
+ * strings that were already valid. Returning a boolean keeps the same message
+ * on an invalid `MIN_APP_VERSION` at boot and makes `safeParse` usable on the
+ * version header, which arrives from a client and can be anything.
+ */
+export const semverSchema = z
+  .string()
+  .refine((version) => semver.valid(version) !== null, {
+    message: "Invalid version",
+  });
 
-  return isValid;
-});
+/**
+ * A semver that is allowed to be absent.
+ *
+ * An empty string counts as absent on purpose. Vercel keeps a variable in the
+ * project once it has been added, so blanking the value is how someone turns a
+ * gate back off, and that has to mean the same thing as never setting it.
+ */
+export const optionalSemverSchema = z.preprocess(
+  (value) => (value === "" ? undefined : value),
+  semverSchema.optional(),
+);
 
 const configSchema = z.object({
   /** GENERAL */
@@ -117,8 +135,25 @@ const configSchema = z.object({
    */
   CRON_SECRET: z.string().optional(),
 
-  /** APP */
+  /**
+   * APP
+   *
+   * The oldest build allowed to keep running. Anything below it gets the
+   * blocking update screen instead of the app.
+   *
+   * `MIN_APP_VERSION` is the floor both stores share. The per platform pair
+   * exists because approvals do not land together: a build can be live on the
+   * App Store while the same build is still in review on Google Play, and
+   * raising one global floor in that window locks every Android user out of an
+   * app they have no way to update yet. Raise the platform that shipped, leave
+   * the other alone, and clear both once the release is out everywhere.
+   *
+   * Unset or empty on a platform means "no platform floor", which falls back
+   * to `MIN_APP_VERSION`.
+   */
   MIN_APP_VERSION: semverSchema,
+  MIN_APP_VERSION_IOS: optionalSemverSchema,
+  MIN_APP_VERSION_ANDROID: optionalSemverSchema,
 
   /**
    * APPLE MAGIC

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -75,6 +75,8 @@ export const ANALYTICS_EVENTS = {
   SUBSCRIPTION_EVENT: "Subscription Event",
   SWIPE: "Swipe",
   SWIPE_BACK: "Swipe Back",
+  UPDATE_REQUIRED_SHOWN: "Update Required Shown",
+  UPDATE_REQUIRED_STORE_TAPPED: "Update Required Store Tapped",
   UPGRADE: "Upgrade",
 } as const;
 
@@ -369,6 +371,21 @@ export type MobileEventProperties = {
     swipe_type: SwipeKind;
   };
   [ANALYTICS_EVENTS.SWIPE_BACK]: undefined;
+  /**
+   * Both halves of the forced update carry the same two versions, so the wall
+   * and the tap that leaves it join on their own without a session lookup.
+   * `Update Required Shown` grouped by `app_version` is how many people a
+   * raised floor is actually holding, and the ratio to
+   * `Update Required Store Tapped` is how many of them go and get the build.
+   */
+  [ANALYTICS_EVENTS.UPDATE_REQUIRED_SHOWN]: {
+    app_version: string;
+    minimum_version: string;
+  };
+  [ANALYTICS_EVENTS.UPDATE_REQUIRED_STORE_TAPPED]: {
+    app_version: string;
+    minimum_version: string;
+  };
   [ANALYTICS_EVENTS.UPGRADE]: {
     package?: string;
     trial?: boolean | null;
@@ -663,6 +680,8 @@ export const MOBILE_EVENT_NAMES = [
   ANALYTICS_EVENTS.SKIP_COMPLETE_DOG_PROFILE,
   ANALYTICS_EVENTS.SWIPE,
   ANALYTICS_EVENTS.SWIPE_BACK,
+  ANALYTICS_EVENTS.UPDATE_REQUIRED_SHOWN,
+  ANALYTICS_EVENTS.UPDATE_REQUIRED_STORE_TAPPED,
   ANALYTICS_EVENTS.UPGRADE,
 ] as const;
 

--- a/packages/shared/types/types.ts
+++ b/packages/shared/types/types.ts
@@ -1,6 +1,7 @@
 export enum RequestHeaders {
   Authorization = "authorization",
   XAppVersion = "x-app-version",
+  XAppPlatform = "x-app-platform",
   XTRPCSource = "x-trpc-source",
   AcceptLanguage = "accept-language",
 }


### PR DESCRIPTION
## Summary

The force update gate already existed but could not safely be switched on, because one global floor cannot describe two stores that approve on different days. It now takes a floor per platform, rechecks on foreground, and reports who it caught.

Why now: once 1.7.x is approved we can push everyone off the 1.6.2 runtime and stop maintaining two update targets.

## Details

- `MIN_APP_VERSION_IOS` and `MIN_APP_VERSION_ANDROID` each override the shared `MIN_APP_VERSION` for one platform. Unset or empty falls back to the shared floor, so nothing changes until someone sets one.
- The app now sends `x-app-platform` alongside the version it already sent. A client that does not send it, which is every build made before this, is held to the shared floor exactly as it is today.
- `semverSchema` threw inside its zod refine, and zod does not catch that, so `safeParse` was only safe on strings that were already valid. A version header the client got wrong turned the one query every launch waits on into a 500. It returns a boolean now.
- Every unreadable input means no gate: no version, an unparseable version, an unknown platform. The update screen has no exit except the store, so guessing wrong in that direction locks people out of an app that was fine.
- The launch check only ever ran once. Phones that sit in the background for days and never cold start would never see a raised floor, so the same check now runs on the way back to the foreground, at most once a minute, and stops once it has sent someone to the update screen. A failed recheck leaves the app running.
- `Update Required Shown` and `Update Required Store Tapped` both carry the running build and the floor that rejected it.
- The update screen clears the stack before it goes up and no longer takes the back gesture. Swapping only the top route left every screen the user had pushed sitting underneath, so a single back swipe put them back in the app the floor had just closed.
- How this gets read: `Update Required Shown` grouped by `app_version` is how many people a raised floor is holding, and its ratio to `Update Required Store Tapped` is how many of them go and get the build. Both join the app version table in the daily readout on #188, which is where the 1.6.2 share should fall once the floor goes up.
- One operational note: a build that has not taken this update sends no platform header, so it is held to the shared `MIN_APP_VERSION`. Gating those users per platform needs this on the 1.6.2 backport first.
- No migration. No change to expo-updates.

## Testing steps

1. Open the app normally. It should start on the swipe deck as usual, with nothing new in the way.
2. Ask for the minimum iOS version to be set above the version you are running, then open the app again. It should show the Pegada logo, "Update Required", and a single Update button, with no way past it.
3. Tap Update. It should open the App Store page for Pegada.
4. Do the same on an Android phone while only the iOS minimum is set. Android should keep working normally, which is the point: a release can be live on one store and still in review on the other.
5. Put the app in the background, have the minimum raised, and bring it back after a minute. It should switch to the update screen without needing a restart.
6. Turn the phone to airplane mode and open the app. It should still work rather than showing the update screen.

## Screenshots

Blocked, with only the iOS floor raised above the running build:

![Update required](https://raw.githubusercontent.com/GSTJ/pegada/shots/min-version/shots/gate-shown.png)

The same build with the floor cleared, launching normally:

![Normal launch](https://raw.githubusercontent.com/GSTJ/pegada/shots/min-version/shots/normal-launch.png)
