### PR TITLE
fix(web): bundle the Gilroy fonts with the image routes

### DIFF
--- a/apps/nextjs/next.config.mjs
+++ b/apps/nextjs/next.config.mjs
@@ -45,18 +45,25 @@ const nextConfig = {
     qualities: [75, 90],
   },
 
-  // `opengraph-image.tsx` reads Gilroy TTFs from `packages/shared` (outside
-  // this app's directory) and `public/logo.svg` off disk at module scope.
-  // Next's default output file tracing only follows files it can see through
-  // static imports/requires, and these are read with `node:fs` at a path
-  // built from `process.cwd()`, so the standalone/serverless bundle Vercel
-  // deploys would otherwise ship without them and 500 at runtime even though
-  // `next dev` (which runs from the full repo checkout) never surfaces it.
-  // Keys are globs matched against the route; values are globs relative to
-  // this file's directory (`apps/nextjs`, the project root `next build` and
-  // Vercel's build both use).
+  // `src/lib/og-assets.ts` reads Gilroy TTFs from `packages/shared` (outside
+  // this app's directory) and `public/logo.svg` off disk. Next's default
+  // output file tracing only follows files it can see through static
+  // imports/requires, and these are read with `node:fs` at a path built from
+  // `process.cwd()`, so unless they are named here the serverless bundle
+  // Vercel deploys ships without them and every shared dog gets a card in a
+  // stock font, which `next dev` (running from the full repo checkout) never
+  // surfaces.
+  //
+  // Values are globs relative to this file's directory (`apps/nextjs`, the
+  // project root that `next build` and Vercel's build both use). The key is a
+  // glob matched against the route path, with `contains: true`, so it is
+  // written against Next's `opengraph-image` file convention rather than
+  // against this app's own segment names: `[locale]`, `dog` and `[id]` are
+  // ours to rename, and spelling them out here means a rename ships a
+  // deployment that builds and typechecks and still loses the font.
+  // `tests/og-image-assets.test.mjs` holds this key and those files together.
   outputFileTracingIncludes: {
-    "/\\[locale\\]/dog/\\[id\\]/opengraph-image": [
+    "**/{opengraph,twitter}-image": [
       "../../packages/shared/themes/fonts/Gilroy-*.ttf",
       "./public/logo.svg",
     ],

--- a/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
+++ b/apps/nextjs/src/app/[locale]/dog/[id]/opengraph-image.tsx
@@ -1,16 +1,17 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import type { OgAssets } from "@/lib/og-assets";
 
 import { ImageResponse } from "next/og";
 
 import { getSafeLocale } from "@/lib/get-safe-locale";
+import { getOgAssets } from "@/lib/og-assets";
 import { t } from "@/lib/translate";
 
 import { getDog, getDogImage, getDogTagline } from "./get-dog";
 
 // Explicit, not the segment default: this route reads the Gilroy font files
-// off disk (`node:fs/promises`, `process.cwd()`) and queries the dog via
-// Prisma, both Node-only, so it needs the Node runtime rather than Edge.
+// off disk (`node:fs/promises`, `process.cwd()`, see `@/lib/og-assets`) and
+// queries the dog via Prisma, both Node-only, so it needs the Node runtime
+// rather than Edge.
 export const runtime = "nodejs";
 
 export const size = { width: 1200, height: 630 };
@@ -26,49 +27,6 @@ const COLORS = {
   text: "#0F172A",
   subtitle: "#5A5F6D",
 };
-
-// Read once at module scope, same as the docs example for `ImageResponse`
-// fonts (`readFile` + `process.cwd()`), not per-request: font data never
-// changes between requests. `process.cwd()` is `apps/nextjs` in both `next
-// dev` and `next build`/the deployed function, so two `..` reaches the repo
-// root and into the same `packages/shared/themes/fonts` the app itself
-// loads its Gilroy weights from.
-const FONTS_DIR = join(
-  process.cwd(),
-  "..",
-  "..",
-  "packages",
-  "shared",
-  "themes",
-  "fonts",
-);
-
-const LOGO_PATH = join(process.cwd(), "public", "logo.svg");
-
-const [gilroyMedium, gilroySemiBold, gilroyBold, gilroyExtraBold, logoSvg] =
-  await Promise.all([
-    readFile(join(FONTS_DIR, "Gilroy-Medium.ttf")),
-    readFile(join(FONTS_DIR, "Gilroy-SemiBold.ttf")),
-    readFile(join(FONTS_DIR, "Gilroy-Bold.ttf")),
-    readFile(join(FONTS_DIR, "Gilroy-ExtraBold.ttf")),
-    readFile(LOGO_PATH, "utf8"),
-  ]);
-
-// Satori (`next/og`'s renderer) only reliably draws an `<img>` from a data
-// URI, not an arbitrary `src` path — the actual brand mark
-// (`public/logo.svg`, the heart-shaped paw), inlined this way, is what makes
-// this a logo instead of the word "Pegada" set in a font.
-const logoBase64 = Buffer.from(logoSvg).toString("base64");
-const LOGO_DATA_URI = `data:image/svg+xml;base64,${logoBase64}`;
-
-const OG_FONTS = [
-  { name: "Gilroy", data: gilroyMedium, weight: 500, style: "normal" },
-  { name: "Gilroy", data: gilroySemiBold, weight: 600, style: "normal" },
-  { name: "Gilroy", data: gilroyBold, weight: 700, style: "normal" },
-  { name: "Gilroy", data: gilroyExtraBold, weight: 800, style: "normal" },
-] satisfies NonNullable<
-  ConstructorParameters<typeof ImageResponse>[1]
->["fonts"];
 
 // Hoisted to module scope, not inlined in JSX: every value below is static
 // (only the text nodes vary per dog), so building these once avoids a fresh
@@ -128,9 +86,9 @@ const detailsStyle = {
   flex: 1,
 } as const;
 
-// The lockup: the real mark (an `<img>` of `public/logo.svg`, see
-// `LOGO_DATA_URI` above) next to the wordmark, in the same Gilroy ExtraBold
-// the app itself sets its brand name in. Neither one alone is the logo.
+// The lockup: the real mark (an `<img>` of `public/logo.svg`, inlined by
+// `@/lib/og-assets`) next to the wordmark, in the same Gilroy ExtraBold the
+// app itself sets its brand name in. Neither one alone is the logo.
 const brandRowStyle = {
   display: "flex",
   alignItems: "center",
@@ -220,34 +178,35 @@ type Props = {
 
 type LogoStyle = { width: number; height: number; display: "flex" };
 
-const LogoMark = (props: { style: LogoStyle }) => (
-  // oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image
-  <img
-    src={LOGO_DATA_URI}
-    width={props.style.width}
-    height={props.style.height}
-    alt=""
-    style={props.style}
-  />
-);
+const LogoMark = (props: { src: string | undefined; style: LogoStyle }) =>
+  props.src ? (
+    // oxlint-disable-next-line nextjs/no-img-element -- satori (next/og) renders its own <img>, not next/image
+    <img
+      src={props.src}
+      width={props.style.width}
+      height={props.style.height}
+      alt=""
+      style={props.style}
+    />
+  ) : null;
 
 /** Branded card with no dog-specific data, for a missing/removed profile. */
-const buildFallbackImage = () =>
+const buildFallbackImage = ({ fonts, logoDataUri }: OgAssets) =>
   new ImageResponse(
     <div style={fallbackContainerStyle}>
-      <LogoMark style={fallbackLogoMarkStyle} />
+      <LogoMark src={logoDataUri} style={fallbackLogoMarkStyle} />
       <div style={fallbackWordmarkStyle}>Pegada</div>
       <div style={fallbackTaglineStyle}>{t("home.title")}</div>
     </div>,
-    { ...size, fonts: OG_FONTS },
+    { ...size, fonts },
   );
 
 const Image = async ({ params }: Props) => {
   const { id } = await params;
-  const dog = await getDog(id);
+  const [assets, dog] = await Promise.all([getOgAssets(), getDog(id)]);
 
   if (!dog) {
-    return buildFallbackImage();
+    return buildFallbackImage(assets);
   }
 
   const dogImage = getDogImage(dog);
@@ -255,7 +214,7 @@ const Image = async ({ params }: Props) => {
   // `getDog`'s `where` already requires an approved image, so this is
   // belt and braces rather than a case that fires in practice.
   if (!dogImage) {
-    return buildFallbackImage();
+    return buildFallbackImage(assets);
   }
 
   const lng = getSafeLocale();
@@ -276,7 +235,7 @@ const Image = async ({ params }: Props) => {
 
       <div style={detailsStyle}>
         <div style={brandRowStyle}>
-          <LogoMark style={logoMarkStyle} />
+          <LogoMark src={assets.logoDataUri} style={logoMarkStyle} />
           <div style={wordmarkStyle}>Pegada</div>
         </div>
         <div style={nameStyle}>{dog.name}</div>
@@ -284,7 +243,7 @@ const Image = async ({ params }: Props) => {
         <div style={tagStyle}>{t("dog.og.tag")}</div>
       </div>
     </div>,
-    { ...size, fonts: OG_FONTS },
+    { ...size, fonts: assets.fonts },
   );
 };
 

--- a/apps/nextjs/src/lib/og-assets.ts
+++ b/apps/nextjs/src/lib/og-assets.ts
@@ -1,0 +1,142 @@
+import type { ImageResponse } from "next/og";
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * The Gilroy weights and the brand mark that `opengraph-image.tsx` draws,
+ * read off disk rather than imported: satori renders outside the bundler, so
+ * `next/font` (which is what the pages themselves use, `src/lib/fonts.ts`)
+ * has nothing to hand it.
+ *
+ * `process.cwd()` is `apps/nextjs` in `next dev`, in `next build` and in the
+ * deployed function, so two `..` reaches the repo root and the same
+ * `packages/shared/themes/fonts` the app loads its own Gilroy from.
+ *
+ * Nothing about that makes the files a build dependency. The paths are built
+ * at runtime, webpack never sees them, and the function Vercel deploys ships
+ * without them unless `outputFileTracingIncludes` in `next.config.mjs` names
+ * them: building with that entry removed drops every `Gilroy-*.ttf` and
+ * `logo.svg` out of the route's `.nft.json`, and the deployed route then
+ * answers `ENOENT: no such file or directory, open
+ * '/var/task/packages/shared/themes/fonts/Gilroy-Medium.ttf'`.
+ *
+ * The other way round is to let the bundler trace the file itself, with `new
+ * URL("./Gilroy-Medium.ttf", import.meta.url)`. That does not build here:
+ * webpack rewrites it into its own relative-URL shim, and `fileURLToPath`
+ * rejects the shim with `The "path" argument must be of type string or an
+ * instance of URL. Received an instance of URL`.
+ *
+ * So the config entry is the mechanism, and `tests/og-image-assets.test.mjs`
+ * is what keeps its route key and these paths from drifting apart.
+ */
+const FONTS_DIR = join(
+  process.cwd(),
+  "..",
+  "..",
+  "packages",
+  "shared",
+  "themes",
+  "fonts",
+);
+
+/**
+ * The card sets medium on the tagline, bold on the tag and extrabold on the
+ * wordmark and the dog's name. Semibold is loaded with them so a line of copy
+ * can move to that step without also losing its face.
+ */
+const FONTS = (
+  [
+    { file: "Gilroy-Medium.ttf", weight: 500 },
+    { file: "Gilroy-SemiBold.ttf", weight: 600 },
+    { file: "Gilroy-Bold.ttf", weight: 700 },
+    { file: "Gilroy-ExtraBold.ttf", weight: 800 },
+  ] as const
+).map(({ file, weight }) => ({ path: join(FONTS_DIR, file), weight }));
+
+/** Every file the OG image routes open, for the tracing test to check. */
+export const OG_FONT_PATHS = FONTS.map(({ path }) => path);
+export const OG_LOGO_PATH = join(process.cwd(), "public", "logo.svg");
+
+type OgFonts = NonNullable<
+  ConstructorParameters<typeof ImageResponse>[1]
+>["fonts"];
+
+export type OgAssets = {
+  /**
+   * Undefined when the files could not be read, which `ImageResponse` reads
+   * as "use your own bundled face" rather than as an error.
+   */
+  fonts: OgFonts;
+  /** Undefined the same way; the card then draws without the mark. */
+  logoDataUri: string | undefined;
+};
+
+/**
+ * A card in the wrong font still gives the link a preview; a module that
+ * fails to initialise gives the scraper a 500 and the link no preview at all,
+ * which is the whole reason the image exists. So a read that fails costs the
+ * card that one asset and nothing else. Logged, so a tracing regression still
+ * surfaces as an exception instead of going quiet.
+ */
+const readOrSkip = async <T>(what: string, read: () => Promise<T>) => {
+  try {
+    return await read();
+  } catch (error) {
+    // oxlint-disable-next-line no-console -- The only report a tracing regression gets; Vercel collects it as an exception.
+    console.error(`Could not read ${what} for the OG image`, error);
+
+    return undefined;
+  }
+};
+
+const readFonts = () =>
+  readOrSkip("the Gilroy weights", () =>
+    Promise.all(
+      FONTS.map(async ({ path, weight }) => ({
+        name: "Gilroy",
+        data: await readFile(path),
+        weight,
+        style: "normal" as const,
+      })),
+    ),
+  );
+
+const readLogo = () =>
+  readOrSkip("the brand mark", async () => {
+    const svg = await readFile(OG_LOGO_PATH, "utf8");
+
+    // Satori only reliably draws an `<img>` from a data URI, not from an
+    // arbitrary `src` path, so the real mark has to be inlined to be a logo
+    // rather than the word "Pegada" set in a font.
+    return `data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`;
+  });
+
+const read = async (): Promise<OgAssets> => {
+  const [fonts, logoDataUri] = await Promise.all([readFonts(), readLogo()]);
+
+  return { fonts, logoDataUri };
+};
+
+let assets: Promise<OgAssets> | undefined;
+
+/**
+ * Read on the first request rather than at module scope: font data never
+ * changes between requests, and a rejected top-level `await` would poison the
+ * module for the life of the instance and report itself without a stack ("An
+ * error occurred in the Server Components render").
+ *
+ * Only a complete read is kept. Anything less is dropped so the next request
+ * tries again, since one unlucky read would otherwise cost every card served
+ * by that instance its typeface until the next deploy. Requests that arrive
+ * while a read is in flight share it.
+ */
+export const getOgAssets = async () => {
+  const result = await (assets ??= read());
+
+  if (!result.fonts || !result.logoDataUri) {
+    assets = undefined;
+  }
+
+  return result;
+};

--- a/apps/nextjs/tests/og-image-assets.test.mjs
+++ b/apps/nextjs/tests/og-image-assets.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { globSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+
+import nextConfig from "../next.config.mjs";
+
+const { OG_FONT_PATHS, OG_LOGO_PATH, getOgAssets } =
+  await import("../src/lib/og-assets.ts");
+
+/**
+ * The defect: the dog card's OG image answered
+ * `ENOENT: no such file or directory, open
+ * '/var/task/packages/shared/themes/fonts/Gilroy-Medium.ttf'` in production.
+ * The route reads Gilroy and `public/logo.svg` with `node:fs` at paths built
+ * from `process.cwd()`, which the bundler cannot see, so the files only reach
+ * the deployed function because `outputFileTracingIncludes` names them. Remove
+ * that config entry and `next build` still passes, the route's `.nft.json`
+ * quietly loses every font, and every share of a dog loses its link preview.
+ *
+ * So the config entry is load-bearing and nothing else checks it. Below: the
+ * files are readable, the include globs cover every one of them, and the key
+ * still matches the routes that need them, matched the way Next matches it
+ * (`picomatch`, `contains: true`, against `normalizeAppPath` of the entry).
+ */
+const require = createRequire(import.meta.url);
+const picomatch = require("next/dist/compiled/picomatch");
+const {
+  normalizeAppPath,
+} = require("next/dist/shared/lib/router/utils/app-paths");
+
+const APP_DIR = path.join(import.meta.dirname, "..", "src", "app");
+
+/** Next's metadata image conventions, the ones that render through satori. */
+const IMAGE_ROUTE_FILES = "**/{opengraph,twitter}-image.tsx";
+
+const includes = nextConfig.outputFileTracingIncludes;
+
+/** The routes Next builds for the image files that exist in the app today. */
+const imageRoutes = globSync(IMAGE_ROUTE_FILES, { cwd: APP_DIR }).map((file) =>
+  normalizeAppPath(`app/${path.dirname(file)}/${path.parse(file).name}/route`),
+);
+
+test("the app has image routes to trace assets for", () => {
+  assert.ok(
+    imageRoutes.length > 0,
+    `no ${IMAGE_ROUTE_FILES} under src/app, so this file is checking nothing`,
+  );
+});
+
+test("every image route is covered by an include key", () => {
+  for (const route of imageRoutes) {
+    const matched = Object.keys(includes).filter((key) =>
+      picomatch(key, { dot: true, contains: true })(route),
+    );
+
+    assert.ok(
+      matched.length > 0,
+      `${route} matches no outputFileTracingIncludes key, so it deploys without its fonts`,
+    );
+  }
+});
+
+test("the include globs resolve to every file the route reads", () => {
+  const globs = Object.values(includes).flat();
+  const traced = new Set(
+    globs.flatMap((pattern) =>
+      globSync(pattern, { cwd: path.join(import.meta.dirname, "..") }).map(
+        (file) => path.resolve(import.meta.dirname, "..", file),
+      ),
+    ),
+  );
+
+  for (const file of [...OG_FONT_PATHS, OG_LOGO_PATH]) {
+    assert.ok(
+      traced.has(path.resolve(file)),
+      `${path.basename(file)} is read at runtime but no include glob resolves to it`,
+    );
+  }
+});
+
+test("the assets read back as fonts and a logo", async () => {
+  const { fonts, logoDataUri } = await getOgAssets();
+
+  assert.equal(fonts?.length, OG_FONT_PATHS.length);
+
+  for (const font of fonts ?? []) {
+    assert.equal(font.name, "Gilroy");
+    // 0x00010000 is the TrueType version tag every one of these files opens
+    // with: a truncated or missing file gets past a length check, not this.
+    assert.deepEqual(
+      Buffer.from(font.data.subarray(0, 4)),
+      Buffer.from([0x00, 0x01, 0x00, 0x00]),
+      `${font.weight} is not a TrueType file`,
+    );
+  }
+
+  assert.match(
+    logoDataUri ?? "",
+    /^data:image\/svg\+xml;base64,[A-Za-z0-9+/]+/,
+  );
+});


### PR DESCRIPTION
## Summary

The image that shows up when someone shares a dog kept its typeface only because one hand written config key happened to match the route path, and nothing tested that key. This ties the fonts to Next's own file convention and makes a missing font cost the font alone.

## Details

- The font files live in the shared package and are opened at request time from a path built at runtime, so the bundler never sees them. They reach the deployed function only because `next.config.mjs` lists them, under a key that had to keep matching the route path by hand. Building with that entry removed still succeeds and quietly drops every Gilroy file from the route's trace manifest.
- Production renders correctly today. This removes the fragility and the blast radius rather than repairing a live outage. Renaming a folder or a dynamic segment is all it would have taken to ship a green build whose card answers `ENOENT: no such file or directory, open '/var/task/packages/shared/themes/fonts/Gilroy-Medium.ttf'` on every request.
- The key now follows Next's own `opengraph-image` file convention, so those renames no longer detach the fonts from the route that reads them.
- The reads moved into a shared loader and are no longer a module level await. A read that fails now costs the card that one asset, and only a complete read is kept, so one unlucky read does not follow the instance around. Before, a failed read rejected while the module was initialising and the route answered 500 for the life of that instance. That is also the most likely explanation for the stackless server render errors logged in the same window, though nothing reachable locally can confirm it.
- New tests assert that the include globs resolve to every file the route opens, that the key still matches the routes that need it (matched with Next's own matcher and the same options the build uses), and that the fonts read back as real font data.
- Checked against a production build. The route's trace manifest now lists all six Gilroy files and the logo. Serving that build with the font folder moved out of reach shows the difference: on main, a 500 with no image, on this branch, a 200 image in a stock face.
- Metric this moves: sharing. A card that fails to render is a shared link with no preview on WhatsApp and Instagram, and a link with no preview is a link nobody taps.

## Testing steps

1. Open a dog profile in the app and share it to WhatsApp, or paste the link into any chat.
2. The preview card should show the dog photo, the name, and the Pegada wordmark in the app's own rounded typeface, with the pink heart paw beside it.
3. Paste a link for a dog that was removed. You should still get a branded card rather than a blank preview.

## Screenshots

What a scraper would get if the fonts ever stopped reaching the deployed function. An error page, and the link gets no card at all.

![before](https://raw.githubusercontent.com/GSTJ/pegada/shots/og-fonts/shots/before-500-no-preview.png)

The card that ships.

![after](https://raw.githubusercontent.com/GSTJ/pegada/shots/og-fonts/shots/after-gilroy.png)

The same situation as the first shot, on this branch. The card still renders and still carries the mark.

![after with the fonts missing](https://raw.githubusercontent.com/GSTJ/pegada/shots/og-fonts/shots/after-assets-missing.png)
