### PR TITLE
feat(api): record reports instead of opening a mail draft

### DIFF
--- a/apps/mobile/.maestro/21-swipe-journey.yaml
+++ b/apps/mobile/.maestro/21-swipe-journey.yaml
@@ -30,14 +30,12 @@ tags:
 #     like / dislike / maybe / report cycle runs against them safely.
 #
 # Report flow (apps/mobile/src/views/DogProfile/index.tsx → reportUser):
-# - Triggers a native Alert with title "Report" (i18n key dogProfile.report)
-#   and body "By reporting a profile, you are helping us to keep the
-#   community safe. Would you like to proceed?" (dogProfile.reportMessage).
-# - Tapping "Yes" (dogProfile.yes) calls Linking.openURL(mailto:) then
-#   swipe.swipe.mutate({ swipeType: Dislike }) on the reported dog, then
-#   router.back(). No Report table exists — the act of reporting persists
-#   only as an Interest row of type NOT_INTERESTED (verified via psql
-#   \dt — see checks/21-swipe-journey.sh).
+# - Opens the report sheet (src/components/ReportSheet), which lists five
+#   reasons and one optional text box.
+# - Picking a reason enables "Send report", which calls report.create and
+#   writes a Report row, then swipe.swipe.mutate({ swipeType: Dislike }) on
+#   the reported dog, then router.back(). checks/21-swipe-journey.sh asserts
+#   the row landed.
 - launchApp:
     clearState: true
     clearKeychain: true
@@ -117,26 +115,36 @@ tags:
 - scroll
 - waitForAnimationToEnd
 
-# --- 9. Trigger the report Alert and confirm -----------------------------
+# --- 9. Open the report sheet and file a report --------------------------
 # Report row sits at the BOTTOM of the BottomColumn ScrollView, below
-# reportUser(dog) → Alert.alert("Report", ...).
+# reportUser(dog) → showReportSheet(dog).
 - tapOn:
     id: "dog-profile-report"
 - waitForAnimationToEnd:
     timeout: 3000
 
-# Title "Report" + body text (dogProfile.reportMessage from en.json).
+# The five reasons and the send button (reportSheet.* keys from en.json).
 - assertVisible:
-    text: "Report"
-- assertVisible: "By reporting a profile, you are helping us to keep the community safe. Would you like to proceed?"
-- takeScreenshot: 21-report-dialog
+    id: "report-reason-fake_profile"
+- assertVisible:
+    id: "report-submit"
+- takeScreenshot: 21-report-sheet
 
-# Confirm — "Yes" (dogProfile.yes). The handler fires
-# Linking.openURL("mailto:report@pegada.app...") + swipe.swipe.mutate
-# (Dislike) + router.back(). The Alert dismisses regardless of whether
-# mailto can be handled by the simulator.
+# Send is disabled until a reason is picked, so pick one first.
 - tapOn:
-    text: "Yes"
+    id: "report-reason-fake_profile"
+- waitForAnimationToEnd
+- tapOn:
+    id: "report-details"
+- inputText: "Maestro run"
+- hideKeyboard
+- waitForAnimationToEnd
+- takeScreenshot: 21-report-sheet-filled
+
+# report.create writes the row, the sheet closes, a toast confirms, and the
+# reported dog leaves the deck as a dislike.
+- tapOn:
+    id: "report-submit"
 - waitForAnimationToEnd:
     timeout: 8000
 

--- a/apps/mobile/.maestro/checks/21-swipe-journey.sh
+++ b/apps/mobile/.maestro/checks/21-swipe-journey.sh
@@ -7,7 +7,7 @@
 # Schema reminder (psql \dt):
 #   - The Report flow in apps/mobile/src/views/DogProfile/index.tsx opens the
 #     report sheet, which calls `report.create` and then
-#     `swipe.swipe.mutate({ swipeType: Dislike })` — so a report persists as a
+#     `swipe.swipe.mutate({ swipeType: Dislike })`, so a report persists as a
 #     Report row AND as a NOT_INTERESTED Interest row on the reported dog.
 #
 # Expected end state (against the maestro-seed.ts baseline):
@@ -85,7 +85,7 @@ if [[ "$MAYBE" -lt 1 ]]; then
   fail=1
 fi
 if [[ "$REPORTS" -lt 1 ]]; then
-  echo "[check-21] FAIL — expected >=1 Report row from the report sheet, got $REPORTS" >&2
+  echo "[check-21] FAIL: expected >=1 Report row from the report sheet, got $REPORTS" >&2
   fail=1
 fi
 

--- a/apps/mobile/.maestro/checks/21-swipe-journey.sh
+++ b/apps/mobile/.maestro/checks/21-swipe-journey.sh
@@ -5,13 +5,13 @@
 # rows to Postgres for test@pegada.app's Rex.
 #
 # Schema reminder (psql \dt):
-#   - There is NO Report table. The Report flow in
-#     apps/mobile/src/views/DogProfile/index.tsx fires
-#     `Linking.openURL("mailto:report@pegada.app...")` and then
-#     `swipe.swipe.mutate({ swipeType: Dislike })` — so a "report" persists
-#     ONLY as a NOT_INTERESTED Interest row on the reported dog.
+#   - The Report flow in apps/mobile/src/views/DogProfile/index.tsx opens the
+#     report sheet, which calls `report.create` and then
+#     `swipe.swipe.mutate({ swipeType: Dislike })` — so a report persists as a
+#     Report row AND as a NOT_INTERESTED Interest row on the reported dog.
 #
 # Expected end state (against the maestro-seed.ts baseline):
+#   - >=1 Report row filed by the magic user (step 9).
 #   - >=2 NOT_INTERESTED interests from Rex (one for MatchMe step 4,
 #     one for SwipeDog3 step 6, possibly one extra from the Report step 9
 #     against whatever dog was on top after step 7).
@@ -61,7 +61,15 @@ MAYBE=$(psql "$DATABASE_URL" -tAc \
        AND \"swipeType\" = 'MAYBE'
        AND \"deletedAt\" IS NULL")
 
-echo "[check-21] NOT_INTERESTED=$NOT_INTERESTED, INTERESTED=$INTERESTED, MAYBE=$MAYBE"
+# The report sheet writes one row per complaint. Before it existed the report
+# step left nothing behind but the dislike, so this count is the only thing
+# that tells a working sheet apart from a button that silently does nothing.
+REPORTS=$(psql "$DATABASE_URL" -tAc \
+  "SELECT COUNT(*) FROM \"Report\" r
+     JOIN \"User\" u ON u.id = r.\"reporterId\"
+     WHERE u.email = '$TEST_EMAIL'")
+
+echo "[check-21] NOT_INTERESTED=$NOT_INTERESTED, INTERESTED=$INTERESTED, MAYBE=$MAYBE, REPORTS=$REPORTS"
 
 fail=0
 if [[ "$NOT_INTERESTED" -lt 2 ]]; then
@@ -74,6 +82,10 @@ if [[ "$INTERESTED" -lt 1 ]]; then
 fi
 if [[ "$MAYBE" -lt 1 ]]; then
   echo "[check-21] FAIL — expected >=1 MAYBE (SwipeDog4), got $MAYBE" >&2
+  fail=1
+fi
+if [[ "$REPORTS" -lt 1 ]]; then
+  echo "[check-21] FAIL — expected >=1 Report row from the report sheet, got $REPORTS" >&2
   fail=1
 fi
 

--- a/apps/mobile/src/components/ReportSheet/index.tsx
+++ b/apps/mobile/src/components/ReportSheet/index.tsx
@@ -2,8 +2,15 @@ import type { ReportReason } from "@pegada/shared/analytics/events";
 
 import { useState } from "react";
 import * as React from "react";
-import { ActivityIndicator, Linking, TextInput, View } from "react-native";
+import {
+  ActivityIndicator,
+  Keyboard,
+  Linking,
+  TextInput,
+  View,
+} from "react-native";
 
+import { REPORT_DETAILS_MAX_LENGTH } from "@pegada/shared/constants/constants";
 import i18n from "i18next";
 import { useTranslation } from "react-i18next";
 import { magicModal, useMagicModal } from "react-native-magic-modal";
@@ -16,12 +23,10 @@ import Divider from "@/components/divider";
 import { PressableArea } from "@/components/pressable-area";
 import { Text } from "@/components/text";
 import { api } from "@/contexts/trpc-provider";
+import { useKeyboardOverlap } from "@/hooks/use-keyboard-aware-scroll";
 import { sendError } from "@/services/error-tracking";
 
 import { styles } from "./styles";
-
-/** Kept in step with `REPORT_DETAILS_MAX_LENGTH` in the API's report route. */
-const DETAILS_MAX_LENGTH = 500;
 
 /**
  * Order matters: the two reasons that moderation acts on fastest come first,
@@ -108,6 +113,13 @@ const ReportSheetContent = ({
   const { theme } = useUnistyles();
   const { hide } = useMagicModal();
 
+  // The sheet is anchored to the bottom of the screen, so without this the
+  // keyboard covers the note box and the send button under it, and the only
+  // way out is to swipe the sheet away and lose what was typed. Same hook
+  // `Picker` uses for the same reason; a KeyboardAvoidingView does nothing on
+  // Android, where `behavior` has to be left undefined.
+  const keyboardOverlap = useKeyboardOverlap();
+
   const [reason, setReason] = useState<ReportReason | null>(null);
   const [details, setDetails] = useState("");
 
@@ -150,18 +162,27 @@ const ReportSheetContent = ({
 
   return (
     <View
-      style={[styles.overlay, { paddingBottom: insets.bottom || undefined }]}
+      style={[
+        styles.overlay,
+        {
+          paddingBottom: Math.max(keyboardOverlap, insets.bottom) || undefined,
+        },
+      ]}
     >
       <View style={styles.sheet}>
         <View style={styles.handleContainer}>
           <View style={styles.handleBar} />
         </View>
-        <Text fontWeight="medium" fontSize="lg" style={styles.title}>
-          {t("reportSheet.title", { name: firstName })}
-        </Text>
-        <Text fontSize="xs" style={styles.subtitle}>
-          {t("reportSheet.subtitle")}
-        </Text>
+        {/* The header doubles as the way out of the note box: tapping it puts
+            the keyboard away without losing what was typed. */}
+        <PressableArea accessible={false} onPress={() => Keyboard.dismiss()}>
+          <Text fontWeight="medium" fontSize="lg" style={styles.title}>
+            {t("reportSheet.title", { name: firstName })}
+          </Text>
+          <Text fontSize="xs" style={styles.subtitle}>
+            {t("reportSheet.subtitle")}
+          </Text>
+        </PressableArea>
         <Divider style={styles.titleDivider} />
 
         {REASONS.map((item) => (
@@ -181,7 +202,7 @@ const ReportSheetContent = ({
           testID="report-details"
           accessibilityLabel={t("reportSheet.detailsLabel")}
           multiline
-          maxLength={DETAILS_MAX_LENGTH}
+          maxLength={REPORT_DETAILS_MAX_LENGTH}
           value={details}
           onChangeText={setDetails}
           placeholder={t("reportSheet.detailsPlaceholder")}

--- a/apps/mobile/src/components/ReportSheet/index.tsx
+++ b/apps/mobile/src/components/ReportSheet/index.tsx
@@ -1,0 +1,248 @@
+import type { ReportReason } from "@pegada/shared/analytics/events";
+
+import { useState } from "react";
+import * as React from "react";
+import { ActivityIndicator, Linking, TextInput, View } from "react-native";
+
+import i18n from "i18next";
+import { useTranslation } from "react-i18next";
+import { magicModal, useMagicModal } from "react-native-magic-modal";
+import { magicToast } from "react-native-magic-toast";
+import { FadeInDown, FadeOutDown } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useUnistyles } from "react-native-unistyles";
+
+import Divider from "@/components/divider";
+import { PressableArea } from "@/components/pressable-area";
+import { Text } from "@/components/text";
+import { api } from "@/contexts/trpc-provider";
+import { sendError } from "@/services/error-tracking";
+
+import { styles } from "./styles";
+
+/** Kept in step with `REPORT_DETAILS_MAX_LENGTH` in the API's report route. */
+const DETAILS_MAX_LENGTH = 500;
+
+/**
+ * Order matters: the two reasons that moderation acts on fastest come first,
+ * and "something else" is last so it is not the path of least resistance.
+ */
+const REASONS = [
+  { id: "fake_profile", labelKey: "reportSheet.reasonFakeProfile" },
+  {
+    id: "inappropriate_photos",
+    labelKey: "reportSheet.reasonInappropriatePhotos",
+  },
+  { id: "harassment", labelKey: "reportSheet.reasonHarassment" },
+  { id: "spam", labelKey: "reportSheet.reasonSpam" },
+  { id: "other", labelKey: "reportSheet.reasonOther" },
+  // `as const` rather than an annotation: `t` only accepts keys it knows, so
+  // the label keys have to stay literal types.
+] as const satisfies readonly { id: ReportReason; labelKey: string }[];
+
+export type ReportedDog = { id: string; name: string };
+
+/**
+ * What reporting used to be, kept as the fallback for a failed mutation.
+ *
+ * A complaint nobody can read is still better than a complaint that vanishes,
+ * so a person who taps send on a dead connection ends up where they used to
+ * end up rather than nowhere.
+ */
+export const openReportMailto = async (dog: ReportedDog) => {
+  await Linking.openURL(
+    `mailto:report@pegada.app?subject=${encodeURIComponent(
+      i18n.t("dogProfile.report"),
+    )}&body=${encodeURIComponent(
+      i18n.t("dogProfile.reportBody", { id: dog.id, name: dog.name }),
+    )}`,
+  );
+};
+
+const ReasonRow = ({
+  label,
+  selected,
+  testID,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  testID: string;
+  onPress: () => void;
+}) => {
+  return (
+    <PressableArea
+      testID={testID}
+      // Without `accessible`, a Pressable wrapping bare Text is not one
+      // accessibility element on iOS 26 Fabric. Same treatment as `FakeDoorRow`.
+      accessible
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={styles.reasonRow}
+    >
+      <View style={[styles.radio, selected && styles.radioSelected]}>
+        {selected ? <View style={styles.radioDot} /> : null}
+      </View>
+      <Text
+        fontWeight="medium"
+        fontSize="sm"
+        style={[styles.reasonLabel, selected && styles.reasonLabelSelected]}
+      >
+        {label}
+      </Text>
+    </PressableArea>
+  );
+};
+
+const ReportSheetContent = ({
+  dog,
+  onReported,
+}: {
+  dog: ReportedDog;
+  onReported: () => void;
+}) => {
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  const { theme } = useUnistyles();
+  const { hide } = useMagicModal();
+
+  const [reason, setReason] = useState<ReportReason | null>(null);
+  const [details, setDetails] = useState("");
+
+  const [firstName] = dog.name.split(" ");
+
+  const createReport = api.report.create.useMutation({
+    onSuccess: () => {
+      hide(undefined);
+      magicToast.success(t("reportSheet.success"));
+      onReported();
+    },
+    onError: async (error) => {
+      sendError(error);
+      hide(undefined);
+
+      try {
+        await openReportMailto(dog);
+      } catch (mailtoError) {
+        sendError(mailtoError);
+        magicToast.alert(t("reportSheet.failed"));
+        return;
+      }
+
+      onReported();
+    },
+  });
+
+  const handleSubmit = () => {
+    if (!reason || createReport.isPending) return;
+
+    createReport.mutate({
+      targetType: "dog",
+      targetId: dog.id,
+      reason,
+      details: details.trim() || undefined,
+    });
+  };
+
+  const submitDisabled = !reason || createReport.isPending;
+
+  return (
+    <View
+      style={[styles.overlay, { paddingBottom: insets.bottom || undefined }]}
+    >
+      <View style={styles.sheet}>
+        <View style={styles.handleContainer}>
+          <View style={styles.handleBar} />
+        </View>
+        <Text fontWeight="medium" fontSize="lg" style={styles.title}>
+          {t("reportSheet.title", { name: firstName })}
+        </Text>
+        <Text fontSize="xs" style={styles.subtitle}>
+          {t("reportSheet.subtitle")}
+        </Text>
+        <Divider style={styles.titleDivider} />
+
+        {REASONS.map((item) => (
+          <ReasonRow
+            key={item.id}
+            testID={`report-reason-${item.id}`}
+            label={t(item.labelKey)}
+            selected={reason === item.id}
+            onPress={() => setReason(item.id)}
+          />
+        ))}
+
+        <Text fontSize="xs" style={styles.detailsLabel}>
+          {t("reportSheet.detailsLabel")}
+        </Text>
+        <TextInput
+          testID="report-details"
+          accessibilityLabel={t("reportSheet.detailsLabel")}
+          multiline
+          maxLength={DETAILS_MAX_LENGTH}
+          value={details}
+          onChangeText={setDetails}
+          placeholder={t("reportSheet.detailsPlaceholder")}
+          placeholderTextColor={theme.colors.subtitle}
+          style={styles.detailsInput}
+        />
+
+        <PressableArea
+          testID="report-submit"
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={t("reportSheet.submit")}
+          accessibilityState={{ disabled: submitDisabled }}
+          disabled={submitDisabled}
+          onPress={handleSubmit}
+          style={[
+            styles.submitButton,
+            submitDisabled && styles.submitButtonDisabled,
+          ]}
+        >
+          {createReport.isPending ? (
+            <ActivityIndicator color={theme.colors.background} />
+          ) : (
+            <Text fontWeight="bold" fontSize="lg" style={styles.submitLabel}>
+              {t("reportSheet.submit")}
+            </Text>
+          )}
+        </PressableArea>
+      </View>
+
+      <PressableArea
+        testID="report-cancel"
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={t("reportSheet.cancel")}
+        onPress={() => hide(undefined)}
+        style={styles.cancelButton}
+      >
+        <Text fontWeight="bold" fontSize="lg" style={styles.cancelLabel}>
+          {t("reportSheet.cancel")}
+        </Text>
+      </PressableArea>
+    </View>
+  );
+};
+
+/**
+ * The report sheet. Five reasons and one optional box, because the complaint
+ * has to be countable per reason: the kill criterion for the seeded team dogs
+ * in #273 is a number of reports, and the mailto this replaces produced none.
+ *
+ * `onReported` runs after a report is filed, and also after the mailto
+ * fallback, so the reported dog leaves the deck either way.
+ */
+export const showReportSheet = (dog: ReportedDog, onReported: () => void) =>
+  magicModal.show(
+    () => <ReportSheetContent dog={dog} onReported={onReported} />,
+    {
+      style: { justifyContent: "flex-end" },
+      swipeDirection: "down",
+      entering: FadeInDown.duration(220),
+      exiting: FadeOutDown.duration(200),
+    },
+  );

--- a/apps/mobile/src/components/ReportSheet/index.tsx
+++ b/apps/mobile/src/components/ReportSheet/index.tsx
@@ -2,13 +2,7 @@ import type { ReportReason } from "@pegada/shared/analytics/events";
 
 import { useState } from "react";
 import * as React from "react";
-import {
-  ActivityIndicator,
-  Keyboard,
-  Linking,
-  TextInput,
-  View,
-} from "react-native";
+import { ActivityIndicator, Linking, TextInput, View } from "react-native";
 
 import { REPORT_DETAILS_MAX_LENGTH } from "@pegada/shared/constants/constants";
 import i18n from "i18next";
@@ -173,16 +167,12 @@ const ReportSheetContent = ({
         <View style={styles.handleContainer}>
           <View style={styles.handleBar} />
         </View>
-        {/* The header doubles as the way out of the note box: tapping it puts
-            the keyboard away without losing what was typed. */}
-        <PressableArea accessible={false} onPress={() => Keyboard.dismiss()}>
-          <Text fontWeight="medium" fontSize="lg" style={styles.title}>
-            {t("reportSheet.title", { name: firstName })}
-          </Text>
-          <Text fontSize="xs" style={styles.subtitle}>
-            {t("reportSheet.subtitle")}
-          </Text>
-        </PressableArea>
+        <Text fontWeight="medium" fontSize="lg" style={styles.title}>
+          {t("reportSheet.title", { name: firstName })}
+        </Text>
+        <Text fontSize="xs" style={styles.subtitle}>
+          {t("reportSheet.subtitle")}
+        </Text>
         <Divider style={styles.titleDivider} />
 
         {REASONS.map((item) => (

--- a/apps/mobile/src/components/ReportSheet/styles.ts
+++ b/apps/mobile/src/components/ReportSheet/styles.ts
@@ -1,0 +1,185 @@
+import { StyleSheet } from "react-native-unistyles";
+
+// Same derivation as `FakeDoor/styles.ts`: `Text` sits on Gilroy's
+// ascent-descent box rather than its cap height, and neither file can fix
+// that once inside the shared primitive.
+const GILROY_CAP_OFFSET_RATIO = 0.104;
+const capOffset = (fontSize: number) => -(fontSize * GILROY_CAP_OFFSET_RATIO);
+
+const RADIO_SIZE = 20;
+const RADIO_DOT_SIZE = 10;
+
+export const styles = StyleSheet.create((theme) => ({
+  // Sheet chrome, copied from `FakeDoor` so every sheet in the app reads as
+  // the same kind of surface.
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    backgroundColor: theme.colors.surfaceElevated,
+    borderColor: theme.colors.border,
+    borderWidth: theme.stroke.sm,
+    borderTopLeftRadius: theme.radii.md,
+    borderTopRightRadius: theme.radii.md,
+    borderBottomRightRadius: theme.radii.md,
+    borderBottomLeftRadius: theme.radii.md,
+    marginLeft: theme.spacing[3],
+    marginRight: theme.spacing[3],
+    overflow: "hidden",
+  },
+  handleContainer: {
+    alignItems: "center",
+    paddingTop: theme.spacing[2],
+    paddingBottom: theme.spacing[2],
+  },
+  handleBar: {
+    width: theme.spacing[9],
+    height: 4,
+    borderRadius: theme.radii.round,
+    backgroundColor: theme.colors.text,
+    opacity: 0.3,
+  },
+  title: {
+    paddingTop: theme.spacing[1],
+    paddingRight: theme.spacing[4],
+    paddingBottom: theme.spacing[1],
+    paddingLeft: theme.spacing[4],
+  },
+  subtitle: {
+    color: theme.colors.subtitle,
+    paddingRight: theme.spacing[4],
+    paddingBottom: theme.spacing[4],
+    paddingLeft: theme.spacing[4],
+  },
+  titleDivider: {
+    marginLeft: 0,
+    marginRight: 0,
+    backgroundColor: theme.elevated.border,
+  },
+
+  /**
+   * One reason per line rather than the side by side layout `RadioButtons`
+   * uses: that component is built for two short options, and five reasons laid
+   * out in a row wrap into an unreadable grid.
+   */
+  reasonRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing[3],
+    paddingTop: theme.spacing[3.5],
+    paddingRight: theme.spacing[4],
+    paddingBottom: theme.spacing[3.5],
+    paddingLeft: theme.spacing[4],
+  },
+  radio: {
+    width: RADIO_SIZE,
+    height: RADIO_SIZE,
+    borderRadius: theme.radii.round,
+    borderWidth: theme.stroke.md,
+    borderColor: theme.colors.border,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  // Plain style keys rather than Unistyles variants for the three states
+  // below: the rows and the submit button are separate components reading one
+  // stylesheet, and nested `useVariants` calls on the same sheet resolve
+  // against whichever ran last.
+  radioSelected: {
+    borderColor: theme.colors.primary,
+  },
+  radioDot: {
+    width: RADIO_DOT_SIZE,
+    height: RADIO_DOT_SIZE,
+    borderRadius: theme.radii.round,
+    backgroundColor: theme.colors.primary,
+  },
+  reasonLabel: {
+    flexShrink: 1,
+    flexGrow: 1,
+    flexBasis: 0,
+    color: theme.colors.subtitle,
+    transform: [{ translateY: capOffset(theme.typography.sizes.sm.size) }],
+  },
+  reasonLabelSelected: {
+    color: theme.colors.text,
+  },
+
+  detailsLabel: {
+    color: theme.colors.subtitle,
+    paddingTop: theme.spacing[2],
+    paddingRight: theme.spacing[4],
+    paddingBottom: theme.spacing[2],
+    paddingLeft: theme.spacing[4],
+  },
+  detailsInput: {
+    backgroundColor: theme.colors.background,
+    borderColor: theme.colors.border,
+    borderWidth: theme.stroke.sm,
+    borderTopLeftRadius: theme.radii.sm,
+    borderTopRightRadius: theme.radii.sm,
+    borderBottomRightRadius: theme.radii.sm,
+    borderBottomLeftRadius: theme.radii.sm,
+    color: theme.colors.text,
+    fontFamily: theme.typography.fontFamily.regular,
+    fontSize: theme.typography.sizes.sm.size,
+    // A fixed height rather than `multiline` growth: the sheet is anchored to
+    // the bottom of the screen, so a box that grows pushes its own submit
+    // button under the keyboard.
+    height: 88,
+    marginLeft: theme.spacing[4],
+    marginRight: theme.spacing[4],
+    paddingTop: theme.spacing[3],
+    paddingRight: theme.spacing[3],
+    paddingBottom: theme.spacing[3],
+    paddingLeft: theme.spacing[3],
+    textAlignVertical: "top",
+  },
+
+  submitButton: {
+    backgroundColor: theme.colors.primary,
+    borderTopLeftRadius: theme.radii.md,
+    borderTopRightRadius: theme.radii.md,
+    borderBottomRightRadius: theme.radii.md,
+    borderBottomLeftRadius: theme.radii.md,
+    marginTop: theme.spacing[4],
+    marginRight: theme.spacing[4],
+    marginBottom: theme.spacing[4],
+    marginLeft: theme.spacing[4],
+    paddingTop: theme.spacing[4],
+    paddingBottom: theme.spacing[4],
+    alignItems: "center",
+    justifyContent: "center",
+    // Holds the row's height steady when the label is swapped for a spinner.
+    minHeight: 56,
+  },
+  // Disabled until a reason is picked: the five choices are the whole point of
+  // the sheet, and a report with no reason cannot be counted.
+  submitButtonDisabled: {
+    opacity: 0.4,
+  },
+  submitLabel: {
+    color: theme.colors.background,
+    transform: [{ translateY: capOffset(theme.typography.sizes.lg.size) }],
+  },
+
+  cancelButton: {
+    backgroundColor: theme.colors.surfaceElevated,
+    borderColor: theme.colors.border,
+    borderWidth: theme.stroke.sm,
+    borderTopLeftRadius: theme.radii.md,
+    borderTopRightRadius: theme.radii.md,
+    borderBottomRightRadius: theme.radii.md,
+    borderBottomLeftRadius: theme.radii.md,
+    marginTop: theme.spacing[2],
+    marginLeft: theme.spacing[3],
+    marginRight: theme.spacing[3],
+    marginBottom: theme.spacing[2],
+    paddingTop: theme.spacing[4],
+    paddingBottom: theme.spacing[4],
+    alignItems: "center",
+  },
+  cancelLabel: {
+    transform: [{ translateY: capOffset(theme.typography.sizes.lg.size) }],
+  },
+}));

--- a/apps/mobile/src/views/DogProfile/index.tsx
+++ b/apps/mobile/src/views/DogProfile/index.tsx
@@ -2,19 +2,12 @@ import type { SwipeDog } from "@/store/reducers/dogs/swipe";
 
 import { useState } from "react";
 import * as React from "react";
-import {
-  ActivityIndicator,
-  Alert,
-  Linking,
-  View,
-  ScrollView,
-} from "react-native";
+import { ActivityIndicator, Alert, View, ScrollView } from "react-native";
 
 import { router, useLocalSearchParams, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 
 import { Header, HeaderBackButton } from "@react-navigation/elements";
-import i18n from "i18next";
 import { useTranslation } from "react-i18next";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useUnistyles } from "react-native-unistyles";
@@ -27,6 +20,7 @@ import {
   NetworkBoundary,
   UnknownErrorComponent,
 } from "@/components/NetworkBoundary";
+import { showReportSheet } from "@/components/ReportSheet";
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { api } from "@/contexts/trpc-provider";
 import { sendError } from "@/services/error-tracking";
@@ -66,45 +60,35 @@ export const ShareButton: React.FC<{ dog: SwipeDog }> = ({ dog }) => {
   );
 };
 
+/**
+ * What happens to the reported dog once the complaint is filed: it leaves the
+ * deck as a dislike and the profile closes. Unchanged from when reporting was
+ * a mailto, and it runs after the fallback too.
+ */
+const dismissReportedDog = async (dog: SwipeDog) => {
+  try {
+    await getTrcpContext().client.swipe.swipe.mutate({
+      id: dog.id,
+      swipeType: Swipe.Dislike,
+    });
+
+    getTrcpContext().match.getAll.setData(undefined, (request) => {
+      if (!request) return [];
+      return request.filter((match) => match.dog.id !== dog.id);
+    });
+
+    router.back();
+  } catch (error) {
+    // Silently fail: the report is already recorded, and leaving the profile
+    // open is a smaller failure than an error dialog on top of the toast.
+    sendError(error);
+  }
+};
+
 export const reportUser = (dog: SwipeDog) => {
-  Alert.alert(i18n.t("dogProfile.report"), i18n.t("dogProfile.reportMessage"), [
-    {
-      text: i18n.t("dogProfile.cancel"),
-      style: "cancel",
-    },
-    {
-      text: i18n.t("dogProfile.yes"),
-      style: "destructive",
-      onPress: async () => {
-        try {
-          await Linking.openURL(
-            `mailto:report@pegada.app?subject=${encodeURIComponent(
-              i18n.t("dogProfile.report"),
-            )}&body=${encodeURIComponent(
-              i18n.t("dogProfile.reportBody", {
-                id: dog.id,
-                name: dog.name,
-              }),
-            )}`,
-          );
-
-          await getTrcpContext()
-            .client.swipe.swipe.mutate({ id: dog.id, swipeType: Swipe.Dislike })
-            .then(() => {
-              getTrcpContext().match.getAll.setData(undefined, (request) => {
-                if (!request) return [];
-                return request.filter((match) => match.dog.id !== dog.id);
-              });
-
-              router.back();
-            });
-        } catch (error) {
-          // Silently fail
-          sendError(error);
-        }
-      },
-    },
-  ]);
+  showReportSheet({ id: dog.id, name: dog.name }, () => {
+    void dismissReportedDog(dog);
+  });
 };
 
 const useSwipeHandler = (id: string) => {

--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -8,6 +8,7 @@ import { matchRouter } from "./routes/match";
 import { messageRouter } from "./routes/message";
 import { myDogRouter } from "./routes/my-dog";
 import { paymentRouter } from "./routes/payment";
+import { reportRouter } from "./routes/report";
 import { swipeRouter } from "./routes/swipe";
 import { userRouter } from "./routes/user";
 import { createTRPCRouter } from "./trpc";
@@ -25,6 +26,7 @@ export const appRouter = createTRPCRouter({
   echo: echoRouter,
   payment: paymentRouter,
   featureInterest: featureInterestRouter,
+  report: reportRouter,
 });
 
 // export type definition of API

--- a/packages/api/src/routes/report.test.ts
+++ b/packages/api/src/routes/report.test.ts
@@ -1,0 +1,295 @@
+import prisma from "@pegada/database";
+import { generateFakeUserWithDog } from "@pegada/database/fixtures/generate-fake-user-with-dog";
+import { TRPCError } from "@trpc/server";
+
+import { appRouter } from "../root";
+import { createInnerTRPCContext } from "../trpc";
+
+jest.mock("../shared/observability", () => ({
+  observability: {
+    enabled: false,
+    disabledReason: "explicitly-disabled",
+    capture: jest.fn(),
+    captureError: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    register: jest.fn(),
+    flush: jest.fn(),
+    shutdown: jest.fn(),
+  },
+  getPostHogNode: jest.fn(() => null),
+}));
+
+jest.mock("superjson", () => ({
+  __esModule: true,
+  default: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value,
+  },
+}));
+
+const callerFor = (userId: string) =>
+  appRouter.createCaller(
+    createInnerTRPCContext({ session: { user: { id: userId } } }),
+  );
+
+const anonymousCaller = () =>
+  appRouter.createCaller(createInnerTRPCContext({ session: null }));
+
+beforeEach(async () => {
+  await prisma.report.deleteMany();
+  await prisma.featureInterest.deleteMany();
+  await prisma.message.deleteMany();
+  await prisma.match.deleteMany();
+  await prisma.interest.deleteMany();
+  await prisma.image.deleteMany();
+  await prisma.dog.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+it("writes a row naming the reporter, the dog and the reason", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  const result = await callerFor(reporter.id).report.create({
+    targetType: "dog",
+    targetId: dog.id,
+    reason: "fake_profile",
+  });
+
+  const stored = await prisma.report.findUniqueOrThrow({
+    where: { id: result.id },
+  });
+
+  expect(stored).toMatchObject({
+    reporterId: reporter.id,
+    targetType: "DOG",
+    targetId: dog.id,
+    reason: "FAKE_PROFILE",
+    details: null,
+  });
+});
+
+it("stores the optional free text", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  await callerFor(reporter.id).report.create({
+    targetType: "dog",
+    targetId: dog.id,
+    reason: "harassment",
+    details: "  said something threatening in chat  ",
+  });
+
+  const stored = await prisma.report.findFirstOrThrow({
+    where: { reporterId: reporter.id },
+  });
+
+  expect(stored.details).toBe("said something threatening in chat");
+});
+
+// A box holding only spaces is not a complaint anyone can read.
+it("treats blank free text as no free text", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  await callerFor(reporter.id).report.create({
+    targetType: "dog",
+    targetId: dog.id,
+    reason: "spam",
+    details: "   ",
+  });
+
+  const stored = await prisma.report.findFirstOrThrow({
+    where: { reporterId: reporter.id },
+  });
+
+  expect(stored.details).toBeNull();
+});
+
+it("rejects free text longer than 500 characters", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  await expect(
+    callerFor(reporter.id).report.create({
+      targetType: "dog",
+      targetId: dog.id,
+      reason: "other",
+      details: "a".repeat(501),
+    }),
+  ).rejects.toThrow();
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+it("accepts free text of exactly 500 characters", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  await callerFor(reporter.id).report.create({
+    targetType: "dog",
+    targetId: dog.id,
+    reason: "other",
+    details: "a".repeat(500),
+  });
+
+  await expect(prisma.report.count()).resolves.toBe(1);
+});
+
+it("reports an account as well as a dog", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { user: target } = await generateFakeUserWithDog();
+
+  await callerFor(reporter.id).report.create({
+    targetType: "user",
+    targetId: target.id,
+    reason: "inappropriate_photos",
+  });
+
+  const stored = await prisma.report.findFirstOrThrow({
+    where: { reporterId: reporter.id },
+  });
+
+  expect(stored).toMatchObject({
+    targetType: "USER",
+    targetId: target.id,
+    reason: "INAPPROPRIATE_PHOTOS",
+  });
+});
+
+// The column has no foreign key of its own under `relationMode = "prisma"`,
+// so nothing but this check keeps complaints about nothing out of the table.
+it("refuses a dog that does not exist", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+
+  await expect(
+    callerFor(reporter.id).report.create({
+      targetType: "dog",
+      targetId: "no-such-dog",
+      reason: "spam",
+    }),
+  ).rejects.toThrow(TRPCError);
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+it("refuses a deleted dog", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  await prisma.dog.update({
+    where: { id: dog.id },
+    data: { deletedAt: new Date() },
+  });
+
+  await expect(
+    callerFor(reporter.id).report.create({
+      targetType: "dog",
+      targetId: dog.id,
+      reason: "spam",
+    }),
+  ).rejects.toThrow(TRPCError);
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+it("refuses an account that does not exist", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+
+  await expect(
+    callerFor(reporter.id).report.create({
+      targetType: "user",
+      targetId: "no-such-user",
+      reason: "spam",
+    }),
+  ).rejects.toThrow(TRPCError);
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+// Otherwise a count per profile can be inflated by its own owner.
+it("refuses a report of the reporter's own dog", async () => {
+  const { user: reporter, dog } = await generateFakeUserWithDog();
+
+  await expect(
+    callerFor(reporter.id).report.create({
+      targetType: "dog",
+      targetId: dog.id,
+      reason: "spam",
+    }),
+  ).rejects.toThrow(TRPCError);
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+it("refuses a report of the reporter's own account", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+
+  await expect(
+    callerFor(reporter.id).report.create({
+      targetType: "user",
+      targetId: reporter.id,
+      reason: "spam",
+    }),
+  ).rejects.toThrow(TRPCError);
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+it("rejects a reason outside the five choices", async () => {
+  const { user: reporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  await expect(
+    callerFor(reporter.id).report.create({
+      targetType: "dog",
+      targetId: dog.id,
+      // @ts-expect-error deliberately outside the enum
+      reason: "because",
+    }),
+  ).rejects.toThrow();
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+it("requires a signed in reporter", async () => {
+  const { dog } = await generateFakeUserWithDog();
+
+  await expect(
+    anonymousCaller().report.create({
+      targetType: "dog",
+      targetId: dog.id,
+      reason: "spam",
+    }),
+  ).rejects.toThrow(TRPCError);
+
+  await expect(prisma.report.count()).resolves.toBe(0);
+});
+
+// Two people complaining about the same dog is the signal the kill criterion
+// in #273 reads, so both rows have to survive.
+it("keeps one row per complaint about the same dog", async () => {
+  const { user: firstReporter } = await generateFakeUserWithDog();
+  const { user: secondReporter } = await generateFakeUserWithDog();
+  const { dog } = await generateFakeUserWithDog();
+
+  await callerFor(firstReporter.id).report.create({
+    targetType: "dog",
+    targetId: dog.id,
+    reason: "fake_profile",
+  });
+  await callerFor(secondReporter.id).report.create({
+    targetType: "dog",
+    targetId: dog.id,
+    reason: "spam",
+  });
+
+  await expect(
+    prisma.report.count({ where: { targetType: "DOG", targetId: dog.id } }),
+  ).resolves.toBe(2);
+});

--- a/packages/api/src/routes/report.ts
+++ b/packages/api/src/routes/report.ts
@@ -4,6 +4,7 @@ import type {
 } from "@pegada/shared/analytics/events";
 
 import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
+import { REPORT_DETAILS_MAX_LENGTH } from "@pegada/shared/constants/constants";
 import { ReportReason, ReportTargetType } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -28,9 +29,6 @@ const REASONS: Record<ReportReasonName, ReportReason> = {
   other: ReportReason.OTHER,
   spam: ReportReason.SPAM,
 };
-
-/** Long enough to describe what happened, short enough to stay readable. */
-export const REPORT_DETAILS_MAX_LENGTH = 500;
 
 export const reportTargetTypeSchema = z.enum(["dog", "user"]);
 

--- a/packages/api/src/routes/report.ts
+++ b/packages/api/src/routes/report.ts
@@ -1,0 +1,135 @@
+import type {
+  ReportReason as ReportReasonName,
+  ReportTargetType as ReportTargetTypeName,
+} from "@pegada/shared/analytics/events";
+
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
+import { ReportReason, ReportTargetType } from "@prisma/client";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { captureEvent } from "../shared/analytics";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+/**
+ * The wire vocabulary is snake_case to match every other analytics property,
+ * while the column is a Postgres enum in the house SCREAMING_SNAKE style. These
+ * two maps are the only place the two spellings meet.
+ */
+const TARGET_TYPES: Record<ReportTargetTypeName, ReportTargetType> = {
+  dog: ReportTargetType.DOG,
+  user: ReportTargetType.USER,
+};
+
+const REASONS: Record<ReportReasonName, ReportReason> = {
+  fake_profile: ReportReason.FAKE_PROFILE,
+  harassment: ReportReason.HARASSMENT,
+  inappropriate_photos: ReportReason.INAPPROPRIATE_PHOTOS,
+  other: ReportReason.OTHER,
+  spam: ReportReason.SPAM,
+};
+
+/** Long enough to describe what happened, short enough to stay readable. */
+export const REPORT_DETAILS_MAX_LENGTH = 500;
+
+export const reportTargetTypeSchema = z.enum(["dog", "user"]);
+
+export const reportReasonSchema = z.enum([
+  "fake_profile",
+  "harassment",
+  "inappropriate_photos",
+  "other",
+  "spam",
+]);
+
+const createReportSchema = z.object({
+  targetType: reportTargetTypeSchema,
+  targetId: z.string().min(1),
+  reason: reportReasonSchema,
+  // Trimmed first, so a box holding only spaces is stored as "no free text"
+  // rather than as a blank complaint.
+  details: z
+    .string()
+    .trim()
+    .max(REPORT_DETAILS_MAX_LENGTH)
+    .optional()
+    .transform((value) => (value ? value : undefined)),
+});
+
+export const reportRouter = createTRPCRouter({
+  /**
+   * Files one complaint. The row is the point: the kill criterion for the
+   * seeded team dogs in #273 is a count of reports per profile, and until now a
+   * report left the app as an email and was never counted.
+   *
+   * The target is checked before the row is written. `relationMode = "prisma"`
+   * means the column has no foreign key of its own, so a typo would otherwise
+   * land in the table as a complaint about a profile that does not exist.
+   */
+  create: protectedProcedure
+    .input(createReportSchema)
+    .mutation(async ({ ctx, input }) => {
+      const reporterId = ctx.session.user.id;
+
+      if (input.targetType === "dog") {
+        const dog = await ctx.db.dog.findFirst({
+          where: { id: input.targetId, deletedAt: null },
+          select: { userId: true },
+        });
+
+        if (!dog) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Dog not found",
+          });
+        }
+
+        if (dog.userId === reporterId) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "A dog cannot be reported by its own owner",
+          });
+        }
+      } else {
+        if (input.targetId === reporterId) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "An account cannot be reported by itself",
+          });
+        }
+
+        const user = await ctx.db.user.findFirst({
+          where: { id: input.targetId, deletedAt: null },
+          select: { id: true },
+        });
+
+        if (!user) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "User not found",
+          });
+        }
+      }
+
+      const report = await ctx.db.report.create({
+        data: {
+          reporterId,
+          targetType: TARGET_TYPES[input.targetType],
+          targetId: input.targetId,
+          reason: REASONS[input.reason],
+          details: input.details ?? null,
+        },
+        select: { id: true, createdAt: true },
+      });
+
+      // Sent from here rather than from the app so it cannot be dropped by an
+      // ad blocker, and so the event count and the table always agree.
+      captureEvent(reporterId, ANALYTICS_EVENTS.REPORT_SUBMITTED, {
+        reason: input.reason,
+        target_id: input.targetId,
+        target_type: input.targetType,
+      });
+
+      return { id: report.id, createdAt: report.createdAt };
+    }),
+});

--- a/packages/database/migrations/20260904120000_add_report/migration.sql
+++ b/packages/database/migrations/20260904120000_add_report/migration.sql
@@ -1,0 +1,29 @@
+-- Complaints used to leave the app as a mailto, so there was no row to count
+-- and no history to compare against. Additive: one new table and two new enum
+-- types, nothing existing is touched.
+
+-- CreateEnum
+CREATE TYPE "ReportTargetType" AS ENUM ('DOG', 'USER');
+
+-- CreateEnum
+CREATE TYPE "ReportReason" AS ENUM ('FAKE_PROFILE', 'INAPPROPRIATE_PHOTOS', 'HARASSMENT', 'SPAM', 'OTHER');
+
+-- CreateTable
+CREATE TABLE "Report" (
+  "id" TEXT NOT NULL,
+  "reporterId" TEXT NOT NULL,
+  "targetType" "ReportTargetType" NOT NULL,
+  "targetId" TEXT NOT NULL,
+  "reason" "ReportReason" NOT NULL,
+  "details" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "Report_pkey" PRIMARY KEY ("id")
+);
+
+-- The readout query: complaints against one dog over a window.
+CREATE INDEX "Report_targetType_targetId_idx" ON "Report"("targetType", "targetId");
+
+CREATE INDEX "Report_reporterId_idx" ON "Report"("reporterId");
+
+CREATE INDEX "Report_createdAt_idx" ON "Report"("createdAt");

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -69,7 +69,6 @@ model User {
 
   dogs             Dog[]
   featureInterests FeatureInterest[]
-  reports          Report[]
   // Location
   city          String?
   state         String?
@@ -321,7 +320,11 @@ model FeatureInterest {
 model Report {
   id String @id @default(cuid())
 
-  reporter   User   @relation(fields: [reporterId], references: [id])
+  /// The reporter. A plain id rather than a relation, for the same reason
+  /// `User.referredByUserId` is one: under `relationMode = "prisma"` a
+  /// relation is an application side check on every write, and it would also
+  /// make a complaint disappear when the person who filed it deletes their
+  /// account, which is the opposite of what a report is for.
   reporterId String
 
   targetType ReportTargetType

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -44,6 +44,19 @@ enum PlanType {
   PREMIUM
 }
 
+enum ReportTargetType {
+  DOG
+  USER
+}
+
+enum ReportReason {
+  FAKE_PROFILE
+  INAPPROPRIATE_PHOTOS
+  HARASSMENT
+  SPAM
+  OTHER
+}
+
 model Temperament {
   id   String @id(map: "idx_57696_PRIMARY") @default(uuid())
   name String @unique(map: "temperament_name_key")
@@ -56,6 +69,7 @@ model User {
 
   dogs             Dog[]
   featureInterests FeatureInterest[]
+  reports          Report[]
   // Location
   city          String?
   state         String?
@@ -299,6 +313,35 @@ model FeatureInterest {
   // Also the index `relationMode = "prisma"` needs on `userId`, since it
   // leads with that column.
   @@unique([userId, feature])
+}
+
+/// One row per complaint a person filed about a dog or another account.
+/// Before this existed reporting was a mailto, so nothing was counted and
+/// there is no history to compare against.
+model Report {
+  id String @id @default(cuid())
+
+  reporter   User   @relation(fields: [reporterId], references: [id])
+  reporterId String
+
+  targetType ReportTargetType
+
+  /// The reported Dog or User id, depending on `targetType`. Not a relation:
+  /// the column points at one of two tables, and `relationMode = "prisma"`
+  /// would turn either one into an application side existence check on every
+  /// write. The API checks the target exists before it writes the row.
+  targetId String
+
+  reason ReportReason
+
+  /// Optional free text from the reporter, capped at 500 characters by the API.
+  details String?
+
+  createdAt DateTime @default(now())
+
+  @@index([targetType, targetId])
+  @@index([reporterId])
+  @@index([createdAt])
 }
 
 model Breed {

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -62,6 +62,7 @@ export const ANALYTICS_EVENTS = {
   PUSH_RECEIPT_RESULT: "Push Receipt Result",
   PUSH_TICKET_RESULT: "Push Ticket Result",
   REFERRAL_CAPTURED: "Referral Captured",
+  REPORT_SUBMITTED: "Report Submitted",
   RESTORE_PURCHASES: "RestorePurchases",
   RESTORE_PURCHASES_SUCCESS: "Restore Purchases Success",
   SAVE_PREFERENCES_PRESSED: "Save Preferences Pressed",
@@ -95,6 +96,21 @@ export type PaywallTrigger =
   | "other"
   | "profile_plan"
   | "swipe_back";
+
+/** What a complaint is about. A dog card, or the account behind it. */
+export type ReportTargetType = "dog" | "user";
+
+/**
+ * Why someone complained. Five fixed choices rather than free text, because
+ * the readout has to be countable per reason; the free text is optional and
+ * sits alongside them.
+ */
+export type ReportReason =
+  | "fake_profile"
+  | "harassment"
+  | "inappropriate_photos"
+  | "other"
+  | "spam";
 
 /** An OS permission answer, collapsed to the two states that matter. */
 export type PermissionStatus = "denied" | "granted";
@@ -521,6 +537,19 @@ export type ServerEventProperties = {
     message_type: "text";
   };
   /**
+   * One row per complaint, sent from the API so it cannot be dropped by an ad
+   * blocker and so it always agrees with the `Report` table.
+   *
+   * `target_id` rides along because the question this event exists to answer is
+   * about specific profiles, such as the seeded team dogs in #273, and asking
+   * it in PostHog should not need a database round trip.
+   */
+  [ANALYTICS_EVENTS.REPORT_SUBMITTED]: {
+    reason: ReportReason;
+    target_id: string;
+    target_type: ReportTargetType;
+  };
+  /**
    * What the device said about a push, roughly half an hour after it left.
    *
    * This is the only event in the catalogue that means "delivered". Read as an
@@ -750,6 +779,7 @@ export const SERVER_EVENT_NAMES = [
   ANALYTICS_EVENTS.PUSH_TICKET_RESULT,
   ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SENT,
   ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SUPPRESSED,
+  ANALYTICS_EVENTS.REPORT_SUBMITTED,
   ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED,
   ANALYTICS_EVENTS.STORE_REDIRECT,
   ANALYTICS_EVENTS.SUBSCRIPTION_EVENT,

--- a/packages/shared/constants/constants.ts
+++ b/packages/shared/constants/constants.ts
@@ -1,2 +1,7 @@
 export const FREE_DAILY_SWIPE_LIMIT = 10;
 export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+/**
+ * The cap on a report's optional free text. Shared so the box the person types
+ * into and the schema that accepts it cannot drift apart.
+ */
+export const REPORT_DETAILS_MAX_LENGTH = 500;

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -183,6 +183,21 @@
     "sheetBody": "We are putting this one together with care. Want a heads up when it launches?",
     "sheetTitle": "Coming soon"
   },
+  "reportSheet": {
+    "cancel": "Cancel",
+    "detailsLabel": "Want to tell us what happened? (optional)",
+    "detailsPlaceholder": "Write here",
+    "failed": "We could not send that now. Please try again.",
+    "reasonFakeProfile": "Fake profile",
+    "reasonHarassment": "Harassment or threats",
+    "reasonInappropriatePhotos": "Inappropriate photos",
+    "reasonOther": "Something else",
+    "reasonSpam": "Spam or scam",
+    "submit": "Send report",
+    "subtitle": "Pick a reason. We read every report and the profile is never told who sent it.",
+    "success": "Report sent, thank you",
+    "title": "Report {{name}}"
+  },
   "forceUpdate": {
     "button": "Update",
     "description": "A new version of Pegada is available. Please update to continue using the app.",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -183,6 +183,21 @@
     "sheetBody": "Estamos preparando isso com carinho. Quer ser avisado quando lançar?",
     "sheetTitle": "Em breve"
   },
+  "reportSheet": {
+    "cancel": "Cancelar",
+    "detailsLabel": "Quer contar o que aconteceu? (opcional)",
+    "detailsPlaceholder": "Escreva aqui",
+    "failed": "Não deu pra enviar agora. Tenta de novo.",
+    "reasonFakeProfile": "Perfil falso",
+    "reasonHarassment": "Assédio ou ameaça",
+    "reasonInappropriatePhotos": "Fotos impróprias",
+    "reasonOther": "Outro motivo",
+    "reasonSpam": "Spam ou golpe",
+    "submit": "Enviar denúncia",
+    "subtitle": "Escolhe o motivo. A gente olha todas as denúncias e o perfil não fica sabendo quem denunciou.",
+    "success": "Denúncia enviada, obrigado",
+    "title": "Denunciar {{name}}"
+  },
   "forceUpdate": {
     "button": "Atualizar",
     "description": "Uma nova versão do Pegada está disponível. Por favor, atualize para continuar usando o app.",


### PR DESCRIPTION
## Summary

Reporting a dog opened an email draft and left nothing behind, so nobody could count complaints.
A report now writes a row, sends an event, and confirms with a toast, and the email draft stays as the fallback.

## Details

- New `Report` table: who reported, whether the target is a dog or an account, the target id, one of five reasons, optional free text up to 500 characters, and a timestamp. Additive migration, indexed on target and on date so a count per profile over a window is one query.
- New `report.create` mutation on the API. It takes the reporter from the session, checks the target exists and is not the reporter's own dog or account, then writes the row. Free text is trimmed, so a box holding only spaces is stored as no text.
- `Report Submitted` is registered in the shared analytics catalogue and captured from the server, carrying the target type, the target id and the reason. Sent from the API rather than the app so an ad blocker cannot drop it and so the event count and the table always agree.
- The app replaces the confirm dialog and the email draft with a bottom sheet: five reasons, one optional note, one send button that stays disabled until a reason is picked. On success the sheet closes, a toast says the report was sent, and the reported dog leaves the deck as a pass, which is what happened before.
- If the mutation fails the email draft opens exactly as it used to, so a report on a dead connection ends up where it used to end up rather than nowhere.
- Strings in Portuguese and English. The swipe journey flow now walks the sheet, and its post check asserts the row landed.

### Hypothesis and readout

Reports per 1000 matches is the trust readout for the seeded team dogs test in #273, whose kill criterion is more than two reports of seeded dogs in a week.
The baseline is unknown because nothing was ever recorded: every complaint so far left the app as an email and was never counted, so this PR exists to establish the baseline before the seeded dogs ship.

Read it in Postgres by counting rows on the `Report` table grouped by target and by week, or in PostHog on `Report Submitted` split by reason and target id.

## Testing steps

1. Open any dog profile from the swipe deck and scroll to the bottom.
2. Tap the report link with the dog's name on it.
3. A sheet slides up with five reasons. The send button is faded until a reason is picked.
4. Pick a reason, and if you want, type a note in the box below.
5. Tap send. The sheet closes, a message confirms the report was sent, and you land back on the deck with that dog gone.
6. Tap cancel instead at any point and nothing is sent.

## Screenshots

The sheet with the five reasons, the note box with the keyboard up and the send button still in reach, and the confirmation after sending.

![Report sheet](https://raw.githubusercontent.com/GSTJ/pegada/shots/report-flow/shots/report-sheet.png)

![Note box with the keyboard up](https://raw.githubusercontent.com/GSTJ/pegada/shots/report-flow/shots/report-keyboard.png)

![Report sent](https://raw.githubusercontent.com/GSTJ/pegada/shots/report-flow/shots/report-sent.png)
