### PR TITLE
feat(ci): add push suppression and deck supply rows to the daily readout

### DIFF
--- a/scripts/metrics/daily.mjs
+++ b/scripts/metrics/daily.mjs
@@ -23,6 +23,7 @@ import {
   buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
+  buildDeckSupplyQuery,
   buildPushAttributedReturnsQuery,
   buildTotalsQuery,
   buildWindows,
@@ -76,6 +77,7 @@ export async function runDailyMetrics({
     activeUsers,
     activeUsersByCity,
     activeUsersByVersion,
+    deckSupply,
     totals,
     pushReturnsCurrent,
     pushReturnsPrevious,
@@ -90,6 +92,7 @@ export async function runDailyMetrics({
       "pegada daily metrics: active users by app version",
       buildActiveUsersByVersionQuery(windows),
     ),
+    run("pegada daily metrics: deck supply", buildDeckSupplyQuery(windows)),
     run("pegada daily metrics: event totals", buildTotalsQuery(windows)),
     run(
       "pegada daily metrics: push attributed returns, last 7 days",
@@ -119,6 +122,7 @@ export async function runDailyMetrics({
     activeUsersByCity,
     activeUsersByVersion,
     breakdowns,
+    deckSupply,
     generatedAt: now,
     pushReturns: {
       current: pushReturnsCurrent,

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -75,6 +75,25 @@ function fakeWorld({ existingComment = null } = {}) {
           results: [[name.includes("previous") ? 160 : 200]],
         });
       }
+      if (name.endsWith("deck supply")) {
+        return json({
+          columns: [
+            "period",
+            "pages",
+            "served",
+            "requested",
+            "primary_count",
+            "beyond_radius_count",
+            "same_gender_count",
+            "recycled_count",
+            "short_pages",
+          ],
+          results: [
+            ["current", 100, 840, 1000, 700, 90, 30, 20, 40],
+            ["previous", 80, 560, 800, 560, 0, 0, 0, 48],
+          ],
+        });
+      }
       if (name.endsWith("event totals")) {
         return json({
           columns: ["event", "period", "total", "people"],
@@ -141,7 +160,7 @@ test("a dry run renders the comment and never touches GitHub", async () => {
 test("one query goes out per metric block", async () => {
   const fetchImpl = fakeWorld();
   await runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW });
-  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 6);
+  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 7);
 });
 
 test("both push return windows are asked for separately and land in the table", async () => {
@@ -167,6 +186,36 @@ test("both push return windows are asked for separately and land in the table", 
   assert.match(
     result.body,
     /Coverage note: the store build 1\.6\.2 cannot emit/,
+  );
+});
+
+test("the deck supply query fills the deck table", async () => {
+  const fetchImpl = fakeWorld();
+  const result = await runDailyMetrics({
+    argv: ["--dry-run"],
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  assert.equal(
+    fetchImpl.calls.filter(
+      (call) => call.body?.name === "pegada daily metrics: deck supply",
+    ).length,
+    1,
+  );
+  const [, deckSection] = result.body.split("### Deck");
+  assert.match(
+    deckSection,
+    /\| Cards served per page \| 8\.4 \| 7\.0 \| \+1\.4 \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Cards from beyond_radius \| 90 \| 0 \| \+90 \(new\) \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Short pages \(served under requested\) \| 40\.0% \| 60\.0% \| -20\.0 pp \|/,
   );
 });
 

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -15,6 +15,7 @@
 /** Names used by the readout, spelled exactly as PostHog stores them. */
 export const EVENTS = {
   CREATE_DOG_PROFILE: "Create Dog Profile",
+  DECK_SERVED: "Deck Served",
   EMPTY_DECK_SHOWN: "Empty Deck Shown",
   FAKE_DOOR_TAPPED: "Fake Door Tapped",
   IMAGE_MODERATION_RESULT: "Image Moderation Result",
@@ -24,6 +25,7 @@ export const EVENTS = {
   PUSH_NOTIFICATION_OPENED: "Push Notification Opened",
   PUSH_TICKET_RESULT: "Push Ticket Result",
   REENGAGEMENT_PUSH_SENT: "Reengagement Push Sent",
+  REENGAGEMENT_PUSH_SUPPRESSED: "Reengagement Push Suppressed",
   SHARE_COMPLETED: "Share Completed",
   SHARE_PROMPT_TAPPED: "Share Prompt Tapped",
   SHARE_TAPPED: "Share Tapped",
@@ -63,6 +65,7 @@ export const SERVER_EVENTS = [
   "Push Receipt Result",
   "Push Ticket Result",
   "Reengagement Push Sent",
+  "Reengagement Push Suppressed",
   "Signup Attributed",
   "Subscription Event",
 ].sort();
@@ -88,6 +91,13 @@ export const SERVER_EVENTS = [
  * Keep this in step with what the audit sees from 1.6.2, not with what is on
  * main. The point of the note is to stop a reach gap from reading as a dead
  * product, and it only works while every name on it is a genuine gap.
+ *
+ * `otaEvents` is the half of the gap that is already closing. An over the air
+ * update publishes new JavaScript to the 1.6.2 runtime, so a name listed here
+ * is missing on the phones that have not fetched that bundle yet and present on
+ * the ones that have. The row is therefore a mix of two populations while the
+ * update rolls out, and reading it as a flat zero would be wrong in the other
+ * direction: the number is real, it is just smaller than the install base.
  */
 export const STORE_BUILD_COVERAGE = {
   missingEvents: [
@@ -97,6 +107,9 @@ export const STORE_BUILD_COVERAGE = {
     EVENTS.SHARE_PROMPT_TAPPED,
     EVENTS.SHARE_TAPPED,
   ],
+  /** The day the update below was published to the 1.6.2 runtime. */
+  otaDate: "2026-09-04",
+  otaEvents: [EVENTS.PUSH_NOTIFICATION_OPENED],
   version: "1.6.2",
 };
 
@@ -140,6 +153,17 @@ export const BREAKDOWNS = [
     event: EVENTS.FAKE_DOOR_TAPPED,
     property: "feature",
     title: "Fake Door Tapped by feature",
+  },
+  // Why a nudge the cron had ready never went out. Sends alone cannot tell a
+  // quiet week from a broken cadence, and the reasons read very differently:
+  // `cooldown` and `monthly_cap` are the caps doing their job, `gave_up` is a
+  // person the app has stopped trying with, `dead_token` is a phone that can no
+  // longer be reached at all, and `window` is only the evening gate.
+  {
+    id: "push_suppressed_reason",
+    event: EVENTS.REENGAGEMENT_PUSH_SUPPRESSED,
+    property: "reason",
+    title: "Reengagement Push Suppressed by reason",
   },
   {
     id: "signup_ref",
@@ -467,5 +491,65 @@ export function buildPushAttributedReturnsQuery({ end, start }) {
     ") AS activity ON activity.person_id = push.person_id",
     "WHERE activity.acted_at >= push.sent_at",
     `  AND activity.acted_at < push.sent_at + toIntervalMinute(${PUSH_RETURN_WINDOW_MINUTES})`,
+  ].join("\n");
+}
+
+/**
+ * The four tiers a card can come from, in the order the deck falls back
+ * through them.
+ *
+ * `id` is the value the API puts on `deckTier`, and `property` is the counter
+ * the `Deck Served` event carries for it. They differ for the last one:
+ * the tier is called `recycled_pass` and its counter is `recycled_count`, so
+ * both spellings live here rather than being guessed at either end.
+ */
+export const DECK_TIERS = [
+  { id: "primary", property: "primary_count" },
+  { id: "beyond_radius", property: "beyond_radius_count" },
+  { id: "same_gender", property: "same_gender_count" },
+  { id: "recycled_pass", property: "recycled_count" },
+];
+
+/**
+ * Reads a numeric event property as a number.
+ *
+ * PostHog stores properties as JSON, so a count arrives as a value ClickHouse
+ * will not sum without a cast. `OrNull` rather than `OrZero` on purpose: a page
+ * that never carried the property is missing from the sum instead of dragging
+ * the average towards zero.
+ */
+function numericProperty(name) {
+  return `toFloat64OrNull(toString(properties.${name}))`;
+}
+
+/**
+ * One row per window describing what the deck actually handed out.
+ *
+ * The counts are summed rather than averaged in ClickHouse so the report can
+ * divide them by whatever denominator each row needs: pages for the average
+ * page size, the page count for the short share.
+ *
+ * A page is short when it served fewer cards than the app asked for, which is
+ * the same condition the API uses to decide whether to fall back to a wider
+ * tier, so this share is how often the fallbacks had anything to do.
+ */
+export function buildDeckSupplyQuery(windows) {
+  const served = numericProperty("served");
+  const requested = numericProperty("requested");
+  return [
+    "SELECT",
+    `  ${periodExpression(windows)} AS period,`,
+    "  count() AS pages,",
+    `  sum(${served}) AS served,`,
+    `  sum(${requested}) AS requested,`,
+    ...DECK_TIERS.map(
+      (tier) => `  sum(${numericProperty(tier.property)}) AS ${tier.property},`,
+    ),
+    `  countIf(${served} < ${requested}) AS short_pages`,
+    "FROM events",
+    `WHERE ${windowFilter(windows)}`,
+    `  AND event = ${quote(EVENTS.DECK_SERVED)}`,
+    "GROUP BY period",
+    "ORDER BY period",
   ].join("\n");
 }

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -9,6 +9,7 @@ import {
   CITY_UNKNOWN_BUCKET,
   CLIENT_LIBS,
   COUNTED_EVENTS,
+  DECK_TIERS,
   EVENTS,
   PUSH_RETURN_LIB,
   PUSH_RETURN_WINDOW_MINUTES,
@@ -18,6 +19,7 @@ import {
   buildActiveUsersByVersionQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
+  buildDeckSupplyQuery,
   buildPushAttributedReturnsQuery,
   buildTotalsQuery,
   buildWindows,
@@ -71,12 +73,14 @@ test("posthog-node never counts as a client library", () => {
 
 test("the events the API emits are all on the deny list", () => {
   for (const event of [
+    "Deck Served",
     "Image Moderation Result",
     "Match Created",
     "Message Sent",
     "Push Receipt Result",
     "Push Ticket Result",
     "Reengagement Push Sent",
+    "Reengagement Push Suppressed",
     "Signup Attributed",
     "Subscription Event",
   ]) {
@@ -200,6 +204,95 @@ test("every breakdown names an event the totals query also counts", () => {
   }
   const ids = BREAKDOWNS.map((breakdown) => breakdown.id);
   assert.equal(new Set(ids).size, ids.length);
+});
+
+test("the suppression breakdown reads why a nudge was withheld", () => {
+  const suppressed = BREAKDOWNS.find(
+    (breakdown) => breakdown.id === "push_suppressed_reason",
+  );
+  assert.equal(suppressed.event, EVENTS.REENGAGEMENT_PUSH_SUPPRESSED);
+  assert.equal(suppressed.property, "reason");
+  const query = buildBreakdownQuery(buildWindows(NOW), suppressed);
+  assert.match(query, /AND event = 'Reengagement Push Suppressed'/);
+  assert.match(
+    query,
+    /ifNull\(nullIf\(toString\(properties\.reason\), ''\), 'unknown'\) AS bucket/,
+  );
+
+  // The cron writes one of these five, so a sixth bucket means the vocabulary
+  // moved and the table stopped being readable against the cadence.
+  const cataloguePath = fileURLToPath(
+    new URL("../../packages/shared/analytics/events.ts", import.meta.url),
+  );
+  const catalogue = readFileSync(cataloguePath, "utf8");
+  for (const reason of [
+    "cooldown",
+    "dead_token",
+    "gave_up",
+    "monthly_cap",
+    "window",
+  ]) {
+    assert.ok(
+      catalogue.includes(`| "${reason}"`),
+      `${reason} is no longer a suppression reason`,
+    );
+  }
+});
+
+test("the deck supply query sums the tiers and counts the short pages", () => {
+  const query = buildDeckSupplyQuery(buildWindows(NOW));
+  assert.match(query, /AND event = 'Deck Served'/);
+  assert.match(query, /count\(\) AS pages/);
+  assert.match(
+    query,
+    /sum\(toFloat64OrNull\(toString\(properties\.served\)\)\) AS served/,
+  );
+  for (const tier of DECK_TIERS) {
+    assert.ok(
+      query.includes(
+        `sum(toFloat64OrNull(toString(properties.${tier.property}))) AS ${tier.property}`,
+      ),
+      `${tier.id} is not summed`,
+    );
+  }
+  // Short is the same condition the API falls back on, so the share can be read
+  // as how often the wider tiers had anything to do.
+  assert.match(
+    query,
+    /countIf\(toFloat64OrNull\(toString\(properties\.served\)\) < toFloat64OrNull\(toString\(properties\.requested\)\)\) AS short_pages/,
+  );
+  assert.match(query, /GROUP BY period/);
+  assert.match(
+    query,
+    /toDateTime\('2026-08-26 12:00:00', 'UTC'\), 'current', 'previous'/,
+  );
+});
+
+test("the deck tiers name the property the Deck Served event really carries", () => {
+  assert.deepEqual(
+    DECK_TIERS.map((tier) => tier.id),
+    ["primary", "beyond_radius", "same_gender", "recycled_pass"],
+  );
+  // The last tier is the one whose id and counter disagree, which is exactly
+  // the pair a hand written query gets wrong.
+  assert.equal(
+    DECK_TIERS.find((tier) => tier.id === "recycled_pass").property,
+    "recycled_count",
+  );
+  const cataloguePath = fileURLToPath(
+    new URL("../../packages/shared/analytics/events.ts", import.meta.url),
+  );
+  const catalogue = readFileSync(cataloguePath, "utf8");
+  for (const tier of DECK_TIERS) {
+    assert.match(
+      catalogue,
+      new RegExp(`^\\s+${tier.property}: number;$`, "m"),
+      `${tier.property} is not a Deck Served property`,
+    );
+  }
+  for (const property of ["requested", "served"]) {
+    assert.match(catalogue, new RegExp(`^\\s+${property}: number;$`, "m"));
+  }
 });
 
 test("the pricing breakdowns ask the paywall and the subscription the right thing", () => {
@@ -339,6 +432,23 @@ test("the coverage list holds real event names and no server event", () => {
     );
   }
   assert.ok(STORE_BUILD_COVERAGE.missingEvents.length > 0);
+});
+
+// The over the air update publishes new JavaScript to the 1.6.2 runtime, so a
+// name here is missing on the phones that have not fetched it and present on
+// the ones that have. Listing an event the update never carried would excuse a
+// zero that has nothing to do with the rollout.
+test("the over the air list is a subset of the gap and carries the day it shipped", () => {
+  for (const event of STORE_BUILD_COVERAGE.otaEvents) {
+    assert.ok(
+      STORE_BUILD_COVERAGE.missingEvents.includes(event),
+      `${event} is not part of the coverage gap`,
+    );
+  }
+  assert.ok(
+    STORE_BUILD_COVERAGE.otaEvents.includes(EVENTS.PUSH_NOTIFICATION_OPENED),
+  );
+  assert.match(STORE_BUILD_COVERAGE.otaDate, /^\d{4}-\d{2}-\d{2}$/);
 });
 
 // Every name here has arrived from an `$app_version` of 1.6.2 in the events

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -10,6 +10,7 @@ import {
   BREAKDOWNS,
   CITY_TABLE_ROWS,
   CITY_UNKNOWN_BUCKET,
+  DECK_TIERS,
   EVENTS,
   PUSH_RETURN_WINDOW_MINUTES,
   STORE_BUILD_COVERAGE,
@@ -56,8 +57,34 @@ export function formatRateDelta(current, previous) {
   return `${diff > 0 ? "+" : "-"}${Math.abs(diff).toFixed(1)} pp`;
 }
 
+/**
+ * A mean delta, as a plain difference rather than a percentage.
+ *
+ * An average page size moving from 8.0 to 8.4 is worth half a card, and saying
+ * it grew five percent hides which half of the fraction moved.
+ */
+export function formatAverageDelta(current, previous) {
+  if (current === null || previous === null) {
+    return "n/a";
+  }
+  const diff = current - previous;
+  if (Math.abs(diff) < 0.05) {
+    return "0";
+  }
+  return `${diff > 0 ? "+" : "-"}${Math.abs(diff).toFixed(1)}`;
+}
+
 function formatPercent(value) {
   return value === null ? "n/a" : `${value.toFixed(1)}%`;
+}
+
+function formatAverage(value) {
+  return value === null ? "n/a" : value.toFixed(1);
+}
+
+/** A mean, or null when there is nothing to divide by. */
+function mean(total, count) {
+  return count === 0 ? null : total / count;
 }
 
 /** A share of a denominator, or null when the denominator is empty. */
@@ -86,7 +113,13 @@ export function coverageNote(coverage = STORE_BUILD_COVERAGE) {
   if (events.length === 0) {
     return `Coverage note: build ${coverage.version} emits every event in this readout.`;
   }
-  return `Coverage note: the store build ${coverage.version} cannot emit ${events.join(", ")}, so those rows read zero for anyone still on it. They measure reach, not the product.`;
+  const gap = `Coverage note: the store build ${coverage.version} cannot emit ${events.join(", ")}, so those rows read zero for anyone still on it. They measure reach, not the product.`;
+  const updated = coverage.otaEvents ?? [];
+  if (updated.length === 0) {
+    return gap;
+  }
+  const one = updated.length === 1;
+  return `${gap} ${updated.join(", ")} ${one ? "is" : "are"} the exception: the over the air update of ${coverage.otaDate} carries ${one ? "it" : "them"} to the ${coverage.version} runtime, so ${one ? "that row fills" : "those rows fill"} from every phone that has taken the update and the gap is only the devices that have not.`;
 }
 
 /** A percentage row, with the delta in points and `n/a` on either empty side. */
@@ -99,6 +132,16 @@ function rateRow(label, current, previous) {
         : formatRateDelta(current, previous),
     label,
     previous: formatPercent(previous),
+  };
+}
+
+/** An average row, printed to one decimal with the difference as the delta. */
+function averageRow(label, current, previous) {
+  return {
+    current: formatAverage(current),
+    delta: formatAverageDelta(current, previous),
+    label,
+    previous: formatAverage(previous),
   };
 }
 
@@ -165,15 +208,36 @@ function metricTable(rows) {
   ].join("\n");
 }
 
-function countRow(index, label, event, field = "total") {
-  const current = totalOf(index, event, "current", field);
-  const previous = totalOf(index, event, "previous", field);
+/** A count row built from two numbers the totals index does not carry. */
+function valueRow(label, current, previous) {
   return {
     current: number(current),
     delta: formatDelta(current, previous),
     label,
     previous: number(previous),
   };
+}
+
+function countRow(index, label, event, field = "total") {
+  return valueRow(
+    label,
+    totalOf(index, event, "current", field),
+    totalOf(index, event, "previous", field),
+  );
+}
+
+/**
+ * The deck supply rows, keyed by the window they describe.
+ *
+ * ClickHouse leaves a window out entirely when nothing was served in it, so a
+ * missing row and a row of zeroes have to mean the same thing here.
+ */
+function indexDeckSupply(rows) {
+  const index = new Map();
+  for (const row of rows ?? []) {
+    index.set(row.period === "current" ? "current" : "previous", row);
+  }
+  return index;
 }
 
 function breakdownTable(
@@ -234,6 +298,7 @@ export function noCityLine(rows, activeCurrent, activePrevious) {
  * @param {Array} input.activeUsersByCity rows from the city split
  * @param {Array} input.activeUsersByVersion rows from the version split
  * @param {Record<string, Array>} input.breakdowns rows per breakdown id
+ * @param {Array} input.deckSupply rows from the deck supply query, one per window
  * @param {Date} input.generatedAt when the job ran
  * @param {{ current: Array, previous: Array }} input.pushReturns rows from the push attributed returns query, one per window
  * @param {Array} input.totals rows from the totals query
@@ -244,6 +309,7 @@ export function buildReport({
   activeUsersByCity,
   activeUsersByVersion,
   breakdowns,
+  deckSupply,
   generatedAt,
   pushReturns,
   totals,
@@ -279,12 +345,7 @@ export function buildReport({
   const openRatePrevious = openRate("previous");
 
   const core = metricTable([
-    {
-      current: number(activeCurrent),
-      delta: formatDelta(activeCurrent, activePrevious),
-      label: "Active users (app and site)",
-      previous: number(activePrevious),
-    },
+    valueRow("Active users (app and site)", activeCurrent, activePrevious),
     countRow(
       index,
       "New signups (Create Dog Profile)",
@@ -295,23 +356,13 @@ export function buildReport({
     countRow(index, "Matches (New Match)", EVENTS.NEW_MATCH),
     countRow(index, "Messages sent", EVENTS.MESSAGE_SENT),
     countRow(index, "Paywall views", EVENTS.PAYWALL_VIEWED),
-    {
-      current: number(upgradeCurrent),
-      delta: formatDelta(upgradeCurrent, upgradePrevious),
-      label: "Upgrades (type success)",
-      previous: number(upgradePrevious),
-    },
+    valueRow("Upgrades (type success)", upgradeCurrent, upgradePrevious),
   ]);
 
   const sharing = metricTable([
     countRow(index, "Share Tapped", EVENTS.SHARE_TAPPED),
     countRow(index, "Share Completed", EVENTS.SHARE_COMPLETED),
-    {
-      current: number(storyCurrent),
-      delta: formatDelta(storyCurrent, storyPrevious),
-      label: "Share Completed (option story)",
-      previous: number(storyPrevious),
-    },
+    valueRow("Share Completed (option story)", storyCurrent, storyPrevious),
     countRow(index, "Empty Deck Shown", EVENTS.EMPTY_DECK_SHOWN),
     countRow(index, "Share Prompt Tapped", EVENTS.SHARE_PROMPT_TAPPED),
   ]);
@@ -343,6 +394,20 @@ export function buildReport({
       EVENTS.REENGAGEMENT_PUSH_SENT,
       "people",
     ),
+    // The other side of the cadence. A send count on its own cannot tell a week
+    // when nobody was due a nudge from a week when the cron was broken, and
+    // these two rows are what separate the two.
+    countRow(
+      index,
+      "Reengagement Push Suppressed",
+      EVENTS.REENGAGEMENT_PUSH_SUPPRESSED,
+    ),
+    countRow(
+      index,
+      "Users held back from a push",
+      EVENTS.REENGAGEMENT_PUSH_SUPPRESSED,
+      "people",
+    ),
     countRow(index, "Push Ticket Result", EVENTS.PUSH_TICKET_RESULT),
     rateRow("Push Ticket Result ok rate", okCurrent, okPrevious),
     countRow(
@@ -351,16 +416,51 @@ export function buildReport({
       EVENTS.PUSH_NOTIFICATION_OPENED,
     ),
     rateRow("Push open rate", openRateCurrent, openRatePrevious),
-    {
-      current: number(returnedCurrent),
-      delta: formatDelta(returnedCurrent, returnedPrevious),
-      label: `Push attributed returns (${PUSH_RETURN_WINDOW_MINUTES} min)`,
-      previous: number(returnedPrevious),
-    },
+    valueRow(
+      `Push attributed returns (${PUSH_RETURN_WINDOW_MINUTES} min)`,
+      returnedCurrent,
+      returnedPrevious,
+    ),
     rateRow(
       "Push attributed return rate",
       ratio(returnedCurrent, reachedCurrent),
       ratio(returnedPrevious, reachedPrevious),
+    ),
+  ]);
+
+  // What the deck handed out, against what the app asked for. The tier rows
+  // say whether the fallbacks are carrying the deck or the primary query
+  // already covered it, and the short share is how often they had anything to
+  // do at all.
+  const deckRows = indexDeckSupply(deckSupply);
+  const deckField = (period, field) =>
+    Number(deckRows.get(period)?.[field] ?? 0);
+
+  const pagesCurrent = deckField("current", "pages");
+  const pagesPrevious = deckField("previous", "pages");
+  const perPageCurrent = mean(deckField("current", "served"), pagesCurrent);
+  const perPagePrevious = mean(deckField("previous", "served"), pagesPrevious);
+  const shortCurrent = ratio(deckField("current", "short_pages"), pagesCurrent);
+  const shortPrevious = ratio(
+    deckField("previous", "short_pages"),
+    pagesPrevious,
+  );
+
+  const deck = metricTable([
+    countRow(index, "Deck Served", EVENTS.DECK_SERVED),
+    countRow(index, "Swipers served a deck", EVENTS.DECK_SERVED, "people"),
+    averageRow("Cards served per page", perPageCurrent, perPagePrevious),
+    ...DECK_TIERS.map((tier) =>
+      valueRow(
+        `Cards from ${tier.id}`,
+        deckField("current", tier.property),
+        deckField("previous", tier.property),
+      ),
+    ),
+    rateRow(
+      "Short pages (served under requested)",
+      shortCurrent,
+      shortPrevious,
     ),
   ]);
 
@@ -388,6 +488,10 @@ export function buildReport({
     "### Sharing and deck",
     "",
     sharing,
+    "",
+    "### Deck",
+    "",
+    deck,
     "",
     "### Push",
     "",

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -7,6 +7,7 @@ import {
   COMMENT_MARKER,
   buildReport,
   coverageNote,
+  formatAverageDelta,
   formatDelta,
   formatRateDelta,
   noCityLine,
@@ -33,6 +34,32 @@ function versions(rows) {
 
 /** The city split comes back in the same shape as the version split. */
 const cities = versions;
+
+function deck(rows) {
+  return rows.map(
+    ([
+      period,
+      pages,
+      served,
+      requested,
+      primary_count,
+      beyond_radius_count,
+      same_gender_count,
+      recycled_count,
+      short_pages,
+    ]) => ({
+      beyond_radius_count,
+      pages,
+      period,
+      primary_count,
+      recycled_count,
+      requested,
+      same_gender_count,
+      served,
+      short_pages,
+    }),
+  );
+}
 
 const FIXTURE = {
   activeUsers: [
@@ -87,6 +114,16 @@ const FIXTURE = {
       ["swipe_back", "current", 30],
       ["unknown", "current", 5],
     ]),
+    push_suppressed_reason: breakdown([
+      ["cooldown", "current", 140],
+      ["cooldown", "previous", 20],
+      ["monthly_cap", "current", 60],
+      ["monthly_cap", "previous", 8],
+      ["window", "current", 40],
+      ["gave_up", "current", 12],
+      ["dead_token", "current", 8],
+      ["dead_token", "previous", 12],
+    ]),
     push_ticket_status: breakdown([
       ["ok", "current", 90],
       ["error", "current", 10],
@@ -139,6 +176,10 @@ const FIXTURE = {
       ["error", "current", 1],
     ]),
   },
+  deckSupply: deck([
+    ["current", 100, 840, 1000, 700, 90, 30, 20, 40],
+    ["previous", 80, 560, 800, 560, 0, 0, 0, 48],
+  ]),
   generatedAt: NOW,
   pushReturns: {
     current: [{ people: 200 }],
@@ -160,7 +201,11 @@ const FIXTURE = {
     ["Share Completed", "previous", 30, 28],
     ["Empty Deck Shown", "current", 400, 220],
     ["Share Prompt Tapped", "current", 45, 40],
+    ["Deck Served", "current", 100, 40],
+    ["Deck Served", "previous", 80, 35],
     ["Reengagement Push Sent", "current", 1000, 800],
+    ["Reengagement Push Suppressed", "current", 260, 210],
+    ["Reengagement Push Suppressed", "previous", 40, 32],
     ["Push Ticket Result", "current", 100, 90],
     ["Push Ticket Result", "previous", 100, 88],
     ["Push Notification Opened", "current", 140, 120],
@@ -361,12 +406,120 @@ test("the push ok rate is a share of the tickets in each window", () => {
   );
 });
 
+test("the push table counts the nudges the cadence held back", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(
+    body,
+    /\| Reengagement Push Suppressed \| 260 \| 40 \| \+220 \(\+550\.0%\) \|/,
+  );
+  assert.match(
+    body,
+    /\| Users held back from a push \| 210 \| 32 \| \+178 \(\+556\.3%\) \|/,
+  );
+  // A suppression is only readable next to the send it replaced, so both rows
+  // sit in the push table rather than in a section of their own.
+  const [, pushSection] = body.split("### Push");
+  assert.ok(
+    pushSection.indexOf("| Reengagement Push Sent |") <
+      pushSection.indexOf("| Reengagement Push Suppressed |"),
+  );
+});
+
+test("the suppression reasons separate the caps from a dead phone", () => {
+  const body = buildReport(FIXTURE);
+  const [, reasons] = body.split("### Reengagement Push Suppressed by reason");
+  assert.match(reasons, /\| cooldown \| 140 \| 20 \| \+120 \(\+600\.0%\) \|/);
+  assert.match(reasons, /\| monthly_cap \| 60 \| 8 \| \+52 \(\+650\.0%\) \|/);
+  assert.match(reasons, /\| gave_up \| 12 \| 0 \| \+12 \(new\) \|/);
+  assert.match(reasons, /\| dead_token \| 8 \| 12 \| -4 \(-33\.3%\) \|/);
+  assert.ok(reasons.indexOf("| cooldown |") < reasons.indexOf("| window |"));
+});
+
+test("the deck table reports the pages, the page size and the tiers behind it", () => {
+  const body = buildReport(FIXTURE);
+  assert.ok(body.includes("### Deck"));
+  const [, deckSection] = body.split("### Deck");
+  assert.match(
+    deckSection,
+    /\| Deck Served \| 100 \| 80 \| \+20 \(\+25\.0%\) \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Swipers served a deck \| 40 \| 35 \| \+5 \(\+14\.3%\) \|/,
+  );
+  // 840 cards over 100 pages against 560 over 80.
+  assert.match(
+    deckSection,
+    /\| Cards served per page \| 8\.4 \| 7\.0 \| \+1\.4 \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Cards from primary \| 700 \| 560 \| \+140 \(\+25\.0%\) \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Cards from beyond_radius \| 90 \| 0 \| \+90 \(new\) \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Cards from same_gender \| 30 \| 0 \| \+30 \(new\) \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Cards from recycled_pass \| 20 \| 0 \| \+20 \(new\) \|/,
+  );
+  // 40 of 100 pages came back short, against 48 of 80 the week before.
+  assert.match(
+    deckSection,
+    /\| Short pages \(served under requested\) \| 40\.0% \| 60\.0% \| -20\.0 pp \|/,
+  );
+});
+
+test("the deck table sits between the sharing table and the push table", () => {
+  const body = buildReport(FIXTURE);
+  assert.ok(body.indexOf("### Sharing and deck") < body.indexOf("### Deck\n"));
+  assert.ok(body.indexOf("### Deck\n") < body.indexOf("### Push"));
+});
+
+test("a week the deck served nothing reports no page size rather than a division", () => {
+  const body = buildReport({ ...FIXTURE, deckSupply: [] });
+  const [, deckSection] = body.split("### Deck");
+  assert.match(
+    deckSection,
+    /\| Cards served per page \| n\/a \| n\/a \| n\/a \|/,
+  );
+  assert.match(
+    deckSection,
+    /\| Short pages \(served under requested\) \| n\/a \| n\/a \| n\/a \|/,
+  );
+  assert.match(deckSection, /\| Cards from primary \| 0 \| 0 \| 0 \|/);
+});
+
+test("the deck rows survive a query that answered with no rows at all", () => {
+  const body = buildReport({ ...FIXTURE, deckSupply: undefined });
+  const [, deckSection] = body.split("### Deck");
+  assert.match(
+    deckSection,
+    /\| Cards served per page \| n\/a \| n\/a \| n\/a \|/,
+  );
+});
+
+test("an average delta is a plain difference, not a percentage", () => {
+  assert.equal(formatAverageDelta(8.4, 7), "+1.4");
+  assert.equal(formatAverageDelta(7, 8.4), "-1.4");
+  assert.equal(formatAverageDelta(8, 8), "0");
+  assert.equal(formatAverageDelta(8.01, 8), "0");
+  assert.equal(formatAverageDelta(null, 8), "n/a");
+  assert.equal(formatAverageDelta(8, null), "n/a");
+});
+
 test("every breakdown gets its own table, ordered by the current window", () => {
   const body = buildReport(FIXTURE);
   for (const title of [
     "Upgrade by type",
     "Share Completed by option",
     "Push Ticket Result by status",
+    "Reengagement Push Suppressed by reason",
     "Fake Door Tapped by feature",
     "Signup Attributed by ref",
     "Image Moderation Result by verdict",
@@ -510,6 +663,25 @@ test("the coverage note does not excuse an event 1.6.2 is really sending", () =>
       `${event} arrives from 1.6.2, so the note must not blame the build`,
     );
   }
+});
+
+test("the coverage note says the update closed the gap on the phones that took it", () => {
+  const note = coverageNote();
+  assert.match(note, /Push Notification Opened is the exception/);
+  assert.match(note, /over the air update of 2026-09-04/);
+  assert.match(note, /only the devices that have not/);
+  // The gap sentence still comes first: the row is a mix of two populations
+  // while the update rolls out, so neither half can be dropped.
+  assert.ok(note.indexOf("cannot emit") < note.indexOf("is the exception"));
+});
+
+test("the coverage note leaves the exception out when no update has shipped", () => {
+  const note = coverageNote({
+    missingEvents: ["Share Tapped"],
+    version: "1.6.2",
+  });
+  assert.equal(note.includes("over the air"), false);
+  assert.match(note, /cannot emit Share Tapped/);
 });
 
 test("the coverage note says so plainly once the store build sends everything", () => {


### PR DESCRIPTION
## Summary

The readout counted the reminders that went out but not the ones the new cadence held back, and it said nothing about what the deck actually served. This adds both, and corrects the coverage note now that the store build can report push opens.

## Details

- New push rows: `Reengagement Push Suppressed` as events and as people held back. A send count alone cannot tell a week when nobody was due a nudge from a week when the cron broke, and these two rows are what separate them. They sit next to the send rows because a suppression is only readable against the send it replaced.
- New breakdown, `Reengagement Push Suppressed by reason`, with the five reasons the cron writes: `cooldown`, `monthly_cap`, `gave_up`, `dead_token`, `window`. The caps doing their job and a phone that can no longer be reached read very differently and cannot share a row.
- New Deck section: `Deck Served` events and distinct swipers, cards served per page, the four tier sums (`primary`, `beyond_radius`, `same_gender`, `recycled_pass`) and the share of pages that came back short, all for both windows.
- Short is the same condition the API falls back on, so that share is how often the wider tiers had anything to do. The tier sums say whether the refill is carrying the deck or the primary query already covered it.
- One extra HogQL query, sent in the same round as the ones that already run, so the readout is no slower. The counts are summed in ClickHouse and divided in the formatter, so each row picks its own denominator.
- The tier the API puts on a card and the counter the event carries disagree for one of them, `recycled_pass` against `recycled_count`. Both spellings live in one constant and a test checks each property against the shared catalogue, so neither end can guess.
- Coverage note corrected: `Push Notification Opened` is still missing from the store build, but the over the air update of 2026-09-04 carries it to the 1.6.2 runtime. The note now says the row fills from every phone that took the update and the gap is only the devices that have not, so the number is read as a rollout in progress rather than as a flat zero.
- Card averages report a plain difference rather than a percentage, because a page size moving from 7.0 to 8.4 is worth a card and a half and a percentage hides which side moved.

How this gets read after it ships:

- Pushes held back per week against pushes sent, from the two new rows. If suppression is almost all `cooldown` and `monthly_cap`, the caps from #266 are doing the work. A rising `dead_token` share is a delivery problem, and a rising `gave_up` share is people the app has stopped trying with.
- Short page share and the `beyond_radius`, `same_gender` and `recycled_pass` sums against `primary`, from #271. Baseline over the last 7 days: 27 `Empty Deck Shown` across 7 people, 2.25 per swiper. If the refill works, the short share stays visible while `Empty Deck Shown` falls.
- Cards served per page is the number that says whether a short deck is a filter problem or a supply problem once it is read next to the radius.

## Testing steps

Open the tracking issue and read the daily readout comment. The push section has two more rows counting the reminders that were deliberately held back, and there is a new table under it breaking those down by why. Above the push section there is a new deck table saying how many decks went out, how many cards each one carried, where those cards came from, and how often a deck came back with fewer cards than the app asked for. The line under the push table now explains that the push open row is filling up as people take the latest update, rather than reading as nothing at all. Nothing else in the readout moves.

## Screenshots

The new sections, rendered from the test fixture:

```markdown
### Deck

| Metric | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| Deck Served | 100 | 80 | +20 (+25.0%) |
| Swipers served a deck | 40 | 35 | +5 (+14.3%) |
| Cards served per page | 8.4 | 7.0 | +1.4 |
| Cards from primary | 700 | 560 | +140 (+25.0%) |
| Cards from beyond_radius | 90 | 0 | +90 (new) |
| Cards from same_gender | 30 | 0 | +30 (new) |
| Cards from recycled_pass | 20 | 0 | +20 (new) |
| Short pages (served under requested) | 40.0% | 60.0% | -20.0 pp |

### Push

| Metric | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| Reengagement Push Sent | 1,000 | 900 | +100 (+11.1%) |
| Users reached by push | 800 | 640 | +160 (+25.0%) |
| Reengagement Push Suppressed | 260 | 40 | +220 (+550.0%) |
| Users held back from a push | 210 | 32 | +178 (+556.3%) |
| Push Ticket Result | 100 | 100 | 0 |
| Push Ticket Result ok rate | 90.0% | 96.0% | -6.0 pp |
| Push Notification Opened | 140 | 100 | +40 (+40.0%) |
| Push open rate | 14.0% | 11.1% | +2.9 pp |
| Push attributed returns (60 min) | 200 | 160 | +40 (+25.0%) |
| Push attributed return rate | 25.0% | 25.0% | 0 |

Coverage note: the store build 1.6.2 cannot emit Fake Door Tapped, Push Notification Opened, Share Completed, Share Prompt Tapped, Share Tapped, so those rows read zero for anyone still on it. They measure reach, not the product. Push Notification Opened is the exception: the over the air update of 2026-09-04 carries it to the 1.6.2 runtime, so that row fills from every phone that has taken the update and the gap is only the devices that have not.

### Reengagement Push Suppressed by reason

| Bucket | Last 7 days | Previous 7 days | Delta |
| --- | ---: | ---: | ---: |
| cooldown | 140 | 20 | +120 (+600.0%) |
| monthly_cap | 60 | 8 | +52 (+650.0%) |
| window | 40 | 0 | +40 (new) |
| gave_up | 12 | 0 | +12 (new) |
| dead_token | 8 | 12 | -4 (-33.3%) |
```
