### PR TITLE
feat(ci): split subscription events by product in the daily readout

### DIFF
--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -183,6 +183,16 @@ export const BREAKDOWNS = [
     property: "cancel_reason",
     title: "Subscription Event by cancel reason",
   },
+  // Which plan people actually buy. The store product id carries the duration,
+  // so yearly, monthly and weekly land in separate buckets and the mix can be
+  // read after a price change. TEST and TRANSFER events carry no product, so
+  // they sit in `unknown` rather than inflating one of the plans.
+  {
+    id: "subscription_product",
+    event: EVENTS.SUBSCRIPTION_EVENT,
+    property: "product_id",
+    title: "Subscription Event by product",
+  },
 ];
 
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -186,6 +186,25 @@ test("the pricing breakdowns ask the paywall and the subscription the right thin
   );
 });
 
+test("the product breakdown reads the property the server actually sends", () => {
+  const product = BREAKDOWNS.find(
+    (breakdown) => breakdown.id === "subscription_product",
+  );
+  assert.equal(product.event, EVENTS.SUBSCRIPTION_EVENT);
+  assert.equal(product.property, "product_id");
+  assert.match(
+    buildBreakdownQuery(buildWindows(NOW), product),
+    /ifNull\(nullIf\(toString\(properties\.product_id\), ''\), 'unknown'\) AS bucket/,
+  );
+
+  // The name has to match the shared catalogue, otherwise every bucket would
+  // silently be `unknown`.
+  const cataloguePath = fileURLToPath(
+    new URL("../../packages/shared/analytics/events.ts", import.meta.url),
+  );
+  assert.match(readFileSync(cataloguePath, "utf8"), /^\s+product_id\?:/m);
+});
+
 test("every event name still exists in the shared analytics catalogue", () => {
   const cataloguePath = fileURLToPath(
     new URL("../../packages/shared/analytics/events.ts", import.meta.url),

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -87,6 +87,14 @@ const FIXTURE = {
       ["BILLING_ERROR", "current", 1],
       ["unknown", "current", 28],
     ]),
+    subscription_product: breakdown([
+      ["pegada_yearly", "current", 18],
+      ["pegada_yearly", "previous", 11],
+      ["pegada_monthly", "current", 9],
+      ["pegada_monthly", "previous", 14],
+      ["pegada_weekly", "current", 4],
+      ["unknown", "current", 1],
+    ]),
     subscription_period_type: breakdown([
       ["TRIAL", "current", 14],
       ["TRIAL", "previous", 9],
@@ -279,6 +287,7 @@ test("every breakdown gets its own table, ordered by the current window", () => 
     "Paywall Viewed by trigger",
     "Subscription Event by period type",
     "Subscription Event by cancel reason",
+    "Subscription Event by product",
   ]) {
     assert.ok(body.includes(`### ${title}`), `missing ${title}`);
   }
@@ -312,6 +321,18 @@ test("the cancel reason table separates a refund from a voluntary cancel", () =>
   assert.match(reasons, /\| BILLING_ERROR \| 1 \| 0 \| \+1 \(new\) \|/);
   // Every subscription event that is not a cancel carries no reason at all.
   assert.match(reasons, /\| unknown \| 28 \| 0 \| \+28 \(new\) \|/);
+});
+
+test("the product table separates yearly from monthly and weekly", () => {
+  const body = buildReport(FIXTURE);
+  const [, products] = body.split("### Subscription Event by product");
+  assert.match(products, /\| pegada_yearly \| 18 \| 11 \| \+7 \(\+63\.6%\) \|/);
+  assert.match(products, /\| pegada_monthly \| 9 \| 14 \| -5 \(-35\.7%\) \|/);
+  assert.match(products, /\| pegada_weekly \| 4 \| 0 \| \+4 \(new\) \|/);
+  assert.ok(
+    products.indexOf("| pegada_yearly |") <
+      products.indexOf("| pegada_monthly |"),
+  );
 });
 
 test("an empty breakdown says so instead of rendering an empty table", () => {


### PR DESCRIPTION
## Summary

The daily readout now splits `Subscription Event` by the store product, so the yearly, monthly and weekly mix is readable after the price change.

## Details

- Adds a `subscription_product` breakdown keyed on the `product_id` property of the `Subscription Event` server event, next to the existing splits by type, period type and cancel reason.
- `product_id` is what the RevenueCat webhook already sends from `readSubscriptionFields` in the payment service, and it is declared on the shared analytics catalogue, so no new instrumentation was needed and history is readable from the first run.
- TEST and TRANSFER events carry no product. They land in the `unknown` bucket instead of inflating one of the plans.
- Metric it moves: revenue. Plan mix is the missing half of the pricing readout, which already shows how many subscriptions start, renew and cancel but not which duration people buy. The baseline gets set on the first run after merge, then the yearly share is the number to watch across the price change.
- Fixture tests cover the new table and assert the property name still matches the shared catalogue, which is the only way this breakdown could silently turn into a single `unknown` row.

## Testing steps

1. Open the daily metrics issue after the next scheduled run.
2. Scroll to the subscription tables at the bottom of the comment.
3. Confirm there is a table titled "Subscription Event by product" listing one row per plan with the last 7 days, the previous 7 days and the change.

## Screenshots

The readout is a comment, not a screen. This is the new section as the report renders it:

```markdown
### Subscription Event by product

| Bucket | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| pegada_yearly | 18 | 11 | +7 (+63.6%) |
| pegada_monthly | 9 | 14 | -5 (-35.7%) |
| pegada_weekly | 4 | 0 | +4 (new) |
| unknown | 1 | 0 | +1 (new) |
```
