### PR TITLE
feat(ci): show active users by city in the daily readout

### DIFF
--- a/scripts/metrics/daily.mjs
+++ b/scripts/metrics/daily.mjs
@@ -19,6 +19,7 @@ import { upsertMarkedComment } from "./github.mjs";
 import { queryHogql } from "./posthog.mjs";
 import {
   BREAKDOWNS,
+  buildActiveUsersByCityQuery,
   buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
@@ -73,6 +74,7 @@ export async function runDailyMetrics({
 
   const [
     activeUsers,
+    activeUsersByCity,
     activeUsersByVersion,
     totals,
     pushReturnsCurrent,
@@ -80,6 +82,10 @@ export async function runDailyMetrics({
     ...breakdownRows
   ] = await Promise.all([
     run("pegada daily metrics: active users", buildActiveUsersQuery(windows)),
+    run(
+      "pegada daily metrics: active users by city",
+      buildActiveUsersByCityQuery(windows),
+    ),
     run(
       "pegada daily metrics: active users by app version",
       buildActiveUsersByVersionQuery(windows),
@@ -110,6 +116,7 @@ export async function runDailyMetrics({
 
   const body = buildReport({
     activeUsers,
+    activeUsersByCity,
     activeUsersByVersion,
     breakdowns,
     generatedAt: now,

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -49,6 +49,16 @@ function fakeWorld({ existingComment = null } = {}) {
           ],
         });
       }
+      if (name.endsWith("active users by city")) {
+        return json({
+          columns: ["bucket", "period", "people"],
+          results: [
+            ["Sao Paulo", "current", 420],
+            ["Sao Paulo", "previous", 400],
+            ["unknown", "current", 124],
+          ],
+        });
+      }
       if (name.endsWith("active users by app version")) {
         return json({
           columns: ["bucket", "period", "people"],
@@ -117,6 +127,11 @@ test("a dry run renders the comment and never touches GitHub", async () => {
     result.body,
     /\| 1\.4\.0 \| 900 \| 210 \| \+690 \(\+328\.6%\) \|/,
   );
+  assert.match(
+    result.body,
+    /\| Sao Paulo \| 420 \| 400 \| \+20 \(\+5\.0%\) \|/,
+  );
+  assert.match(result.body, /No city: 124 of 1,240 \(10\.0%\)/);
   assert.equal(
     fetchImpl.calls.every((call) => isPostHog(call.url)),
     true,
@@ -126,7 +141,7 @@ test("a dry run renders the comment and never touches GitHub", async () => {
 test("one query goes out per metric block", async () => {
   const fetchImpl = fakeWorld();
   await runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW });
-  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 5);
+  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 6);
 });
 
 test("both push return windows are asked for separately and land in the table", async () => {

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -298,6 +298,73 @@ export function buildActiveUsersByVersionQuery(windows) {
 }
 
 /**
+ * How many cities the readout prints. Enough to see where the people are
+ * without turning the comment into a directory of every town one person has
+ * ever opened the app in.
+ */
+export const CITY_TABLE_ROWS = 10;
+
+/** The bucket a person the readout cannot place lands in. */
+export const CITY_UNKNOWN_BUCKET = "unknown";
+
+/**
+ * Where a person is, in the order the answer can be trusted.
+ *
+ * `person.properties.city` is the real one: the app reverse geocodes the device
+ * location once the person allows it and sends the result on identify, so it is
+ * the city they told us they are in. Being a person property rather than an
+ * event property, it is their current city on every one of their events, which
+ * is what keeps a person with a city in a single row.
+ *
+ * `$geoip_city_name` is PostHog's own guess from the request IP. Nothing in the
+ * app turns GeoIP off, so it is present for everyone, but it is an IP lookup: a
+ * carrier that routes through another state, or a VPN, moves the person. It is
+ * the fallback, never the first answer.
+ *
+ * `$geoip_subdivision_1_code` carries the state and is deliberately left out.
+ * Appending it would split one city between the people whose city came from the
+ * app and the people whose city came from an IP, and a state that disagrees
+ * with the city the person chose is worse than no state at all.
+ *
+ * Somebody who declined location is identified with a literal null, which
+ * arrives as the string `null` rather than as an absent property, so it is ruled
+ * out alongside the empty string.
+ */
+function cityExpression() {
+  const stated = "nullIf(nullIf(toString(person.properties.city), ''), 'null')";
+  const geoip = "nullIf(toString(properties.$geoip_city_name), '')";
+  return `coalesce(${stated}, ${geoip}, ${quote(CITY_UNKNOWN_BUCKET)})`;
+}
+
+/**
+ * The active users of {@link buildActiveUsersQuery}, split by city.
+ *
+ * Client events only, the same rule as the headline, so the number under a city
+ * counts people who used the product there rather than rows the API wrote about
+ * them.
+ *
+ * Every city comes back and the formatter keeps the top `CITY_TABLE_ROWS`. That
+ * is deliberate: the `unknown` bucket has to be readable even in a week when it
+ * is too small to make the table.
+ *
+ * Drafted on issue #270 to answer one question, which city gets the seeded team
+ * dogs of issue #273.
+ */
+export function buildActiveUsersByCityQuery(windows) {
+  return [
+    "SELECT",
+    `  ${cityExpression()} AS bucket,`,
+    `  ${periodExpression(windows)} AS period,`,
+    "  count(DISTINCT person_id) AS people",
+    "FROM events",
+    `WHERE ${windowFilter(windows)}`,
+    `  AND ${clientEventFilter()}`,
+    "GROUP BY bucket, period",
+    "ORDER BY bucket, period",
+  ].join("\n");
+}
+
+/**
  * One row per event per window, carrying both the raw count and the number of
  * distinct people behind it. The people column is what answers "how many
  * swipers", so it is cheaper to select it for every event than to run a second

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from "node:url";
 
 import {
   BREAKDOWNS,
+  CITY_TABLE_ROWS,
+  CITY_UNKNOWN_BUCKET,
   CLIENT_LIBS,
   COUNTED_EVENTS,
   EVENTS,
@@ -12,6 +14,7 @@ import {
   PUSH_RETURN_WINDOW_MINUTES,
   SERVER_EVENTS,
   STORE_BUILD_COVERAGE,
+  buildActiveUsersByCityQuery,
   buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
@@ -96,6 +99,57 @@ test("the version split counts distinct people per build, client events only", (
     query,
     /toDateTime\('2026-08-26 12:00:00', 'UTC'\), 'current', 'previous'/,
   );
+});
+
+test("the city split prefers the city the person gave us over the IP guess", () => {
+  const query = buildActiveUsersByCityQuery(buildWindows(NOW));
+  assert.match(
+    query,
+    /coalesce\(nullIf\(nullIf\(toString\(person\.properties\.city\), ''\), 'null'\), nullIf\(toString\(properties\.\$geoip_city_name\), ''\), 'unknown'\) AS bucket/,
+  );
+  // The order is the whole point: an IP lookup never overrides a city the
+  // person allowed the app to read off their device.
+  assert.ok(
+    query.indexOf("person.properties.city") < query.indexOf("$geoip_city_name"),
+  );
+});
+
+test("the city split leaves the state out so one city stays one row", () => {
+  const query = buildActiveUsersByCityQuery(buildWindows(NOW));
+  assert.equal(query.includes("$geoip_subdivision_1_code"), false);
+});
+
+test("the city split counts distinct people over the same client events as the headline", () => {
+  const windows = buildWindows(NOW);
+  const query = buildActiveUsersByCityQuery(windows);
+  const headline = buildActiveUsersQuery(windows);
+  assert.match(query, /count\(DISTINCT person_id\) AS people/);
+  assert.match(query, /properties\.\$lib IN \('posthog-react-native', 'web'\)/);
+  for (const event of SERVER_EVENTS) {
+    assert.ok(query.includes(quote(event)), `${event} is not excluded`);
+  }
+  assert.match(query, /GROUP BY bucket, period/);
+  assert.match(
+    query,
+    /toDateTime\('2026-08-26 12:00:00', 'UTC'\), 'current', 'previous'/,
+  );
+  // Same window and same filter as the headline, so a city count can be read
+  // as a share of it.
+  assert.ok(
+    headline.includes("timestamp >= toDateTime('2026-08-19 12:00:00', 'UTC')"),
+  );
+  assert.ok(
+    query.includes("timestamp >= toDateTime('2026-08-19 12:00:00', 'UTC')"),
+  );
+});
+
+test("the city split asks for every city and leaves the trimming to the report", () => {
+  const query = buildActiveUsersByCityQuery(buildWindows(NOW));
+  // A LIMIT here would drop the unknown bucket in any week it is small, and
+  // that bucket is how the share of unplaced people is read.
+  assert.equal(query.includes("LIMIT"), false);
+  assert.equal(CITY_TABLE_ROWS, 10);
+  assert.equal(CITY_UNKNOWN_BUCKET, "unknown");
 });
 
 test("the totals query still counts server events, which are volume not activity", () => {

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -8,6 +8,8 @@
 
 import {
   BREAKDOWNS,
+  CITY_TABLE_ROWS,
+  CITY_UNKNOWN_BUCKET,
   EVENTS,
   PUSH_RETURN_WINDOW_MINUTES,
   STORE_BUILD_COVERAGE,
@@ -174,7 +176,10 @@ function countRow(index, label, event, field = "total") {
   };
 }
 
-function breakdownTable(rows, { field = "total", header = "Bucket" } = {}) {
+function breakdownTable(
+  rows,
+  { field = "total", header = "Bucket", limit = MAX_BREAKDOWN_ROWS } = {},
+) {
   const index = indexBreakdown(rows, field);
   if (index.size === 0) {
     return "No events in either window.";
@@ -182,7 +187,7 @@ function breakdownTable(rows, { field = "total", header = "Bucket" } = {}) {
   const ordered = [...index.entries()]
     .map(([bucket, entry]) => ({ bucket, ...entry }))
     .sort((a, b) => b.current - a.current || b.previous - a.previous)
-    .slice(0, MAX_BREAKDOWN_ROWS);
+    .slice(0, limit);
 
   return [
     `| ${header} | Last 7 days | Previous 7 days | Delta |`,
@@ -195,10 +200,38 @@ function breakdownTable(rows, { field = "total", header = "Bucket" } = {}) {
 }
 
 /**
+ * Where the city in the table comes from, said once under it.
+ *
+ * Whoever reads this row is about to pick a city to put dogs in, and the two
+ * sources are not equally good: one is the city the person allowed the app to
+ * read off their device, the other is a guess from an IP address.
+ */
+export const CITY_SOURCE_NOTE =
+  "City is the one the app reverse geocoded after the person allowed location, falling back to the PostHog IP lookup and then to unknown.";
+
+/**
+ * The share of the active users the city table cannot place.
+ *
+ * Measured against the headline active users rather than against the sum of the
+ * table, because a person whose events do not all carry the same city appears
+ * in more than one row and the rows can add up to more than the headline.
+ */
+export function noCityLine(rows, activeCurrent, activePrevious) {
+  const entry = indexBreakdown(rows, "people").get(CITY_UNKNOWN_BUCKET) ?? {
+    current: 0,
+    previous: 0,
+  };
+  const share = (people, active) =>
+    `${number(people)} of ${number(active)} (${formatPercent(ratio(people, active))})`;
+  return `No city: ${share(entry.current, activeCurrent)} in the last 7 days, ${share(entry.previous, activePrevious)} in the previous 7 days.`;
+}
+
+/**
  * The whole comment.
  *
  * @param {object} input
  * @param {Array} input.activeUsers rows from the active users query
+ * @param {Array} input.activeUsersByCity rows from the city split
  * @param {Array} input.activeUsersByVersion rows from the version split
  * @param {Record<string, Array>} input.breakdowns rows per breakdown id
  * @param {Date} input.generatedAt when the job ran
@@ -208,6 +241,7 @@ function breakdownTable(rows, { field = "total", header = "Bucket" } = {}) {
  */
 export function buildReport({
   activeUsers,
+  activeUsersByCity,
   activeUsersByVersion,
   breakdowns,
   generatedAt,
@@ -367,6 +401,18 @@ export function buildReport({
       field: "people",
       header: "App version",
     }),
+    "",
+    "### Active users by city",
+    "",
+    breakdownTable(activeUsersByCity, {
+      field: "people",
+      header: "City",
+      limit: CITY_TABLE_ROWS,
+    }),
+    "",
+    noCityLine(activeUsersByCity, activeCurrent, activePrevious),
+    "",
+    CITY_SOURCE_NOTE,
     "",
     ...breakdownSections,
     "This comment is rewritten in place by the daily metrics workflow.",

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -3,11 +3,13 @@ import { test } from "node:test";
 
 import { STORE_BUILD_COVERAGE, buildWindows } from "./queries.mjs";
 import {
+  CITY_SOURCE_NOTE,
   COMMENT_MARKER,
   buildReport,
   coverageNote,
   formatDelta,
   formatRateDelta,
+  noCityLine,
 } from "./report.mjs";
 
 const NOW = new Date("2026-09-02T12:00:00.000Z");
@@ -29,11 +31,33 @@ function versions(rows) {
   return rows.map(([bucket, period, people]) => ({ bucket, people, period }));
 }
 
+/** The city split comes back in the same shape as the version split. */
+const cities = versions;
+
 const FIXTURE = {
   activeUsers: [
     { people: 1240, period: "current" },
     { people: 1100, period: "previous" },
   ],
+  activeUsersByCity: cities([
+    ["Sao Paulo", "current", 420],
+    ["Sao Paulo", "previous", 400],
+    ["Rio de Janeiro", "current", 260],
+    ["Rio de Janeiro", "previous", 300],
+    ["Belo Horizonte", "current", 140],
+    ["Belo Horizonte", "previous", 120],
+    ["Curitiba", "current", 90],
+    ["Porto Alegre", "current", 80],
+    ["Recife", "current", 70],
+    ["Salvador", "current", 60],
+    ["Brasilia", "current", 50],
+    ["Fortaleza", "current", 40],
+    ["Manaus", "current", 30],
+    ["Belem", "current", 20],
+    ["Natal", "current", 10],
+    ["unknown", "current", 124],
+    ["unknown", "previous", 220],
+  ]),
   activeUsersByVersion: versions([
     ["1.4.0", "current", 900],
     ["1.4.0", "previous", 210],
@@ -242,6 +266,69 @@ test("a missing app version split says so instead of rendering an empty table", 
   const body = buildReport({ ...FIXTURE, activeUsersByVersion: [] });
   const [, versionSection] = body.split("### Active users by app version");
   assert.match(versionSection, /^\n\nNo events in either window\./);
+});
+
+test("the city table names the top ten and stops there", () => {
+  const body = buildReport(FIXTURE);
+  assert.ok(body.includes("### Active users by city"));
+  const [, citySection] = body.split("### Active users by city");
+  assert.match(citySection, /\| City \| Last 7 days \|/);
+  assert.match(
+    citySection,
+    /\| Sao Paulo \| 420 \| 400 \| \+20 \(\+5\.0%\) \|/,
+  );
+  assert.match(
+    citySection,
+    /\| Rio de Janeiro \| 260 \| 300 \| -40 \(-13\.3%\) \|/,
+  );
+  assert.ok(
+    citySection.indexOf("| Sao Paulo |") <
+      citySection.indexOf("| Rio de Janeiro |"),
+  );
+  // Fifteen cities and an unknown bucket went in, ten rows come out, and the
+  // unknown bucket earns its row on size like any other.
+  assert.match(citySection, /\| unknown \| 124 \| 220 \| -96 \(-43\.6%\) \|/);
+  assert.ok(citySection.includes("| Fortaleza |"));
+  assert.equal(citySection.includes("| Manaus |"), false);
+  assert.equal(citySection.includes("| Natal |"), false);
+  const [table] = citySection.split("No city:");
+  assert.equal(
+    table.split("\n").filter((line) => line.startsWith("| ")).length,
+    12,
+  );
+});
+
+test("the unplaced people are a share of the headline, not of the table", () => {
+  const body = buildReport(FIXTURE);
+  // 124 of the 1,240 active users this week, 220 of the 1,100 the week before.
+  assert.match(
+    body,
+    /No city: 124 of 1,240 \(10\.0%\) in the last 7 days, 220 of 1,100 \(20\.0%\) in the previous 7 days\./,
+  );
+  assert.ok(body.includes(CITY_SOURCE_NOTE));
+});
+
+test("a week nobody used the app reports no share rather than a division", () => {
+  assert.equal(
+    noCityLine([], 0, 0),
+    "No city: 0 of 0 (n/a) in the last 7 days, 0 of 0 (n/a) in the previous 7 days.",
+  );
+});
+
+test("every active user counts as unplaced when no city ever arrives", () => {
+  const line = noCityLine(
+    [{ bucket: "unknown", people: 12, period: "current" }],
+    12,
+    0,
+  );
+  assert.match(line, /No city: 12 of 12 \(100\.0%\) in the last 7 days/);
+});
+
+test("a missing city split says so instead of rendering an empty table", () => {
+  const body = buildReport({ ...FIXTURE, activeUsersByCity: [] });
+  const [, citySection] = body.split("### Active users by city");
+  assert.match(citySection, /^\n\nNo events in either window\./);
+  assert.match(citySection, /No city: 0 of 1,240 \(0\.0%\)/);
 });
 
 test("the push table reports how many people a send reached", () => {


### PR DESCRIPTION
## Summary

The daily readout now shows where the active users are, so the seeded team dogs test on issue #273 can be aimed at a real city instead of a guess.

Adds one table, top 10 cities by distinct active users over both seven day windows, plus a line for the share of users the readout cannot place.

## Details

- Reuses the query drafted on issue #270: city is read as the person property the app sets, falling back to the PostHog IP lookup, then to unknown.
- The app sets that person property from the device location it reverse geocodes once the person allows it, and sends it on identify. It is a person property, so a user who has a city lands in exactly one row.
- GeoIP is on. Nothing in the mobile client or the shared observability wrapper turns it off, so the IP lookup is there as a fallback for users who never allowed location.
- The state code from the IP lookup is deliberately left out of the label. Appending it would split one city between users whose city came from the app and users whose city came from an IP, and a state that disagrees with the city the person chose is worse than no state.
- Client events only, the same rule the headline active users number uses, so a city count can be read as a share of it.
- The query returns every city and the formatter keeps the top 10. That is what lets the unplaced share stay readable in a week when it is too small to make the table.
- A user identified with an empty location arrives as the string null rather than as a missing value, so that case is folded into unknown alongside the empty string.
- The unplaced share is measured against the headline active users, not against the sum of the table, because a user whose events do not all carry the same city can appear in more than one row.
- Metric this moves: it does not move one by itself. It is the instrumentation that picks the city for issue #273, whose readout is messages sent per new user and D7 retention of the seeded match cohort.

## Testing steps

1. Open the daily metrics comment on issue 188 after the next scheduled run, or start the daily metrics workflow by hand from the Actions tab.
2. Look for the new section listing cities. It should show up to ten cities, each with the number of people for the last seven days, the previous seven days, and the change between them.
3. Check the line under the table. It says how many of the active users had no city at all in each window, and where the city came from.
4. Confirm the biggest city in the table is the one to seed the team dogs in.

## Screenshots

The readout is a comment, so this is the section it now renders:

```markdown
### Active users by city

| City | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| Sao Paulo | 420 | 400 | +20 (+5.0%) |
| Rio de Janeiro | 260 | 300 | -40 (-13.3%) |
| Belo Horizonte | 140 | 120 | +20 (+16.7%) |
| unknown | 124 | 220 | -96 (-43.6%) |
| Curitiba | 90 | 0 | +90 (new) |
| Porto Alegre | 80 | 0 | +80 (new) |
| Recife | 70 | 0 | +70 (new) |
| Salvador | 60 | 0 | +60 (new) |
| Brasilia | 50 | 0 | +50 (new) |
| Fortaleza | 40 | 0 | +40 (new) |

No city: 124 of 1,240 (10.0%) in the last 7 days, 220 of 1,100 (20.0%) in the previous 7 days.

City is the one the app reverse geocoded after the person allowed location, falling back to the PostHog IP lookup and then to unknown.
```

Numbers above come from the test fixture, not from production.
