### PR TITLE
fix(ci): read exception names from the exception list in the events audit

### DIFF
--- a/scripts/metrics/events-audit-queries.mjs
+++ b/scripts/metrics/events-audit-queries.mjs
@@ -199,6 +199,82 @@ export const MAX_EXCEPTION_GROUPS = 15;
 export const EXCEPTION_MESSAGE_LENGTH = 120;
 
 /**
+ * The property both SDKs in this repo put an exception on.
+ *
+ * posthog-react-native and posthog-node send an array of exception objects
+ * here, so it arrives as a JSON string and has to be read with the ClickHouse
+ * JSON functions rather than with property dot access. HogQL allows at most
+ * five keys per `JSONExtract` call, which is why the paths below step through
+ * the list, the exception and the frame instead of going in one hop.
+ */
+const EXCEPTION_LIST_PROPERTY = "properties.$exception_list";
+
+/** The exception that was thrown. Anything after it is a cause it wrapped. */
+const THROWN_EXCEPTION = `JSONExtractRaw(${EXCEPTION_LIST_PROPERTY}, 1)`;
+
+/**
+ * The frame that threw.
+ *
+ * Last rather than first: the SDK reverses the parsed stack before it sends
+ * it, so the list runs from the entry point every crash shares to the line the
+ * fault is actually on.
+ */
+const THROWN_FRAME = `JSONExtractRaw(${THROWN_EXCEPTION}, 'stacktrace', 'frames', -1)`;
+
+/** An event property as a string, or nothing when it is not there. */
+function propertyString(key) {
+  return `nullIf(toString(properties.${key}), '')`;
+}
+
+/**
+ * A string out of a JSON value, or nothing when it is missing.
+ *
+ * `?` counts as missing: it is what symbolication writes for a frame it could
+ * not resolve, and a table of question marks is worse than a table of blanks.
+ */
+function jsonString(json, ...path) {
+  const keys = path.map(quote).join(", ");
+  return `nullIf(nullIf(JSONExtractString(${json}, ${keys}), ''), '?')`;
+}
+
+/** The first of these with anything in it. */
+function firstOf(...expressions) {
+  return `coalesce(${expressions.join(", ")})`;
+}
+
+/**
+ * The line that threw, as `function in file`.
+ *
+ * A frame is read three ways because it depends on how far PostHog got with
+ * it. A symbolicated frame has `resolved_name` and `source`; an unsymbolicated
+ * one keeps what the SDK sent under `junk_drawer.raw_frame`; an exception that
+ * never went through error tracking still has the SDK's own `function` and
+ * `filename`. `mangled_name` is last because a minified name is better than an
+ * empty cell and worse than everything above it.
+ *
+ * The two halves are joined through an array with the blanks dropped rather
+ * than concatenated, so a frame with only a file still reads and a frame with
+ * neither collapses to nothing instead of to a stray separator.
+ */
+function topFrameExpression() {
+  const rawFrame = `JSONExtractRaw(${THROWN_FRAME}, 'junk_drawer', 'raw_frame')`;
+  const name = firstOf(
+    jsonString(THROWN_FRAME, "resolved_name"),
+    jsonString(rawFrame, "function"),
+    jsonString(THROWN_FRAME, "function"),
+    jsonString(THROWN_FRAME, "mangled_name"),
+    quote(""),
+  );
+  const file = firstOf(
+    jsonString(THROWN_FRAME, "source"),
+    jsonString(rawFrame, "filename"),
+    jsonString(THROWN_FRAME, "filename"),
+    quote(""),
+  );
+  return `arrayStringConcat(arrayFilter(part -> part != '', [${name}, ${file}]), ' in ')`;
+}
+
+/**
  * The busiest exception groups in the window, one row per type and message.
  *
  * `$exception` is the only autocapture event that is a bug report rather than a
@@ -213,9 +289,17 @@ export const EXCEPTION_MESSAGE_LENGTH = 120;
  * a trailing id are one fault, and counting them apart is how a fault that is
  * happening constantly reads as fifteen rare ones.
  *
- * `$exception_type` and `$exception_message` are what PostHog's error tracking
- * writes. A client that sent an exception without them lands in `unknown`,
- * which is a group worth seeing rather than a row worth dropping.
+ * The name and the message come out of `$exception_list`, which is what both
+ * SDKs in this repo actually send: an array of exceptions, each one carrying
+ * `type`, `value` and a `stacktrace`. `$exception_type` and `$exception_message`
+ * are read as a fallback because PostHog's own error tracking writes them and
+ * anything sent by hand may still carry them. Reading only the flat pair is how
+ * every row in the first version of this table said `unknown`.
+ *
+ * The frame is collected inside the group rather than grouped on, for the same
+ * reason the libraries are: one fault reached by two paths is still one fault.
+ * `max` picks one of them and prefers a real one, since a blank sorts below
+ * every name.
  */
 export function buildExceptionGroupsQuery(
   window,
@@ -223,13 +307,23 @@ export function buildExceptionGroupsQuery(
 ) {
   const lib = `ifNull(nullIf(toString(properties.$lib), ''), 'unknown')`;
   const version = `ifNull(nullIf(toString(properties.${APP_VERSION_PROPERTY}), ''), 'unknown')`;
-  const type = `ifNull(nullIf(toString(properties.$exception_type), ''), 'unknown')`;
-  const message = `ifNull(nullIf(toString(properties.$exception_message), ''), 'unknown')`;
+  const type = firstOf(
+    jsonString(THROWN_EXCEPTION, "type"),
+    propertyString("$exception_type"),
+    quote("unknown"),
+  );
+  const message = firstOf(
+    jsonString(THROWN_EXCEPTION, "value"),
+    propertyString("$exception_message"),
+    quote("unknown"),
+  );
+  const frame = topFrameExpression();
   const clientLibs = CLIENT_LIBS.map(quote).join(", ");
   return [
     "SELECT",
     `  ${type} AS exception_type,`,
     `  substring(${message}, 1, ${EXCEPTION_MESSAGE_LENGTH}) AS message,`,
+    `  substring(max(${frame}), 1, ${EXCEPTION_MESSAGE_LENGTH}) AS frame,`,
     "  count() AS total,",
     "  count(DISTINCT person_id) AS people,",
     `  arrayStringConcat(arraySort(groupUniqArray(${lib})), ', ') AS libs,`,

--- a/scripts/metrics/events-audit-queries.test.mjs
+++ b/scripts/metrics/events-audit-queries.test.mjs
@@ -171,3 +171,227 @@ test("the exception query stays inside its own seven days", () => {
   );
   assert.match(query, /timestamp < toDateTime\('2026-09-04 12:00:00', 'UTC'\)/);
 });
+
+/**
+ * A `$exception` payload the way PostHog stores it once error tracking has
+ * been over it: the frames symbolicated into `resolved_name` and `source`,
+ * with whatever the SDK originally sent kept under `junk_drawer`.
+ *
+ * Copied down from a real row on the project. The audit read the flat
+ * `$exception_type` and `$exception_message` for its first two runs and
+ * reported every crash in the week as one `unknown` group, because neither SDK
+ * in this repo writes those two keys.
+ */
+const RESOLVED_EXCEPTION = JSON.stringify([
+  {
+    mechanism: { handled: false, synthetic: false, type: "generic" },
+    stacktrace: {
+      frames: [
+        {
+          in_app: false,
+          lang: "javascript",
+          mangled_name: "?",
+          module: "promise",
+          resolved: true,
+          resolved_name: "Promise.all",
+          source: "node:internal/promise",
+        },
+        {
+          in_app: true,
+          lang: "javascript",
+          line: 88,
+          mangled_name: "e",
+          resolved: true,
+          resolved_name: "SwipeScreen",
+          source: "app/(app)/index.tsx",
+        },
+        {
+          in_app: true,
+          junk_drawer: {
+            raw_frame: {
+              colno: 12,
+              filename: "src/components/DogCard.tsx",
+              function: "DogCard",
+              lineno: 41,
+            },
+          },
+          lang: "javascript",
+          line: 41,
+          mangled_name: "?",
+          resolved: true,
+          resolved_name: "DogCard",
+          source: "src/components/DogCard.tsx",
+        },
+      ],
+      type: "resolved",
+    },
+    type: "TypeError",
+    value: "undefined is not an object (evaluating 'dog.photos[0].url')",
+  },
+]);
+
+/**
+ * The same crash the way the SDK builds it, before ingestion touches it.
+ *
+ * An exception captured by hand never goes through symbolication, so the frame
+ * keeps the plain `function` and `filename` the stack parser produced.
+ */
+const RAW_EXCEPTION = JSON.stringify([
+  {
+    stacktrace: {
+      frames: [
+        { filename: "app/_layout.tsx", function: "RootLayout", lineno: 24 },
+        {
+          filename: "src/components/DogCard.tsx",
+          function: "DogCard",
+          lineno: 41,
+        },
+      ],
+      type: "raw",
+    },
+    type: "TypeError",
+    value: "undefined is not an object (evaluating 'dog.photos[0].url')",
+  },
+]);
+
+/** The arguments of one call, split on the commas that are not inside another. */
+function splitArguments(text) {
+  const parts = [];
+  let depth = 0;
+  let quoted = false;
+  let start = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (quoted) {
+      quoted = character !== "'";
+    } else if (character === "'") {
+      quoted = true;
+    } else if (character === "(" || character === "[") {
+      depth += 1;
+    } else if (character === ")" || character === "]") {
+      depth -= 1;
+    } else if (character === "," && depth === 0) {
+      parts.push(text.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  parts.push(text.slice(start).trim());
+  return parts;
+}
+
+/** ClickHouse indexes an array from one, and from the end when negative. */
+function elementAt(array, index) {
+  return index < 0 ? array.at(index) : array[index - 1];
+}
+
+/**
+ * Runs one `JSONExtract` call the way ClickHouse would.
+ *
+ * Keys walk into objects, numbers index arrays from one, and a negative number
+ * counts from the end. `Raw` answers with JSON text so the next call up can
+ * read it, `String` answers with the string or nothing, and anything missing
+ * is the empty string rather than an error.
+ */
+function evaluateExtract(expression, payload) {
+  const call = /^JSONExtract(?<kind>String|Raw)\((?<rest>.*)\)$/su.exec(
+    expression.trim(),
+  );
+  if (!call) {
+    return expression.trim() === "properties.$exception_list"
+      ? payload
+      : undefined;
+  }
+
+  const [source, ...path] = splitArguments(call.groups.rest);
+  const json = evaluateExtract(source, payload);
+  let value = json === undefined || json === "" ? undefined : JSON.parse(json);
+  for (const key of path) {
+    if (value === null || value === undefined) {
+      break;
+    }
+    if (key.startsWith("'")) {
+      value = Array.isArray(value) ? undefined : value[key.slice(1, -1)];
+    } else {
+      value = Array.isArray(value) ? elementAt(value, Number(key)) : undefined;
+    }
+  }
+  if (call.groups.kind === "Raw") {
+    return value === undefined ? "" : JSON.stringify(value);
+  }
+  return typeof value === "string" ? value : "";
+}
+
+/** The whole call starting at this point in the query, brackets balanced. */
+function callAt(query, index) {
+  let depth = 0;
+  for (let end = index; end < query.length; end += 1) {
+    if (query[end] === "(") {
+      depth += 1;
+    } else if (query[end] === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return query.slice(index, end + 1);
+      }
+    }
+  }
+  return query.slice(index);
+}
+
+/** Every string the query pulls out of a payload. */
+function readValues(query, payload) {
+  const values = new Set();
+  for (let index = query.indexOf("JSONExtractString("); index !== -1;) {
+    const call = callAt(query, index);
+    values.add(evaluateExtract(call, payload));
+    index = query.indexOf("JSONExtractString(", index + call.length);
+  }
+  return values;
+}
+
+test("the exception query reads the name and message out of the list", () => {
+  // Run against a payload rather than compared as text: a wrong key or a zero
+  // based index fails here instead of in production, where it reads as every
+  // crash in the window being the same unknown fault.
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+
+  for (const payload of [RESOLVED_EXCEPTION, RAW_EXCEPTION]) {
+    const values = readValues(query, payload);
+    assert.ok(values.has("TypeError"));
+    assert.ok(
+      values.has("undefined is not an object (evaluating 'dog.photos[0].url')"),
+    );
+  }
+});
+
+test("the exception query takes the frame that threw, not the entry point", () => {
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+
+  for (const payload of [RESOLVED_EXCEPTION, RAW_EXCEPTION]) {
+    const values = readValues(query, payload);
+    assert.ok(values.has("DogCard"));
+    assert.ok(values.has("src/components/DogCard.tsx"));
+    assert.equal(values.has("RootLayout"), false);
+    assert.equal(values.has("Promise.all"), false);
+  }
+});
+
+test("the exception query still reads the flat properties as a fallback", () => {
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+  assert.match(query, /properties\.\$exception_type/);
+  assert.match(query, /properties\.\$exception_message/);
+  assert.match(query, /, 'unknown'\)/);
+});
+
+test("the exception query truncates the frame and keeps it out of the group", () => {
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+  assert.match(
+    query,
+    new RegExp(
+      `substring\\(max\\(.+\\), 1, ${EXCEPTION_MESSAGE_LENGTH}\\) AS frame`,
+    ),
+  );
+  assert.equal(
+    query.includes("GROUP BY exception_type, message, frame"),
+    false,
+  );
+});

--- a/scripts/metrics/events-audit-report.mjs
+++ b/scripts/metrics/events-audit-report.mjs
@@ -463,6 +463,7 @@ function exceptionSection(exceptions) {
   const rows = exceptions.map((row) => [
     codeCell(row.exception_type),
     codeCell(row.message),
+    codeCell(row.frame) || "n/a",
     number(row.total),
     number(row.people),
     libLabel(row.libs),
@@ -471,10 +472,18 @@ function exceptionSection(exceptions) {
   return [
     "### 5. Exceptions",
     "",
-    `The ${number(MAX_EXCEPTION_GROUPS)} busiest \`$exception\` groups in the window, by exception type and message. Messages are cut at ${number(EXCEPTION_MESSAGE_LENGTH)} characters, and the grouping is on the cut value, so two failures that differ only in a trailing id count as one. App version is the build the phone was running, and \`n/a\` on anything the server threw.`,
+    `The ${number(MAX_EXCEPTION_GROUPS)} busiest \`$exception\` groups in the window, by exception type and message. Messages are cut at ${number(EXCEPTION_MESSAGE_LENGTH)} characters, and the grouping is on the cut value, so two failures that differ only in a trailing id count as one. Frame is the line that threw, on one of the events in the group, and \`n/a\` when the exception arrived without a stack. App version is the build the phone was running, and \`n/a\` on anything the server threw.`,
     "",
     table(
-      ["Type", "Message", "Events", "People", "Library", "App version"],
+      [
+        "Type",
+        "Message",
+        "Frame",
+        "Events",
+        "People",
+        "Library",
+        "App version",
+      ],
       rows,
       "No exceptions in the window.",
     ),

--- a/scripts/metrics/events-audit-report.test.mjs
+++ b/scripts/metrics/events-audit-report.test.mjs
@@ -188,13 +188,14 @@ export const PROPERTY_KEYS = [
 /**
  * Exception groups, one of each shape the table has to survive: an app crash
  * with a version behind it, a server throw with none, a message carrying the
- * two characters that break a markdown table, and a client that sent no type
- * at all.
+ * two characters that break a markdown table and no frame to go with it, and a
+ * client that sent no type at all.
  */
 export const EXCEPTIONS = [
   {
     app_versions: "1.6.2, 1.7.2",
     exception_type: "TypeError",
+    frame: "DogCard in src/components/DogCard.tsx",
     libs: "posthog-react-native",
     message: "undefined is not an object (evaluating 'dog.photos[0].url')",
     people: 14,
@@ -203,6 +204,7 @@ export const EXCEPTIONS = [
   {
     app_versions: "",
     exception_type: "PrismaClientKnownRequestError",
+    frame: "listDogs in packages/api/src/router/dog.ts",
     libs: "posthog-node",
     message: "Timed out fetching a new connection from the connection pool",
     people: 6,
@@ -211,6 +213,7 @@ export const EXCEPTIONS = [
   {
     app_versions: "1.6.2",
     exception_type: "Error",
+    frame: "",
     libs: "posthog-node, posthog-react-native",
     message: "Request failed | GET /api/trpc/dog.list\nstatus `500`",
     people: 3,
@@ -219,6 +222,7 @@ export const EXCEPTIONS = [
   {
     app_versions: "unknown",
     exception_type: "",
+    frame: "",
     libs: "",
     message: "",
     people: 1,
@@ -455,11 +459,11 @@ test("the exception table reports counts, library and app version", () => {
   const body = buildReport(FIXTURE);
   assert.match(
     body,
-    /\| Type \| Message \| Events \| People \| Library \| App version \|/,
+    /\| Type \| Message \| Frame \| Events \| People \| Library \| App version \|/,
   );
   assert.match(
     body,
-    /\| `TypeError` \| `undefined is not an object \(evaluating 'dog\.photos\[0\]\.url'\)` \| 31 \| 14 \| mobile \| `1\.6\.2, 1\.7\.2` \|/,
+    /\| `TypeError` \| `undefined is not an object \(evaluating 'dog\.photos\[0\]\.url'\)` \| `DogCard in src\/components\/DogCard\.tsx` \| 31 \| 14 \| mobile \| `1\.6\.2, 1\.7\.2` \|/,
   );
 });
 
@@ -479,9 +483,9 @@ test("an exception seen from both sides names both", () => {
 test("a message cannot break the row it sits in", () => {
   const body = buildReport(FIXTURE);
   const row = body.split("\n").find((line) => line.includes("Request failed"));
-  // Six columns means seven pipes. A raw pipe or a newline in the message
+  // Seven columns means eight pipes. A raw pipe or a newline in the message
   // would silently shift every column after it.
-  assert.equal(row.split(/(?<!\\)\|/u).length - 1, 7);
+  assert.equal(row.split(/(?<!\\)\|/u).length - 1, 8);
   assert.equal(row.includes("\n"), false);
   assert.match(row, /Request failed \\\| GET/);
 });
@@ -492,6 +496,20 @@ test("a code cell survives backticks, pipes and blank values", () => {
   assert.equal(codeCell("`quoted`"), "`` `quoted` ``");
   assert.equal(codeCell(""), "");
   assert.equal(codeCell(null), "");
+});
+
+test("an exception with no stack says so instead of leaving a gap", () => {
+  const body = buildReport(FIXTURE);
+  const row = body.split("\n").find((line) => line.includes("Request failed"));
+  assert.match(row, /\| n\/a \| 5 \| 3 \|/);
+});
+
+test("the frame column names the line that threw", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(
+    body,
+    /\| `listDogs in packages\/api\/src\/router\/dog\.ts` \| 12 \| 6 \|/,
+  );
 });
 
 test("an exception with nothing on it still gets a row", () => {

--- a/scripts/metrics/events-audit.test.mjs
+++ b/scripts/metrics/events-audit.test.mjs
@@ -70,6 +70,7 @@ function fakeWorld({ existingComment = null, swipeName = "Swipe" } = {}) {
           columns: [
             "exception_type",
             "message",
+            "frame",
             "total",
             "people",
             "libs",
@@ -79,6 +80,7 @@ function fakeWorld({ existingComment = null, swipeName = "Swipe" } = {}) {
             [
               "TypeError",
               "undefined is not an object",
+              "DogCard in src/components/DogCard.tsx",
               6,
               4,
               "posthog-react-native",
@@ -135,7 +137,7 @@ test("a dry run prints the body and never touches GitHub", async () => {
   assert.match(result.body, /### 5\. Exceptions/);
   assert.match(
     result.body,
-    /\| `TypeError` \| `undefined is not an object` \| 6 \| 4 \| mobile \| `1\.6\.2` \|/,
+    /\| `TypeError` \| `undefined is not an object` \| `DogCard in src\/components\/DogCard\.tsx` \| 6 \| 4 \| mobile \| `1\.6\.2` \|/,
   );
   assert.equal(
     fetchImpl.calls.some((call) => !isPostHog(call.url)),


### PR DESCRIPTION
## Summary

The exceptions table in the events audit reported every crash of the week as one row called `unknown`, because it read two properties neither of our SDKs writes. It now reads the exception list the SDKs actually send, so each fault shows up with its name, its message and the line it came from.

## Details

- Reads the thrown exception out of `$exception_list`, taking `type` for the name and `value` for the message, and keeps `$exception_type` and `$exception_message` as a fallback for anything sent by hand.
- Adds a frame column with the function and the file the fault came from. The last frame is the one that threw, since the SDK reverses the stack before sending it.
- A frame is read three ways depending on how far symbolication got with it: `resolved_name` and `source` first, then whatever the SDK sent under `junk_drawer`, then the plain `function` and `filename` on an exception that never went through error tracking. An unresolved frame reads as blank rather than as a question mark.
- Grouping still happens on type and message truncated at 120 characters, so a fault whose message ends in an id stays one row. The frame is collected inside the group rather than grouped on.
- Paths are read in steps because HogQL allows at most five keys per extraction call.
- The query tests now run the generated extractions against two real payload shapes, the one PostHog stores after symbolication and the one the SDK sends, so a wrong key or a stack read from the wrong end fails in the test suite.
- Metric: this is the readout the crash work is prioritised on. Before this, 67 exception events over 53 people were one anonymous row and nothing could be prioritised. The next audit names all 15 groups.

## Testing steps

1. Open the Actions tab of the repository and start the events audit, ticking the box that prints the result in the log instead of commenting.
2. Wait for the job to finish and open its log.
3. Scroll to the exceptions section at the bottom. Every row should carry a real error name, the message a person would have hit, and where in the app or the server it came from, instead of a single row saying unknown.

## Screenshots

The exceptions section from a run of the audit against the live project, on this branch:

```markdown
| Type | Message | Frame | Events | People | Library | App version |
| --- | --- | --- | --- | --- | --- | --- |
| `Error` | `There was an error sending a notification: DeviceNotRegistered.` | `o in .next/server/chunks/104.js` | 19 | 19 | server | n/a |
| `TRPCClientError` | `This photo upload has expired. Try uploading it again.` | `construct in native` | 8 | 1 | mobile | `1.6.2` |
| `TRPCError` | `Already logged in` | `.next/server/app/api/trpc/[trpc]/route.js` | 6 | 6 | server | n/a |
| `Error` | `[googleMobileAds/unknown] Presentation Error: Will not present ad because ad object has been used.` | `_handleAdEvent in /node_modules/react-native-google-mobile-ads/src/ads/MobileAd.ts` | 3 | 1 | mobile | `1.6.1` |
| `Error` | `ENOENT: no such file or directory, open '/var/task/packages/shared/themes/fonts/Gilroy-Medium.ttf'` | `open in node:internal/fs/promises` | 1 | 1 | server | n/a |
```

The same section before this change was one row: `unknown`, `unknown`, 67 events, 53 people.
