### PR TITLE
fix(mobile): keep a signed in user out of the sign in loop

### DIFF
--- a/apps/mobile/src/services/get-initial-route-name.test.ts
+++ b/apps/mobile/src/services/get-initial-route-name.test.ts
@@ -16,7 +16,10 @@ import { getData } from "@/services/storage";
 import { TRANSIENT_RETRY_ATTEMPTS } from "@/services/transient-retry";
 import { SceneName } from "@/types/scene-name";
 
-import { getInitialRouteName } from "./get-initial-route-name";
+import {
+  getInitialRouteName,
+  LAUNCH_ROUTE_BUDGET_MS,
+} from "./get-initial-route-name";
 
 jest.mock<Record<string, unknown>>("react-native", () => ({
   Platform: { OS: "ios" },
@@ -60,6 +63,23 @@ const mockGetData = jest.mocked(getData);
 /** The failure this function is built around: an attempt that never answered. */
 const timedOut = () => Promise.reject(new TypeError("Aborted"));
 
+/** A server that accepted the connection and then went quiet. */
+const neverAnswers = () =>
+  new Promise(() => {
+    // Accepted, and then nothing.
+  });
+
+/** The same, but honouring the abort the launch attaches to each attempt. */
+const hangsUntilAbandoned = (
+  _input: unknown,
+  options: { signal: AbortSignal },
+) =>
+  new Promise((_resolve, reject) => {
+    options.signal.addEventListener("abort", () => {
+      reject(new TypeError("Aborted"));
+    });
+  });
+
 const dogWithLocation = {
   images: [],
   user: { latitude: -23.5, longitude: -46.6 },
@@ -75,6 +95,10 @@ beforeEach(() => {
   myDogFetch.mockReset();
   myDogFetch.mockResolvedValue(dogWithLocation);
   mockGetData.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 test("opens the app when the launch query never answers and a token is stored", async () => {
@@ -123,4 +147,37 @@ test("keeps a token holder out of sign in when the dog query is the one that fai
   mockGetData.mockResolvedValue("stored-token");
 
   await expect(getInitialRouteName()).resolves.toBe(SceneName.Swipe);
+});
+
+test("gives up on the splash screen once the launch budget is spent", async () => {
+  jest.useFakeTimers();
+  echoQuery.mockImplementation(neverAnswers);
+  mockGetData.mockResolvedValue("stored-token");
+
+  const routeName = getInitialRouteName();
+  await jest.advanceTimersByTimeAsync(LAUNCH_ROUTE_BUDGET_MS);
+
+  // A server that accepts the connection and then says nothing cannot hold the
+  // splash screen open. The stored token answers from disk instead.
+  await expect(routeName).resolves.toBe(SceneName.Swipe);
+});
+
+test("abandons a hanging attempt in time to make another inside the budget", async () => {
+  jest.useFakeTimers();
+  echoQuery.mockImplementation(hangsUntilAbandoned);
+  mockGetData.mockResolvedValue("stored-token");
+
+  const routeName = getInitialRouteName();
+  await jest.advanceTimersByTimeAsync(LAUNCH_ROUTE_BUDGET_MS);
+
+  await expect(routeName).resolves.toBe(SceneName.Swipe);
+  // Two attempts, not one that ran out the clock and not a third the budget
+  // could not pay for.
+  expect(echoQuery).toHaveBeenCalledTimes(2);
+});
+
+test("keeps the launch budget inside a wait someone will sit through", () => {
+  // `useProtectedRoute` runs the launch again when the route segments change,
+  // so the worst case a user feels is twice this.
+  expect(LAUNCH_ROUTE_BUDGET_MS).toBeLessThanOrEqual(10_000);
 });

--- a/apps/mobile/src/services/get-initial-route-name.test.ts
+++ b/apps/mobile/src/services/get-initial-route-name.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The defect: the launch query got one attempt, and every failure of it -
+ * including the cold start timeout the app already retries everywhere else -
+ * landed the user on sign in. A user with a valid token in storage was sent to
+ * a screen they were already past, and the login there answers "Already logged
+ * in", so there was no way out but reinstalling.
+ *
+ * A token on disk outlives a failed request. It is the only evidence of a
+ * session this function has when nothing answers, so it decides the fallback.
+ *
+ * Every React Native flavoured import is stubbed, matching the other tests in
+ * this package: there is no RN transform here.
+ */
+import { getTrcpContext } from "@/contexts/trcp-context";
+import { getData } from "@/services/storage";
+import { TRANSIENT_RETRY_ATTEMPTS } from "@/services/transient-retry";
+import { SceneName } from "@/types/scene-name";
+
+import { getInitialRouteName } from "./get-initial-route-name";
+
+jest.mock<Record<string, unknown>>("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+jest.mock<Record<string, unknown>>("expo-constants", () => ({
+  __esModule: true,
+  default: { expoConfig: { version: "1.7.2" } },
+}));
+
+jest.mock<Record<string, unknown>>("@/contexts/trcp-context", () => ({
+  getTrcpContext: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/analytics", () => ({
+  analytics: { identify: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/force-update", () => ({
+  rememberMinimumSupportedVersion: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/get-logged-user-id", () => ({
+  getLoggedUserID: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/services/storage", () => ({
+  getData: jest.fn(),
+  StorageKeys: { Token: "token" },
+}));
+
+const echoQuery = jest.fn();
+const myDogFetch = jest.fn();
+
+const mockGetData = jest.mocked(getData);
+
+/** The failure this function is built around: an attempt that never answered. */
+const timedOut = () => Promise.reject(new TypeError("Aborted"));
+
+const dogWithLocation = {
+  images: [],
+  user: { latitude: -23.5, longitude: -46.6 },
+};
+
+beforeEach(() => {
+  jest.mocked(getTrcpContext).mockReturnValue({
+    client: { echo: { get: { query: echoQuery } } },
+    myDog: { get: { fetch: myDogFetch } },
+  } as unknown as ReturnType<typeof getTrcpContext>);
+
+  echoQuery.mockReset();
+  myDogFetch.mockReset();
+  myDogFetch.mockResolvedValue(dogWithLocation);
+  mockGetData.mockResolvedValue(null);
+});
+
+test("opens the app when the launch query never answers and a token is stored", async () => {
+  echoQuery.mockImplementation(timedOut);
+  mockGetData.mockResolvedValue("stored-token");
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.Swipe);
+});
+
+test("still sends a device with no token to sign in", async () => {
+  echoQuery.mockImplementation(timedOut);
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.SignIn);
+});
+
+test("retries the launch query instead of giving up on the first timeout", async () => {
+  echoQuery.mockImplementation(timedOut);
+  mockGetData.mockResolvedValue("stored-token");
+
+  await getInitialRouteName();
+
+  expect(echoQuery).toHaveBeenCalledTimes(TRANSIENT_RETRY_ATTEMPTS + 1);
+});
+
+test("routes normally when a retry recovers the launch query", async () => {
+  echoQuery
+    .mockImplementationOnce(timedOut)
+    .mockResolvedValue({ authenticated: true, forceUpdate: false });
+  mockGetData.mockResolvedValue("stored-token");
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.Swipe);
+});
+
+test("sends the user to sign in when the server answers that the token is not valid", async () => {
+  echoQuery.mockResolvedValue({ authenticated: false, forceUpdate: false });
+  mockGetData.mockResolvedValue("stored-token");
+
+  // An answer, not a failure: the server looked at the token and refused it.
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.SignIn);
+  expect(echoQuery).toHaveBeenCalledTimes(1);
+});
+
+test("keeps a token holder out of sign in when the dog query is the one that fails", async () => {
+  echoQuery.mockResolvedValue({ authenticated: true, forceUpdate: false });
+  myDogFetch.mockImplementation(timedOut);
+  mockGetData.mockResolvedValue("stored-token");
+
+  await expect(getInitialRouteName()).resolves.toBe(SceneName.Swipe);
+});

--- a/apps/mobile/src/services/get-initial-route-name.ts
+++ b/apps/mobile/src/services/get-initial-route-name.ts
@@ -68,16 +68,58 @@ const wait = (ms: number) =>
   });
 
 /**
- * Runs the launch query under the same policy the auth mutations use.
+ * Ceiling on one attempt at the launch query.
+ *
+ * Deliberately shorter than the tRPC client's own 15 second ceiling (see
+ * contexts/trpc-provider). That one is sized for a request a screen is waiting
+ * to render, where waiting is the only option. This one is sized for a request
+ * the splash screen is waiting on, where a second attempt is worth more than a
+ * long first one. Four seconds clears a function that has to boot and a Prisma
+ * engine that has to start, and leaves room for the retries inside the budget
+ * below.
+ */
+const LAUNCH_QUERY_TIMEOUT_MS = 4_000;
+
+/**
+ * Ceiling on the whole decision, retries and the dog query included.
+ *
+ * The fallback below answers the same question from disk, instantly, so there
+ * is no reason to hold the splash screen much past one cold boot while the
+ * network makes its mind up. `useProtectedRoute` re-runs this when the route
+ * segments change, so an unbounded launch was paid for twice: a phone with no
+ * connection sat on the splash screen for a minute and a half.
+ */
+export const LAUNCH_ROUTE_BUDGET_MS = 10_000;
+
+/**
+ * One attempt at the launch query, abandoned rather than left hanging.
  *
  * `client.echo.get.query()` goes straight down the tRPC client, so nothing
- * retries it: the first request of a cold deployment is also the one request
- * every launch waits on, and a single blip on it used to decide where the
- * user lands. React Query already retries `myDog.get.fetch()`, so only this
- * call needs the wrapper.
+ * retries it and nothing but the client's own long timeout stops it: the first
+ * request of a cold deployment is also the one request every launch waits on,
+ * and a single blip on it used to decide where the user lands.
+ */
+const queryLaunchState = async () => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), LAUNCH_QUERY_TIMEOUT_MS);
+
+  try {
+    return await getTrcpContext().client.echo.get.query(undefined, {
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Retries the launch query under the same policy the auth mutations use, for
+ * as long as the budget can still pay for another attempt. React Query already
+ * retries `myDog.get.fetch()`, so only this call needs the wrapper.
  */
 const withTransientRetry = async <T>(
   run: () => Promise<T>,
+  deadline: number,
   failureCount = 0,
 ): Promise<T> => {
   try {
@@ -85,8 +127,13 @@ const withTransientRetry = async <T>(
   } catch (error) {
     if (!shouldRetryTransient(failureCount, error)) throw error;
 
-    await wait(transientRetryDelayMs(failureCount));
-    return withTransientRetry(run, failureCount + 1);
+    const delay = transientRetryDelayMs(failureCount);
+    // Never start an attempt that cannot finish before the budget runs out.
+    // Firing it would cost a request nobody is left waiting for.
+    if (Date.now() + delay + LAUNCH_QUERY_TIMEOUT_MS > deadline) throw error;
+
+    await wait(delay);
+    return withTransientRetry(run, deadline, failureCount + 1);
   }
 };
 
@@ -113,10 +160,10 @@ const getOfflineRouteName = async () => {
   }
 };
 
-export const getInitialRouteName = async () => {
+const resolveInitialRouteName = async (deadline: number) => {
   try {
     const { authenticated, forceUpdate, minimumSupportedVersion } =
-      await withTransientRetry(() => getTrcpContext().client.echo.get.query());
+      await withTransientRetry(queryLaunchState, deadline);
 
     rememberMinimumSupportedVersion(minimumSupportedVersion);
 
@@ -144,5 +191,23 @@ export const getInitialRouteName = async () => {
   } catch (error) {
     sendError(error);
     return getOfflineRouteName();
+  }
+};
+
+export const getInitialRouteName = async () => {
+  const deadline = Date.now() + LAUNCH_ROUTE_BUDGET_MS;
+
+  let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+  const budgetSpent = new Promise<void>((resolve) => {
+    budgetTimer = setTimeout(resolve, LAUNCH_ROUTE_BUDGET_MS);
+  });
+
+  try {
+    return await Promise.race([
+      resolveInitialRouteName(deadline),
+      budgetSpent.then(getOfflineRouteName),
+    ]);
+  } finally {
+    clearTimeout(budgetTimer);
   }
 };

--- a/apps/mobile/src/services/get-initial-route-name.ts
+++ b/apps/mobile/src/services/get-initial-route-name.ts
@@ -8,6 +8,11 @@ import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
 import { rememberMinimumSupportedVersion } from "@/services/force-update";
 import { getLoggedUserID } from "@/services/get-logged-user-id";
+import { getData, StorageKeys } from "@/services/storage";
+import {
+  shouldRetryTransient,
+  transientRetryDelayMs,
+} from "@/services/transient-retry";
 import { SceneName } from "@/types/scene-name";
 
 import { sendError } from "./error-tracking";
@@ -57,10 +62,61 @@ export const trackUser = () => {
   });
 };
 
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Runs the launch query under the same policy the auth mutations use.
+ *
+ * `client.echo.get.query()` goes straight down the tRPC client, so nothing
+ * retries it: the first request of a cold deployment is also the one request
+ * every launch waits on, and a single blip on it used to decide where the
+ * user lands. React Query already retries `myDog.get.fetch()`, so only this
+ * call needs the wrapper.
+ */
+const withTransientRetry = async <T>(
+  run: () => Promise<T>,
+  failureCount = 0,
+): Promise<T> => {
+  try {
+    return await run();
+  } catch (error) {
+    if (!shouldRetryTransient(failureCount, error)) throw error;
+
+    await wait(transientRetryDelayMs(failureCount));
+    return withTransientRetry(run, failureCount + 1);
+  }
+};
+
+/**
+ * Where to land when the launch query never answered.
+ *
+ * The stored token is the only evidence of a session that survives a failed
+ * request, and this branch runs precisely when no request succeeded. Sending a
+ * user who holds one to sign in was the loop: they are already signed in, so
+ * the login mutation answers "Already logged in" and there is no way forward.
+ *
+ * Into the app instead. Every screen there fetches for itself, and a token the
+ * server actually rejects comes back as a 401, which the tRPC client turns
+ * into a real logout. Sign in stays the answer for a device with no token,
+ * which is the only case where it is the truth.
+ */
+const getOfflineRouteName = async () => {
+  try {
+    const token = await getData(StorageKeys.Token);
+    return token ? SceneName.Swipe : SceneName.SignIn;
+  } catch (error) {
+    sendError(error);
+    return SceneName.SignIn;
+  }
+};
+
 export const getInitialRouteName = async () => {
   try {
     const { authenticated, forceUpdate, minimumSupportedVersion } =
-      await getTrcpContext().client.echo.get.query();
+      await withTransientRetry(() => getTrcpContext().client.echo.get.query());
 
     rememberMinimumSupportedVersion(minimumSupportedVersion);
 
@@ -68,6 +124,8 @@ export const getInitialRouteName = async () => {
       return SceneName.ForceUpdate;
     }
 
+    // The server looked at the token and said no. That is an answer, not a
+    // failure, so sign in is correct here even with a token on disk.
     if (!authenticated) {
       return SceneName.SignIn;
     }
@@ -85,6 +143,6 @@ export const getInitialRouteName = async () => {
     return SceneName.Swipe;
   } catch (error) {
     sendError(error);
-    return SceneName.SignIn;
+    return getOfflineRouteName();
   }
 };

--- a/apps/mobile/src/services/transient-retry.test.ts
+++ b/apps/mobile/src/services/transient-retry.test.ts
@@ -60,6 +60,13 @@ describe("shouldRetryTransient", () => {
     expect(shouldRetryTransient(0, serverError(429))).toBe(false);
   });
 
+  it("leaves an already logged in login alone", () => {
+    // The login guard used to throw a bare Error, which tRPC could only send
+    // as a 500, so this very policy turned one tap into three requests. It
+    // throws CONFLICT now, and a 409 is final.
+    expect(shouldRetryTransient(0, serverError(409))).toBe(false);
+  });
+
   it("stops once the attempts are spent", () => {
     const error = serverError(500);
 

--- a/packages/api/src/routes/authentication.test.ts
+++ b/packages/api/src/routes/authentication.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The defect: this guard threw a bare `Error`, and tRPC has nowhere to put an
+ * uncoded throw except INTERNAL_SERVER_ERROR, so a user who already held a
+ * session got a 500. The app retries an uncoded 5xx twice (see
+ * apps/mobile/src/services/transient-retry.ts), so a single tap on Continue
+ * became three requests and three exception rows in the audit.
+ *
+ * The guard itself is unchanged: it still refuses. What is pinned here is that
+ * it refuses with a code, and that the code lands in the 4xx range the client
+ * treats as final.
+ */
+import { TRPCError } from "@trpc/server";
+import { getHTTPStatusCodeFromError } from "@trpc/server/http";
+
+import { createInnerTRPCContext } from "../trpc";
+import { authenticationRouter } from "./authentication";
+
+jest.mock("../shared/observability", () => ({
+  observability: {
+    enabled: false,
+    disabledReason: "explicitly-disabled",
+    capture: jest.fn(),
+    captureError: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    register: jest.fn(),
+    flush: jest.fn(),
+    shutdown: jest.fn(),
+  },
+  getPostHogNode: jest.fn(() => null),
+}));
+
+jest.mock("superjson", () => ({
+  __esModule: true,
+  default: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value,
+  },
+}));
+
+const loginAsSignedInUser = () =>
+  authenticationRouter
+    .createCaller(
+      createInnerTRPCContext({ session: { user: { id: "user-1" } } }),
+    )
+    .login({ email: "someone@pegada.app" });
+
+it("refuses a login from a session that already exists", async () => {
+  await expect(loginAsSignedInUser()).rejects.toBeInstanceOf(TRPCError);
+});
+
+it("carries a code the client will not retry", async () => {
+  const caught = await loginAsSignedInUser().catch((error: unknown) => error);
+
+  expect(caught).toBeInstanceOf(TRPCError);
+  expect((caught as TRPCError).code).toBe("CONFLICT");
+  // 409, not 500. `shouldRetryTransient` on the app retries a 5xx that carries
+  // no error code, which is what turned one tap into three requests.
+  expect(getHTTPStatusCodeFromError(caught as TRPCError)).toBe(409);
+});

--- a/packages/api/src/routes/authentication.ts
+++ b/packages/api/src/routes/authentication.ts
@@ -2,6 +2,7 @@ import {
   REFERRAL_ID_REGEX,
   REFERRAL_REF_REGEX,
 } from "@pegada/shared/utils/referral";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import { AuthenticationService } from "../services/authentication-service";
@@ -38,8 +39,17 @@ export const authenticationRouter = createTRPCRouter({
 
       // Prevents malicious users from exploiting the lack of
       // rate limiting for logged in users
+      //
+      // Coded, not a bare Error: an uncoded throw leaves tRPC no choice but
+      // INTERNAL_SERVER_ERROR, and the app retries an uncoded 5xx twice (see
+      // apps/mobile/src/services/transient-retry.ts). One tap by someone who
+      // already had a session cost three requests and logged three
+      // exceptions. CONFLICT maps to 409, which the client treats as final.
       if (alreadyLoggedIn) {
-        throw new Error("Already logged in");
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Already logged in",
+        });
       }
 
       const authenticationService = new AuthenticationService({


### PR DESCRIPTION
## Summary

Someone who is already signed in can land on the sign in screen and get stuck there. The app sends them to sign in whenever the first request of a launch fails, even with a valid session saved on the phone, and the sign in attempt then fails because the server can see they already have a session.

## Details

- The launch request is now retried under the same policy the sign in and code screens already use, instead of being given up on after one timeout.
- When it still cannot be answered, the app checks for a saved session before deciding. With one, it opens the app and lets each screen fetch for itself. With none, it goes to sign in, which is the only case where sign in is the truth.
- If the server answers that the saved session is no longer valid, the user goes to sign in as before. The server looked and refused, so that is a real answer.
- The whole decision is bounded. Each attempt at the launch request is abandoned after 4 seconds instead of the 15 the rest of the app allows, and the decision as a whole gives up after 10 seconds and uses the saved session. Waiting longer buys nothing, since the saved session answers the same question from the phone itself. Without the bound a phone with no connection sat on the splash screen for around a minute and a half.
- The login route refused an already signed in caller with an uncoded error, which the server could only report as a 500. The app retries an uncoded 500 twice, so one tap cost three requests and logged three exceptions. It now refuses with a conflict, a 409, which the app treats as final and leaves alone.
- Hypothesis: this is what the signup drop off is made of. Last week Create Dog Profile fired 14 times and Complete Dog Profile fired 13. The expectation is that the gap between those two events closes and that the two exception rows for this error go to zero.
- How it gets read after shipping: the Create Dog Profile and Complete Dog Profile counts in the daily report, and the "TRPCError Already logged in" rows in the seven day exceptions audit on #188.
- Tests cover both halves. On the server, a login from a caller who already has a session comes back coded as a 409 rather than an uncoded 500. On the app, a saved session plus a launch request that never answers opens the app, no saved session still opens sign in, and the launch cannot outgrow its budget without a test failing.
- Issue #282, item 3.

## Testing steps

1. Sign in on a phone and go all the way through to the deck of dogs, so the app remembers you.
2. Close the app fully. Turn on airplane mode, or use a connection bad enough that the app cannot reach the server.
3. Open the app from cold. It should open on the deck within about ten seconds. It should not show the sign in screen and it should not ask for your email again.
4. Turn the network back on. The deck fills in and everything works normally.
5. Now sign out, close the app, turn the network off again and open it. This time the sign in screen is the right place to be, because there is no saved session on the phone. It should still appear quickly rather than after a long blank wait.
6. Back on a normal connection, sign in from scratch and confirm the email and code flow is unchanged, and that opening the app is no slower than before.

## Screenshots

No visible change in this one: the screens are identical, only which screen the app opens on after a failed launch request, and how long it waits first, are different.
