### PR TITLE
fix(api): prune dead push tokens and stop retrying them

### DIFF
--- a/packages/api/src/queue/handlers/push.test.ts
+++ b/packages/api/src/queue/handlers/push.test.ts
@@ -51,6 +51,10 @@ const { UserService } = jest.requireMock("../../services/user-service") as {
   UserService: { blacklistPushToken: jest.Mock };
 };
 
+const { sendError } = jest.requireMock("../../errors/errors") as {
+  sendError: jest.Mock;
+};
+
 const { observability } = jest.requireMock("../../shared/observability") as {
   observability: { capture: jest.Mock };
 };
@@ -96,6 +100,7 @@ describe("handleSendPushNotification", () => {
       error_code: null,
       kind: "likes_waiting",
       status: "ok",
+      token_pruned: false,
     });
 
     await expect(
@@ -104,6 +109,10 @@ describe("handleSendPushNotification", () => {
         select: { ticketError: true, ticketStatus: true },
       }),
     ).resolves.toEqual({ ticketError: null, ticketStatus: "ok" });
+
+    // A token that worked is a token that stays.
+    expect(UserService.blacklistPushToken).not.toHaveBeenCalled();
+    expect(sendError).not.toHaveBeenCalled();
 
     // A ticket with an id is a push to ask about later.
     expect(enqueue).toHaveBeenCalledWith(
@@ -143,6 +152,7 @@ describe("handleSendPushNotification", () => {
       error_code: "DeviceNotRegistered",
       kind: "match",
       status: "error",
+      token_pruned: true,
     });
 
     await expect(
@@ -156,6 +166,57 @@ describe("handleSendPushNotification", () => {
     });
 
     expect(UserService.blacklistPushToken).toHaveBeenCalledWith(PUSH_TOKEN);
+
+    // An uninstall is the expected end of a token, and it used to be the
+    // loudest exception on the server.
+    expect(sendError).not.toHaveBeenCalled();
+  });
+
+  it("reads a dead token out of the message when Expo left it uncoded", async () => {
+    mockSend.mockResolvedValue([
+      {
+        status: "error",
+        message: `"${PUSH_TOKEN}" is not a registered push notification recipient: DeviceNotRegistered`,
+      },
+    ]);
+
+    await handleSendPushNotification({
+      to: PUSH_TOKEN,
+      title: "oi",
+      userId: USER_ID,
+      pushKind: "match",
+    });
+
+    expect(UserService.blacklistPushToken).toHaveBeenCalledWith(PUSH_TOKEN);
+    expect(sendError).not.toHaveBeenCalled();
+  });
+
+  it("still reports an error that is not a dead token, and keeps the token", async () => {
+    mockSend.mockResolvedValue([
+      { status: "error", details: { error: "MessageTooBig" } },
+    ]);
+
+    await handleSendPushNotification({
+      to: PUSH_TOKEN,
+      title: "oi",
+      userId: USER_ID,
+      pushKind: "match",
+    });
+
+    expect(observability.capture).toHaveBeenCalledWith("Push Ticket Result", {
+      distinctId: USER_ID,
+      error_code: "MessageTooBig",
+      kind: "match",
+      status: "error",
+      token_pruned: false,
+    });
+
+    expect(UserService.blacklistPushToken).not.toHaveBeenCalled();
+    expect(sendError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "There was an error sending a notification: MessageTooBig.",
+      }),
+    );
   });
 
   it("keeps the attribution out of the message handed to Expo", async () => {
@@ -200,6 +261,7 @@ describe("handleCheckPushReceipts", () => {
       error_code: null,
       kind: "likes_waiting",
       status: "ok",
+      token_pruned: false,
     });
 
     await expect(
@@ -239,6 +301,7 @@ describe("handleCheckPushReceipts", () => {
       error_code: "DeviceNotRegistered",
       kind: "likes_waiting",
       status: "error",
+      token_pruned: true,
     });
 
     await expect(
@@ -252,6 +315,41 @@ describe("handleCheckPushReceipts", () => {
     });
 
     expect(UserService.blacklistPushToken).toHaveBeenCalledWith(PUSH_TOKEN);
+    expect(sendError).not.toHaveBeenCalled();
+  });
+
+  it("settles a rejection Expo left uncoded instead of asking forever", async () => {
+    const log = await seedLog();
+
+    mockGetReceipts.mockResolvedValue({
+      "ticket-1": {
+        status: "error",
+        message: `"${PUSH_TOKEN}" is not a registered push notification recipient: DeviceNotRegistered`,
+      },
+    });
+
+    await handleCheckPushReceipts({
+      receipts: [
+        {
+          id: "ticket-1",
+          pushToken: PUSH_TOKEN,
+          userId: USER_ID,
+          pushKind: "likes_waiting",
+          notificationLogId: log.id,
+        },
+      ],
+    });
+
+    expect(observability.capture).toHaveBeenCalledWith("Push Receipt Result", {
+      distinctId: USER_ID,
+      error_code: "DeviceNotRegistered",
+      kind: "likes_waiting",
+      status: "error",
+      token_pruned: true,
+    });
+
+    expect(UserService.blacklistPushToken).toHaveBeenCalledWith(PUSH_TOKEN);
+    expect(enqueue).not.toHaveBeenCalled();
   });
 
   it("says nothing about a receipt that has not settled, and asks again", async () => {

--- a/packages/api/src/queue/handlers/push.ts
+++ b/packages/api/src/queue/handlers/push.ts
@@ -1,3 +1,4 @@
+import type { ExpoDeliveryResult } from "../../shared/push-errors";
 import type {
   ICheckPushNotificationReceiptsJobData,
   IPushReceiptReference,
@@ -17,6 +18,7 @@ import { sendError } from "../../errors/errors";
 import { UserService } from "../../services/user-service";
 import { captureEvent } from "../../shared/analytics";
 import { config } from "../../shared/config";
+import { DEAD_TOKEN_ERROR, isDeadTokenError } from "../../shared/push-errors";
 import { enqueue } from "../enqueue";
 import { TOPICS } from "../topics";
 
@@ -28,20 +30,23 @@ const expo = new Expo({
   maxConcurrentRequests: 100,
 });
 
-const handlePushError = async (errorMessage: string, pushToken: string) => {
-  const newError = new Error(
-    `There was an error sending a notification: ${errorMessage}.`,
-  );
+/**
+ * Take a token Expo has rejected out of circulation.
+ *
+ * Best effort. A prune that fails is worth reporting, but it must not fail a
+ * job whose push has already been handed over: the queue would retry the send
+ * and the user would see it twice.
+ */
+const pruneToken = async (pushToken: string) => {
+  try {
+    await UserService.blacklistPushToken(pushToken);
 
-  if (errorMessage === "DeviceNotRegistered") {
-    try {
-      await UserService.blacklistPushToken(pushToken);
-    } catch (error) {
-      sendError(error);
-    }
+    return true;
+  } catch (error) {
+    sendError(error);
+
+    return false;
   }
-
-  sendError(newError);
 };
 
 type DeliveryEvent =
@@ -51,26 +56,46 @@ type DeliveryEvent =
 type DeliveryOutcome = {
   errorCode: string | null;
   status: PushDeliveryStatus;
+  /** Expo says the token is gone, so nothing may be sent to it again. */
+  deadToken: boolean;
 };
 
-/** A ticket or a receipt, in the two fields both of them answer with. */
-type ExpoResult = { details?: { error?: string }; status: string };
-
-/** Neither confirmed nor rejected yet, so there is nothing to record. */
-const isInFlight = (result: ExpoResult) =>
-  result.status !== "ok" && !result.details?.error;
+/**
+ * Neither confirmed nor rejected yet, so there is nothing to record.
+ *
+ * Read off the status rather than off `details.error`: Expo does not always
+ * put a code on a rejection, and treating an uncoded rejection as unsettled
+ * had it queued for another look every thirty-five minutes forever, while the
+ * dead token that caused it stayed in the database.
+ */
+const isInFlight = (result: ExpoDeliveryResult) =>
+  result.status !== "ok" && result.status !== "error";
 
 /**
  * Expo's answer, in the two fields the events break down by.
  *
  * An error with no code of its own still counts as an error: what matters for
  * the ok rate is that the push did not make it, and `Unknown` is a more honest
- * bucket than dropping the row.
+ * bucket than dropping the row. A dead token recognised from the message alone
+ * is filed under the code it would have carried, so the ok rate does not split
+ * the same failure across two buckets and the cadence gate, which reads the
+ * code back off `NotificationLog`, sees it.
  */
-const outcomeOf = (result: ExpoResult): DeliveryOutcome =>
-  result.status === "error"
-    ? { errorCode: result.details?.error ?? "Unknown", status: "error" }
-    : { errorCode: null, status: "ok" };
+const outcomeOf = (result: ExpoDeliveryResult): DeliveryOutcome => {
+  if (result.status !== "error") {
+    return { errorCode: null, status: "ok", deadToken: false };
+  }
+
+  const deadToken = isDeadTokenError(result);
+
+  return {
+    errorCode: deadToken
+      ? DEAD_TOKEN_ERROR
+      : (result.details?.error ?? "Unknown"),
+    status: "error",
+    deadToken,
+  };
+};
 
 /**
  * Write down what became of one push.
@@ -89,12 +114,14 @@ const recordDelivery = async (
   event: DeliveryEvent,
   { notificationLogId, pushKind, userId }: PushAttribution,
   { errorCode, status }: DeliveryOutcome,
+  tokenPruned: boolean,
 ) => {
   if (userId) {
     captureEvent(userId, event, {
       error_code: errorCode,
       kind: pushKind ?? null,
       status,
+      token_pruned: tokenPruned,
     });
   }
 
@@ -111,6 +138,43 @@ const recordDelivery = async (
   } catch (error) {
     sendError(error);
   }
+};
+
+/**
+ * Everything that has to happen once Expo has answered about one push.
+ *
+ * The prune comes before the event on purpose, so the event can say whether
+ * the token was actually dropped. That turns "how many dead devices are we
+ * still holding" into a number on the same series as the error code it came
+ * from, rather than something only the database knows.
+ *
+ * `DeviceNotRegistered` is deliberately not reported as an error. Somebody
+ * uninstalling the app is the expected end of a push token, and reporting it
+ * made it the loudest exception on the server while the only sensible response
+ * to it, dropping the token, was already happening one line above. Every other
+ * code still goes to the funnel, because those are the ones nobody has looked
+ * at yet.
+ */
+const settle = async (
+  event: DeliveryEvent,
+  attribution: PushAttribution,
+  pushToken: string | undefined,
+  result: ExpoDeliveryResult,
+) => {
+  const outcome = outcomeOf(result);
+
+  const tokenPruned =
+    outcome.deadToken && pushToken ? await pruneToken(pushToken) : false;
+
+  await recordDelivery(event, attribution, outcome, tokenPruned);
+
+  if (outcome.status !== "error" || outcome.deadToken) return;
+
+  sendError(
+    new Error(
+      `There was an error sending a notification: ${outcome.errorCode}.`,
+    ),
+  );
 };
 
 export const handleSendPushNotification = async (
@@ -135,20 +199,16 @@ export const handleSendPushNotification = async (
   const tickets = await expo.sendPushNotificationsAsync([message]);
 
   // Error codes: https://docs.expo.io/push-notifications/sending-notifications/#individual-errors
-  await Promise.all([
-    ...tickets.map((ticket) =>
-      recordDelivery(
+  await Promise.all(
+    tickets.map((ticket) =>
+      settle(
         ANALYTICS_EVENTS.PUSH_TICKET_RESULT,
         attribution,
-        outcomeOf(ticket),
+        pushToken,
+        ticket,
       ),
     ),
-    ...tickets.flatMap((ticket) =>
-      ticket.status === "error" && ticket.details?.error
-        ? [handlePushError(ticket.details.error, pushToken)]
-        : [],
-    ),
-  ]);
+  );
 
   // Tickets for notifications that could not be enqueued have no id.
   const receipts = tickets.flatMap((ticket) =>
@@ -187,17 +247,14 @@ export const handleCheckPushReceipts = async ({
       if (isInFlight(receipt)) return [];
 
       const reference = referenceFor(id);
-      const pushToken = reference?.pushToken;
 
       return [
-        recordDelivery(
+        settle(
           ANALYTICS_EVENTS.PUSH_RECEIPT_RESULT,
           reference ?? {},
-          outcomeOf(receipt),
+          reference?.pushToken,
+          receipt,
         ),
-        ...(receipt.status === "error" && receipt.details?.error && pushToken
-          ? [handlePushError(receipt.details.error, pushToken)]
-          : []),
       ];
     }),
   );

--- a/packages/api/src/services/reengagement-cadence.ts
+++ b/packages/api/src/services/reengagement-cadence.ts
@@ -3,6 +3,8 @@ import type { ReengagementSuppressionReason } from "@pegada/shared/analytics/eve
 import prisma from "@pegada/database";
 import { Prisma } from "@prisma/client";
 
+import { DEAD_TOKEN_ERROR } from "../shared/push-errors";
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
@@ -68,9 +70,6 @@ const MAX_PUSHES_PER_MONTH = 2;
  * them.
  */
 const SLOT_SLACK_HOURS = 2;
-
-/** Expo's code for a token that no longer belongs to an install. */
-const DEAD_TOKEN_ERROR = "DeviceNotRegistered";
 
 /**
  * When a suppression is worth an event.

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -303,6 +303,36 @@ describe("selectUnansweredMatchCandidates", () => {
 
     await expect(selectUnansweredMatchCandidates(NOW)).resolves.toHaveLength(1);
   });
+
+  it("skips a user whose token Expo has already rejected", async () => {
+    const { match } = await seedSilentMatch(25);
+    const silent = await prisma.match.findUniqueOrThrow({
+      where: { id: match.id },
+      select: { requester: { select: { userId: true } } },
+    });
+
+    // What the pruner writes when a push comes back `DeviceNotRegistered`.
+    await prisma.user.update({
+      where: { id: silent.requester.userId },
+      data: { pushToken: "" },
+    });
+
+    const candidates = await selectUnansweredMatchCandidates(NOW);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.userId).not.toBe(silent.requester.userId);
+  });
+
+  it("leaves out a match where neither side can be reached", async () => {
+    const { requester, responder } = await seedSilentMatch(25);
+
+    await prisma.user.updateMany({
+      where: { id: { in: [requester.userId, responder.userId] } },
+      data: { pushToken: "" },
+    });
+
+    await expect(selectUnansweredMatchCandidates(NOW)).resolves.toEqual([]);
+  });
 });
 
 describe("selectNewDogsNearbyCandidates", () => {

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -6,6 +6,7 @@ import { cadenceDecision, readCadence } from "./reengagement-cadence";
 import {
   isWithinSendWindow,
   localHourFromLongitude,
+  MAX_CANDIDATES_PER_QUERY,
   REENGAGEMENT_KINDS,
   ReengagementService,
   selectLikesWaitingCandidates,
@@ -304,34 +305,67 @@ describe("selectUnansweredMatchCandidates", () => {
     await expect(selectUnansweredMatchCandidates(NOW)).resolves.toHaveLength(1);
   });
 
-  it("skips a user whose token Expo has already rejected", async () => {
-    const { match } = await seedSilentMatch(25);
-    const silent = await prisma.match.findUniqueOrThrow({
-      where: { id: match.id },
-      select: { requester: { select: { userId: true } } },
+  /**
+   * `count` silent matches between users whose token has already been pruned,
+   * seeded in bulk because the point of the test below is the row count.
+   */
+  const seedPrunedMatches = async (count: number, createdAt: Date) => {
+    const dogs = Array.from({ length: count * 2 }, (_, index) => ({
+      id: `pruned-dog-${index}`,
+      name: `pruned-${index}`,
+      gender: index % 2 === 0 ? ("MALE" as const) : ("FEMALE" as const),
+      userId: `pruned-user-${index}`,
+    }));
+
+    await prisma.user.createMany({
+      data: dogs.map((dog, index) => ({
+        id: dog.userId,
+        email: `pruned-${index}@test.example`,
+        // What `UserService.blacklistPushToken` writes once Expo has answered
+        // `DeviceNotRegistered`.
+        pushToken: "",
+        latitude: LATITUDE,
+        longitude: LONGITUDE,
+      })),
     });
 
-    // What the pruner writes when a push comes back `DeviceNotRegistered`.
-    await prisma.user.update({
-      where: { id: silent.requester.userId },
-      data: { pushToken: "" },
+    await prisma.dog.createMany({ data: dogs });
+
+    await prisma.match.createMany({
+      data: Array.from({ length: count }, (_, index) => ({
+        id: `pruned-match-${index}`,
+        requesterId: `pruned-dog-${index * 2}`,
+        responderId: `pruned-dog-${index * 2 + 1}`,
+        createdAt,
+      })),
     });
+  };
+
+  /**
+   * The reachability rule has to be in the query, not after it.
+   *
+   * `take` is applied by Postgres, so a filter that runs in JS on the rows
+   * that came back cannot rescue somebody who never came back: dead installs
+   * sorted ahead of a live one take every slot and the live one is simply not
+   * in the result to be filtered. A full ceiling of pruned matches, all newer
+   * than the one reachable match, is the only shape that tells the two apart.
+   */
+  it("keeps a reachable match when pruned tokens would fill the whole run", async () => {
+    const { match, requester, responder } = await seedSilentMatch(71);
+
+    await seedPrunedMatches(MAX_CANDIDATES_PER_QUERY, hoursAgo(25));
 
     const candidates = await selectUnansweredMatchCandidates(NOW);
 
-    expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.userId).not.toBe(silent.requester.userId);
-  });
-
-  it("leaves out a match where neither side can be reached", async () => {
-    const { requester, responder } = await seedSilentMatch(25);
-
-    await prisma.user.updateMany({
-      where: { id: { in: [requester.userId, responder.userId] } },
-      data: { pushToken: "" },
-    });
-
-    await expect(selectUnansweredMatchCandidates(NOW)).resolves.toEqual([]);
+    expect(candidates.map(({ userId }) => userId).sort()).toEqual(
+      [requester.userId, responder.userId].sort(),
+    );
+    expect(candidates.map(({ url }) => url).sort()).toEqual(
+      [
+        `chat/${match.id}/${requester.id}`,
+        `chat/${match.id}/${responder.id}`,
+      ].sort(),
+    );
   });
 });
 

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -121,7 +121,7 @@ const FALLBACK_OFFSET_HOURS = -3;
  * The 200 the incident sent was this cap being hit, so a backlog does exist.
  * Raise this before widening the window if the queue stops draining.
  */
-const MAX_CANDIDATES_PER_QUERY = 500;
+export const MAX_CANDIDATES_PER_QUERY = 500;
 const MAX_PUSHES_PER_RUN = 200;
 
 const HOUR_MS = 60 * 60 * 1000;

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -245,6 +245,31 @@ const translate = (
 ): string => TranslationService.translate(key, { lng: Language.PtBr, replace });
 
 /**
+ * A user we can actually reach.
+ *
+ * The empty string matters: `UserService.blacklistPushToken` clears a dead
+ * token by writing `""` rather than null, so `IS NOT NULL` alone would keep
+ * re-selecting users whose device has already been rejected by Expo, burning
+ * their daily cap and inflating the sent count this whole change exists to
+ * measure.
+ */
+const REACHABLE_USER = Prisma.sql`
+  "User"."deletedAt" IS NULL
+  AND "User"."pushToken" IS NOT NULL
+  AND "User"."pushToken" <> ''
+`;
+
+/**
+ * The same rule, for the one selector that goes through Prisma rather than
+ * raw SQL. Both halves are needed for the same reason the SQL needs both.
+ */
+const REACHABLE_USER_WHERE = {
+  deletedAt: null,
+  pushToken: { not: null },
+  NOT: { pushToken: "" },
+} satisfies Prisma.UserWhereInput;
+
+/**
  * Matches that went silent, one candidate per side that can be reached.
  *
  * Both sides get the nudge because either of them can break the silence and
@@ -291,6 +316,15 @@ export const selectUnansweredMatchCandidates = async (
             banned: false,
             user: { deletedAt: null },
           },
+          // At least one side has to still have a live token. Either side can
+          // break the silence, so a match is worth pulling for one reachable
+          // half; a match where neither device answers any more is not, and
+          // leaving it in let dead installs fill the per run candidate ceiling
+          // and pushed the reachable people behind them out of the run.
+          OR: [
+            { requester: { user: REACHABLE_USER_WHERE } },
+            { responder: { user: REACHABLE_USER_WHERE } },
+          ],
         },
         select: {
           id: true,
@@ -336,21 +370,6 @@ export const selectUnansweredMatchCandidates = async (
 
   return buckets.flat();
 };
-
-/**
- * A user we can actually reach.
- *
- * The empty string matters: `UserService.blacklistPushToken` clears a dead
- * token by writing `""` rather than null, so `IS NOT NULL` alone would keep
- * re-selecting users whose device has already been rejected by Expo, burning
- * their daily cap and inflating the sent count this whole change exists to
- * measure.
- */
-const REACHABLE_USER = Prisma.sql`
-  "User"."deletedAt" IS NULL
-  AND "User"."pushToken" IS NOT NULL
-  AND "User"."pushToken" <> ''
-`;
 
 /**
  * Has this user liked anybody since `since`? Correlates against the enclosing

--- a/packages/api/src/services/user-service.ts
+++ b/packages/api/src/services/user-service.ts
@@ -93,6 +93,17 @@ export class UserService {
     });
   }
 
+  /**
+   * Drop a token no push will ever reach.
+   *
+   * The empty string rather than null, which is what the column has always
+   * used for this and what the selectors in `reengagement-service` test for.
+   * `updateMany` because the same install can have been signed into more than
+   * one account, and every one of those rows points at a device that is gone.
+   *
+   * Nothing has to undo this: the app re-registers its token every time the
+   * deck opens, so a reinstall writes a live one back.
+   */
   static blacklistPushToken(pushToken: string) {
     return prisma.user.updateMany({
       where: { pushToken },

--- a/packages/api/src/shared/push-errors.ts
+++ b/packages/api/src/shared/push-errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Expo's code for a push token that no longer belongs to an install.
+ *
+ * It is the end of that token's life: the app was uninstalled, or the OS
+ * handed the device a new registration. One definition rather than one per
+ * call site, because the pruner in the queue handler and the cadence gate in
+ * `reengagement-cadence` have to agree on the spelling, or a token gets muted
+ * in one place and kept alive in the other.
+ */
+export const DEAD_TOKEN_ERROR = "DeviceNotRegistered";
+
+/** A ticket or a receipt, in the fields both of them answer with. */
+export type ExpoDeliveryResult = {
+  details?: { error?: string } | null;
+  message?: string | null;
+  status: string;
+};
+
+/**
+ * Has Expo said this token is gone?
+ *
+ * `details.error` is the documented field on both tickets and receipts and the
+ * one to trust. The message is read as well because a failure that never got
+ * classified still names the reason in prose, and a token left alive on that
+ * technicality goes on producing the same rejection every evening.
+ */
+export const isDeadTokenError = (result: ExpoDeliveryResult) =>
+  result.details?.error === DEAD_TOKEN_ERROR ||
+  (result.message?.includes(DEAD_TOKEN_ERROR) ?? false);

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -534,6 +534,14 @@ export type ServerEventProperties = {
     /** Null only for a push enqueued before this property existed. */
     kind: PushKind | null;
     status: PushDeliveryStatus;
+    /**
+     * The token was dropped because Expo said the device is gone.
+     *
+     * Sits next to `error_code` so the clean-up can be read on the same series
+     * as the failure that caused it: how many dead devices we found, and how
+     * many of them we actually stopped sending to.
+     */
+    token_pruned: boolean;
   };
   /**
    * What Expo said when the push was handed over. An error here is a push that
@@ -544,6 +552,8 @@ export type ServerEventProperties = {
     error_code: string | null;
     kind: PushKind | null;
     status: PushDeliveryStatus;
+    /** See the same property on `Push Receipt Result`. */
+    token_pruned: boolean;
   };
   /**
    * One row per re-engagement push handed to Expo. `dedupe_key` is the same key


### PR DESCRIPTION
## Summary

A push that comes back `DeviceNotRegistered` means the app was uninstalled. We were already dropping the token when that happened, and also reporting it as a server exception, which made an ordinary uninstall the top error on the server.

## Details

- The dead token check now runs on both the ticket Expo hands back and the receipt the device answers with, and it reads the message as well as the error code, because Expo does not always classify the failure.
- The token is cleared the same way it always was, on the user row. No migration.
- `DeviceNotRegistered` no longer goes to the error funnel. It is the expected end of a push token and the only sensible response to it, dropping the token, already happens. Every other Expo code is still reported.
- The two existing delivery events, `Push Ticket Result` and `Push Receipt Result`, carry a new `token_pruned` flag next to `error_code`, so the clean up is countable on the same series as the failure that caused it.
- A rejected receipt with no code of its own is now treated as settled. It used to read as still in flight, so it was re-checked every thirty five minutes forever while the dead token stayed in the database.
- The unanswered match selector was the one candidate query with no reachability filter in the database. Dead installs were taking slots in the per run candidate ceiling and pushing reachable people out of the run. A match is only pulled when at least one side still has a live token.
- Expo's code for a dead token had two spellings in two files. There is one definition now, shared by the pruner and by the cadence gate that reads the code back off the notification log.

How this gets read after it ships:

- Retention and push deliverability. On the daily readout for issue #188, the `DeviceNotRegistered` exception count should fall to zero, since it is no longer an exception.
- `Reengagement Push Sent` gets a cleaner denominator: fewer sends aimed at devices that cannot receive them, so opens per push sent stops being diluted by dead installs.
- `token_pruned` on the two delivery events gives the size of the dead install pool for the first time: how many we found, and how many we actually stopped sending to.

## Testing steps

Nothing in the app looks different. This is the server deciding who is still worth sending a notification to.

To check it by hand, install the app on a phone, let it register for notifications, then delete the app. The next reminder aimed at that phone comes back rejected, and from that moment the phone is off the list instead of being tried again every week.

In the analytics dashboard, the error report should stop filling up with entries about unregistered devices, and the reminder counts should describe people who can actually be reached.

## Screenshots

Nothing to show. This is server side only and has no interface.
