### PR TITLE
fix(api): let profile photos outlive a slow first form

### DIFF
--- a/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/components/AddUserPhoto/index.tsx
@@ -41,7 +41,7 @@ import {
 type AddUserPhotoProps = {
   picture: Picture;
   onDelete: () => void;
-  onAdd: ({ url }: { url: string }) => void;
+  onAdd: ({ url, localUri }: { url: string; localUri?: string }) => void;
   /**
    * Position of this slot inside the photo grid. Used to derive a stable
    * `testID` (`add-photo-{index}` / `remove-photo-{index}`) so Maestro flows
@@ -121,14 +121,18 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({
       const selectedImage = await showImagePickerOptions();
 
       /** Early on visual feedback */
-      onAdd({ url: selectedImage.uri });
+      onAdd({ url: selectedImage.uri, localUri: selectedImage.uri });
       setLocalPicture(selectedImage.uri);
 
       const finalUrl = await uploadProfileImage(selectedImage.uri, (s) => {
         stage = s;
       });
 
-      onAdd({ url: finalUrl });
+      // The local URI rides along with the bucket URL for the rest of the
+      // form. The server only holds a fresh upload for a while, and the
+      // profile is not saved until the person has stopped typing, so keeping
+      // the file on hand is what lets the save recover on its own.
+      onAdd({ url: finalUrl, localUri: selectedImage.uri });
 
       // After the upload finishes, not after the picker closes: a photo that
       // never reaches the bucket is a shadowban, not a photo. Profiles without
@@ -183,14 +187,14 @@ export const AddUserPhoto: React.FC<AddUserPhotoProps> = ({
 
       // Optimistic feedback identical to the real flow so screenshots/check
       // observers see the same intermediate state.
-      onAdd({ url: placeholderUri });
+      onAdd({ url: placeholderUri, localUri: placeholderUri });
       setLocalPicture(placeholderUri);
 
       const finalUrl = await uploadProfileImage(placeholderUri, (s) => {
         stage = s;
       });
 
-      onAdd({ url: finalUrl });
+      onAdd({ url: finalUrl, localUri: placeholderUri });
     } catch (error) {
       reportUploadFailure(
         error,

--- a/apps/mobile/src/components/ProfileImageUploader/index.tsx
+++ b/apps/mobile/src/components/ProfileImageUploader/index.tsx
@@ -40,7 +40,7 @@ const AddUserPhotoWrapper = ({
     });
   };
 
-  const onAdd = ({ url }: { url: string }) => {
+  const onAdd = ({ url, localUri }: { url: string; localUri?: string }) => {
     onChange((images) =>
       images
         .map((currentPicture) => {
@@ -51,6 +51,7 @@ const AddUserPhotoWrapper = ({
           return {
             ...currentPicture,
             url,
+            localUri,
             disabledDrag: false,
             disabledReSorted: false,
           };

--- a/apps/mobile/src/components/ProfileImageUploader/utils/index.ts
+++ b/apps/mobile/src/components/ProfileImageUploader/utils/index.ts
@@ -31,6 +31,15 @@ export type Picture = {
   position: number;
   status?: keyof typeof IMAGE_STATUS;
   blurhash?: string;
+  /**
+   * The photo as it still sits on the phone, kept for the whole life of the
+   * form. `url` points at a bucket object the server only holds for a while,
+   * and the profile is not saved until the person has finished typing, so
+   * this is what makes a second upload possible without asking them to pick
+   * the same photo again. Absent on photos loaded from an existing profile:
+   * those are already permanent.
+   */
+  localUri?: string;
 };
 
 export type DeletedPicture = Omit<Picture, "position">;

--- a/apps/mobile/src/services/expired-upload-retry.test.ts
+++ b/apps/mobile/src/services/expired-upload-retry.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Issue #282, item 4: "This photo upload has expired" on Create Profile. The
+ * photos go to the bucket the moment they are picked, the name and the bio are
+ * typed afterwards, and the grant used to die ten minutes in. Save then failed,
+ * and the dead URLs stayed in form state, so every further tap failed the same
+ * way and the profile could not be saved at all.
+ *
+ * The server now holds the grant for an hour. This is the client half: one
+ * re-upload, one more save, and a toast if even that does not land.
+ */
+jest.mock<Record<string, unknown>>(
+  "@/components/ProfileImageUploader/utils",
+  () => ({ uploadProfileImage: jest.fn() }),
+);
+
+jest.mock<Record<string, unknown>>("react-native-magic-toast", () => ({
+  magicToast: { alert: jest.fn() },
+}));
+
+jest.mock<Record<string, unknown>>("@/services/error-tracking", () => ({
+  sendError: jest.fn(),
+}));
+
+jest.mock<Record<string, unknown>>("@/i18n", () => ({
+  __esModule: true,
+  default: { t: (key: string) => key },
+}));
+
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
+import { magicToast } from "react-native-magic-toast";
+
+import { uploadProfileImage } from "@/components/ProfileImageUploader/utils";
+import { sendError } from "@/services/error-tracking";
+
+import { saveWithExpiredUploadRetry } from "./expired-upload-retry";
+
+const reupload = jest.mocked(uploadProfileImage);
+const alert = jest.mocked(magicToast.alert);
+const report = jest.mocked(sendError);
+
+/** What the tRPC client hands the caller for a server-thrown intentional error. */
+const expiredGrant = () => ({
+  data: {
+    error: {
+      error_code: InvalidUploadGrantError.error_code,
+      code: "BAD_REQUEST",
+    },
+  },
+});
+
+const photos = [
+  { id: "first", url: "https://cdn/stale-one.webp", localUri: "file://one" },
+  { id: "second", url: "https://cdn/stale-two.webp", localUri: "file://two" },
+];
+
+test("saves once and touches nothing when the photos are still good", async () => {
+  const save = jest.fn(async () => "saved");
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).resolves.toBe("saved");
+
+  expect(save).toHaveBeenCalledTimes(1);
+  expect(reupload).not.toHaveBeenCalled();
+});
+
+test("leaves any other failure alone rather than re-uploading on a hunch", async () => {
+  const offline = new TypeError("Network request failed");
+  const save = jest.fn(async () => {
+    throw offline;
+  });
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).rejects.toBe(offline);
+
+  expect(save).toHaveBeenCalledTimes(1);
+  expect(reupload).not.toHaveBeenCalled();
+  expect(alert).not.toHaveBeenCalled();
+});
+
+test("puts the photos back and saves again, once", async () => {
+  reupload
+    .mockResolvedValueOnce("https://cdn/fresh-one.webp")
+    .mockResolvedValueOnce("https://cdn/fresh-two.webp");
+
+  const save = jest
+    .fn<Promise<string>, [typeof photos]>()
+    .mockRejectedValueOnce(expiredGrant())
+    .mockResolvedValueOnce("saved");
+
+  const onReuploaded = jest.fn();
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save, onReuploaded }),
+  ).resolves.toBe("saved");
+
+  expect(reupload).toHaveBeenCalledTimes(2);
+  expect(reupload).toHaveBeenNthCalledWith(1, "file://one");
+  expect(reupload).toHaveBeenNthCalledWith(2, "file://two");
+
+  expect(save).toHaveBeenCalledTimes(2);
+  // The second attempt carries the new URLs, and the form gets them too, so a
+  // manual tap afterwards cannot resubmit the dead ones.
+  const freshened = [
+    { ...photos[0], url: "https://cdn/fresh-one.webp" },
+    { ...photos[1], url: "https://cdn/fresh-two.webp" },
+  ];
+  expect(save).toHaveBeenNthCalledWith(2, freshened);
+  expect(onReuploaded).toHaveBeenCalledWith(freshened);
+
+  // Nothing to tell the user about: the save went through.
+  expect(alert).not.toHaveBeenCalled();
+  expect(report).not.toHaveBeenCalled();
+});
+
+test("keeps a photo that only exists in the bucket exactly as it is", async () => {
+  const alreadySaved = [
+    { id: "old", url: "https://cdn/dogs/permanent.webp" },
+    { id: "new", url: "https://cdn/stale.webp", localUri: "file://new" },
+  ];
+  reupload.mockResolvedValueOnce("https://cdn/fresh.webp");
+
+  const save = jest
+    .fn<Promise<string>, [typeof alreadySaved]>()
+    .mockRejectedValueOnce(expiredGrant())
+    .mockResolvedValueOnce("saved");
+
+  await saveWithExpiredUploadRetry({ images: alreadySaved, save });
+
+  expect(reupload).toHaveBeenCalledTimes(1);
+  expect(save).toHaveBeenNthCalledWith(2, [
+    alreadySaved[0],
+    { ...alreadySaved[1], url: "https://cdn/fresh.webp" },
+  ]);
+});
+
+test("tells the user and stops when the second save fails too", async () => {
+  reupload.mockResolvedValue("https://cdn/fresh.webp");
+
+  const stillExpired = expiredGrant();
+  const save = jest
+    .fn<Promise<string>, [typeof photos]>()
+    .mockRejectedValueOnce(expiredGrant())
+    .mockRejectedValueOnce(stillExpired);
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).rejects.toBe(stillExpired);
+
+  expect(save).toHaveBeenCalledTimes(2);
+  expect(reupload).toHaveBeenCalledTimes(photos.length);
+  expect(alert).toHaveBeenCalledWith("editProfile.photosExpired");
+  expect(report).toHaveBeenCalledWith(stillExpired);
+});
+
+test("tells the user and stops when the photos cannot go back up", async () => {
+  const uploadFailed = new Error("upload PUT returned 500");
+  reupload.mockRejectedValue(uploadFailed);
+
+  const save = jest
+    .fn<Promise<string>, [typeof photos]>()
+    .mockRejectedValueOnce(expiredGrant());
+
+  await expect(
+    saveWithExpiredUploadRetry({ images: photos, save }),
+  ).rejects.toBe(uploadFailed);
+
+  expect(save).toHaveBeenCalledTimes(1);
+  expect(alert).toHaveBeenCalledWith("editProfile.photosExpired");
+});

--- a/apps/mobile/src/services/expired-upload-retry.ts
+++ b/apps/mobile/src/services/expired-upload-retry.ts
@@ -1,0 +1,73 @@
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
+import { magicToast } from "react-native-magic-toast";
+
+import { uploadProfileImage } from "@/components/ProfileImageUploader/utils";
+import i18n from "@/i18n";
+import { sendError } from "@/services/error-tracking";
+import { getError } from "@/services/get-error";
+
+export type RetryableImage = {
+  url: string;
+  /** Present only while the photo is still on the phone. */
+  localUri?: string;
+};
+
+/**
+ * Save a dog profile, and if the server says the photos went stale, put them
+ * back in the bucket and save one more time.
+ *
+ * Issue #282: Create Profile uploads the photos as soon as they are picked,
+ * then waits for a name, a bio and a gender. The upload grant used to last ten
+ * minutes, so a form filled in slowly failed on save with
+ * `INVALID_UPLOAD_GRANT`, and because the dead URLs stayed in form state every
+ * further tap failed the same way. The grant now lasts an hour, which is the
+ * real fix; this is the floor under it, for the person who leaves the screen
+ * open over lunch or whose phone slept through the whole form.
+ *
+ * Exactly one extra attempt. A loop here would mean re-uploading every photo
+ * on a phone that is failing for some other reason, on someone else's data
+ * plan, forever.
+ */
+export const saveWithExpiredUploadRetry = async <
+  TImage extends RetryableImage,
+  TResult,
+>({
+  images,
+  save,
+  onReuploaded,
+}: {
+  images: TImage[];
+  save: (images: TImage[]) => Promise<TResult>;
+  /**
+   * Hand the fresh URLs back to the form. Without this a manual tap after a
+   * failed retry would submit the dead ones all over again.
+   */
+  onReuploaded?: (images: TImage[]) => void;
+}): Promise<TResult> => {
+  try {
+    return await save(images);
+  } catch (error) {
+    if (!getError(error, InvalidUploadGrantError)) throw error;
+
+    try {
+      const reuploaded = await Promise.all(
+        images.map(async (image) =>
+          image.localUri
+            ? { ...image, url: await uploadProfileImage(image.localUri) }
+            : image,
+        ),
+      );
+
+      onReuploaded?.(reuploaded);
+
+      return await save(reuploaded);
+    } catch (retryError) {
+      // Only now is it worth anyone's attention: the first failure is one the
+      // app recovers from by itself, and reporting it would keep the exception
+      // rows in the issue #188 audit alive for a problem that fixed itself.
+      magicToast.alert(i18n.t("editProfile.photosExpired"));
+      sendError(retryError);
+      throw retryError;
+    }
+  }
+};

--- a/apps/mobile/src/views/(auth)/CreateProfile/index.tsx
+++ b/apps/mobile/src/views/(auth)/CreateProfile/index.tsx
@@ -8,6 +8,7 @@ import { View, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
 import { dogQuickClientSchema } from "@pegada/shared/schemas/dog-schema";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -31,6 +32,8 @@ import {
 } from "@/hooks/use-keyboard-aware-scroll";
 import { analytics } from "@/services/analytics";
 import { sendError } from "@/services/error-tracking";
+import { saveWithExpiredUploadRetry } from "@/services/expired-upload-retry";
+import { getError } from "@/services/get-error";
 import { SceneName } from "@/types/scene-name";
 
 import { DragHint, MultilineInput, PhotoHint, styles } from "./styles";
@@ -45,7 +48,7 @@ const DEFAULT_VALUES: DogQuickClientSchema = {
 const CreateProfile = () => {
   const { t } = useTranslation();
 
-  const { control, handleSubmit, getValues } = useForm({
+  const { control, handleSubmit, getValues, setValue } = useForm({
     defaultValues: DEFAULT_VALUES,
     resolver: zodResolver(dogQuickClientSchema),
   });
@@ -77,26 +80,58 @@ const CreateProfile = () => {
       });
     },
     onError: (error) => {
+      // Photos that went stale while the form was being filled in are handled
+      // by `saveWithExpiredUploadRetry` below, which uploads them again and
+      // saves a second time. Toasting here would put an error on screen for an
+      // attempt the person never needed to know about.
+      if (getError(error, InvalidUploadGrantError)) return;
+
       magicToast.alert(t("editProfile.profileError"));
       sendError(error);
     },
   });
 
   const saveUser = handleSubmit(async (data) => {
-    const dogData = {
-      name: data.name,
-      bio: data.bio,
-      gender: data.gender,
-      images: data.images
-        .filter((image) => Boolean(image.url))
-        .map((image, index) => ({
-          id: image.id,
-          url: image.url as string,
-          position: index,
-        })),
-    };
+    const images = (data.images as Picture[])
+      .filter((image) => Boolean(image.url))
+      .map((image, index) => ({
+        id: image.id,
+        url: image.url,
+        position: index,
+        localUri: image.localUri,
+      }));
 
-    await dogCreateMutation.mutateAsync(dogData);
+    try {
+      await saveWithExpiredUploadRetry({
+        images,
+        save: (attemptImages) =>
+          dogCreateMutation.mutateAsync({
+            name: data.name,
+            bio: data.bio,
+            gender: data.gender,
+            images: attemptImages.map(({ id, url, position }) => ({
+              id,
+              url,
+              position,
+            })),
+          }),
+        onReuploaded: (attemptImages) => {
+          setValue(
+            "images",
+            (getValues("images") as Picture[]).map((picture) => {
+              const reuploaded = attemptImages.find(
+                (image) => image.id === picture.id,
+              );
+
+              return reuploaded ? { ...picture, url: reuploaded.url } : picture;
+            }),
+          );
+        },
+      });
+    } catch {
+      // Both failure paths have already reported and toasted. The screen keeps
+      // the form exactly as it is so the next tap is a save, not a rebuild.
+    }
   });
 
   const [gesturesEnabled, setGesturesEnabled] = useState(true);

--- a/apps/mobile/src/views/EditProfile/index.tsx
+++ b/apps/mobile/src/views/EditProfile/index.tsx
@@ -8,6 +8,7 @@ import { View, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { InvalidUploadGrantError } from "@pegada/shared/errors/errors";
 import { dogClientSchema } from "@pegada/shared/schemas/dog-schema";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { format } from "date-fns/format";
@@ -37,6 +38,8 @@ import {
 import { analytics } from "@/services/analytics";
 import { colors, sizes } from "@/services/consts";
 import { sendError } from "@/services/error-tracking";
+import { saveWithExpiredUploadRetry } from "@/services/expired-upload-retry";
+import { getError } from "@/services/get-error";
 import { maskDate } from "@/services/mask-date";
 import { Actions } from "@/store/reducers";
 
@@ -146,6 +149,11 @@ const EditProfile = () => {
       router.back();
     },
     onError: (error) => {
+      // Newly added photos that went stale while the rest of the form was
+      // being filled in are handled by `saveWithExpiredUploadRetry` below,
+      // which uploads them again and saves a second time.
+      if (getError(error, InvalidUploadGrantError)) return;
+
       magicToast.alert(t("editProfile.profileError"));
       sendError(error);
     },
@@ -162,14 +170,44 @@ const EditProfile = () => {
       breedId: data.breedId ? data.breedId : null,
       color: data.color ? data.color : null,
       size: data.size ?? null,
-      images: data.images?.map((image, index) => ({
-        id: image.id,
-        url: image.url,
-        position: index,
-      })),
     };
 
-    await myDogUpdateMutation.mutateAsync(updateData);
+    const images = ((data.images ?? []) as Picture[]).map((image, index) => ({
+      id: image.id,
+      url: image.url,
+      position: index,
+      localUri: image.localUri,
+    }));
+
+    try {
+      await saveWithExpiredUploadRetry({
+        images,
+        save: (attemptImages) =>
+          myDogUpdateMutation.mutateAsync({
+            ...updateData,
+            images: attemptImages.map(({ id, url, position }) => ({
+              id,
+              url,
+              position,
+            })),
+          }),
+        onReuploaded: (attemptImages) => {
+          setValue(
+            "images",
+            (getValues("images") as Picture[]).map((picture) => {
+              const reuploaded = attemptImages.find(
+                (image) => image.id === picture.id,
+              );
+
+              return reuploaded ? { ...picture, url: reuploaded.url } : picture;
+            }),
+          );
+        },
+      });
+    } catch {
+      // Both failure paths have already reported and toasted. The screen keeps
+      // the form exactly as it is so the next tap is a save, not a rebuild.
+    }
   });
 
   return (

--- a/packages/api/src/services/image-service.test.ts
+++ b/packages/api/src/services/image-service.test.ts
@@ -3,12 +3,14 @@ import {
   InvalidUploadGrantError,
   UploadLimitReachedError,
 } from "@pegada/shared/errors/errors";
+import { addMinutes } from "date-fns/addMinutes";
 
 import { deleteImageFromS3, moveImageToFolder } from "../shared/file-upload";
 import {
   createTemporaryUploadKey,
   ImageService,
   UPLOAD_GRANT_LIMIT,
+  UPLOAD_GRANT_TTL_SECONDS,
   UPLOAD_URL_TTL_SECONDS,
 } from "./image-service";
 
@@ -186,5 +188,92 @@ describe("upload grants", () => {
     });
     await ImageService.cleanupExpiredTemporaryUpload(activeGrant.id);
     expect(deleteStoredImage).toHaveBeenCalledWith(activeUpload.publicUrl);
+  });
+});
+
+/**
+ * Issue #282: photos uploaded on Create Profile went stale while the person was
+ * still typing the name and the bio, because the presigned PUT window and the
+ * window to finish the form were the same ten minutes. Save then failed, and
+ * every retap resubmitted the same dead URLs out of form state.
+ *
+ * Only `Date` is faked here. Prisma's pool and the S3 client run on real
+ * timers, and freezing those hangs the suite instead of failing it.
+ */
+const freezeClockAt = (now: Date) =>
+  jest.useFakeTimers({
+    doNotFake: [
+      "cancelAnimationFrame",
+      "cancelIdleCallback",
+      "clearImmediate",
+      "clearInterval",
+      "clearTimeout",
+      "hrtime",
+      "nextTick",
+      "performance",
+      "queueMicrotask",
+      "requestAnimationFrame",
+      "requestIdleCallback",
+      "setImmediate",
+      "setInterval",
+      "setTimeout",
+    ],
+    now,
+  });
+
+describe("how long an uploaded photo stays claimable", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const uploadAt = async (uploadedAt: Date) => {
+    freezeClockAt(uploadedAt);
+    return ImageService.getSignedUpload("slow-form-user", {
+      contentLength: 4,
+      contentType: "image/webp",
+    });
+  };
+
+  it("outlives the presigned PUT by a long way", async () => {
+    const uploadedAt = new Date();
+    const upload = await uploadAt(uploadedAt);
+
+    await expect(
+      prisma.uploadGrant.findUniqueOrThrow({
+        where: { temporaryUrl: upload.publicUrl },
+      }),
+    ).resolves.toMatchObject({
+      expiresAt: new Date(
+        uploadedAt.getTime() + UPLOAD_GRANT_TTL_SECONDS * 1000,
+      ),
+    });
+    expect(UPLOAD_GRANT_TTL_SECONDS).toBeGreaterThan(UPLOAD_URL_TTL_SECONDS);
+  });
+
+  it("still saves a profile filled in over three quarters of an hour", async () => {
+    const uploadedAt = new Date();
+    const upload = await uploadAt(uploadedAt);
+
+    jest.setSystemTime(addMinutes(uploadedAt, 45));
+
+    const [image] = await ImageService.makeTemporaryImagesPermanent(
+      [{ url: upload.publicUrl, position: 0 }],
+      "slow-form-user",
+    );
+    expect(image?.url).toContain("/dogs/");
+  });
+
+  it("stops accepting the photo once the hour is up", async () => {
+    const uploadedAt = new Date();
+    const upload = await uploadAt(uploadedAt);
+
+    jest.setSystemTime(addMinutes(uploadedAt, 61));
+
+    await expect(
+      ImageService.makeTemporaryImagesPermanent(
+        [{ url: upload.publicUrl, position: 0 }],
+        "slow-form-user",
+      ),
+    ).rejects.toBeInstanceOf(InvalidUploadGrantError);
   });
 });

--- a/packages/api/src/services/image-service.ts
+++ b/packages/api/src/services/image-service.ts
@@ -30,8 +30,35 @@ import {
 const PERMANENT_STORAGE_FOLDER = "dogs";
 export const UPLOAD_GRANT_LIMIT = 12;
 export const UPLOAD_GRANT_WINDOW_SECONDS = 60 * 60;
+
+/**
+ * How long the presigned PUT stays signable. The app uploads the bytes the
+ * moment the picker closes, so this window only has to cover one request that
+ * is already in flight, and a short one keeps a leaked URL cheap.
+ */
 export const UPLOAD_URL_TTL_SECONDS = 10 * 60;
-export const UPLOAD_CLEANUP_DELAY_SECONDS = UPLOAD_URL_TTL_SECONDS + 60;
+
+/**
+ * How long the grant stays claimable, which is what `makeTemporaryImagesPermanent`
+ * checks when the profile is finally saved.
+ *
+ * These two used to be one constant, and that is the bug in issue #282: Create
+ * Profile is a single screen where the photos upload first and the name, the
+ * bio and the gender are typed afterwards. Anyone who took more than ten
+ * minutes over that form hit "This photo upload has expired" on save, and
+ * every further tap resubmitted the same dead URLs out of form state, so the
+ * profile could never be saved at all. The PUT window and the window a person
+ * has to finish typing are unrelated, so they are now separate numbers.
+ */
+export const UPLOAD_GRANT_TTL_SECONDS = 60 * 60;
+
+/**
+ * Deleting the object has to wait for the grant, not for the signature: the
+ * cleanup job bails out on a grant that has not expired yet, so a delay tied
+ * to the PUT window would fire early, do nothing, and leave the object behind
+ * forever.
+ */
+export const UPLOAD_CLEANUP_DELAY_SECONDS = UPLOAD_GRANT_TTL_SECONDS + 60;
 
 export type SignedUploadInput = {
   contentLength?: number;
@@ -82,7 +109,7 @@ export class ImageService {
         data: {
           userId,
           temporaryUrl,
-          expiresAt: addSeconds(new Date(), UPLOAD_URL_TTL_SECONDS),
+          expiresAt: addSeconds(new Date(), UPLOAD_GRANT_TTL_SECONDS),
         },
         select: { id: true },
       });

--- a/packages/shared/i18n/locales/en/translation.json
+++ b/packages/shared/i18n/locales/en/translation.json
@@ -166,6 +166,7 @@
     "female": "Female",
     "gender": "Gender",
     "male": "Male",
+    "photosExpired": "Couldn't re-upload your photos. Add them again and save the profile.",
     "profileError": "Unable to save profile information",
     "profileUpdated": "Your profile has been updated!",
     "saveProfile": "Save Profile",

--- a/packages/shared/i18n/locales/pt-BR/translation.json
+++ b/packages/shared/i18n/locales/pt-BR/translation.json
@@ -166,6 +166,7 @@
     "female": "Fêmea",
     "gender": "Sexo",
     "male": "Macho",
+    "photosExpired": "Não foi possível reenviar suas fotos. Adicione de novo e salve o perfil.",
     "profileError": "Não foi possível salvar as informações do perfil",
     "profileUpdated": "Seu perfil foi atualizado!",
     "saveProfile": "Salvar perfil",


### PR DESCRIPTION
## Summary

Photos picked on Create Profile went stale ten minutes after they were uploaded, so anyone who took their time over the name and the bio lost every one of them and could not save the profile at all. Photos now stay claimable for an hour, and a save that still meets a stale photo puts it back up and saves again on its own.

## Details

- Issue #282, item 4. Eight "This photo upload has expired" events came from one person on build 1.6.2, which is what a form that cannot be saved looks like from the outside: the dead URLs stayed in form state, so every further tap failed the same way.
- The presigned PUT window and the grant window used to be one ten minute constant. They are two constants now. The signed PUT stays at ten minutes, because the upload starts the moment the picker closes and only has to cover one request that is already in flight, and a short signature keeps a leaked URL cheap. The grant, which is the thing checked when the profile is finally saved, is now an hour, because that window has to cover a person typing.
- The object cleanup delay now follows the grant instead of the signature. Left on the old constant it would have fired while the grant was still live, found nothing to do, and abandoned the object in the bucket for good.
- The app keeps each picked photo's local file next to its bucket URL for the life of the form. When a save comes back carrying the expired upload grant code, it uploads those files again, writes the fresh URLs into the form so a manual tap cannot resubmit the dead ones, and saves one more time. Exactly once. If that second save fails, or the re-upload itself fails, it shows a message and stops.
- The client keys off the INVALID_UPLOAD_GRANT code the server already sends with that error rather than matching on the message text. Both Create Profile and Edit Profile go through the same path.
- The first failure, the one the app recovers from by itself, is no longer reported. Only a save that has failed twice is.
- New string `editProfile.photosExpired` in pt-BR and in en.

Hypothesis: the gap in last week's signup funnel between Create Dog Profile at 14 and Complete Dog Profile at 13 is people whose photos went stale while they were still filling the form in. After this ships, read those two event counts in the weekly funnel and expect them to sit level, and read the events audit on issue #188, where this error currently holds two exception rows, and expect those rows at zero.

## Testing steps

1. On a fresh account, get to the screen where you create your dog's profile.
2. Add a photo or two, then leave the screen alone for a good fifteen minutes. Long enough to make a coffee.
3. Come back, type a name and a short bio, pick a gender, and press Create Profile.
4. It saves, and you move on to the next step with the photos in place. Before this change the screen said "This photo upload has expired" and pressing the button again never got past it.
5. Repeat on Edit Profile: add a new photo, wait, change the bio, then save.
6. If the screen sits for more than an hour, the app quietly sends the photos up again and saves anyway. If even that second attempt fails, a short message asks you to add the photos again.

## Screenshots

No new screen. The only thing new on screen is a short message in the usual toast, and it appears only when the automatic second attempt has also failed.
