### PR TITLE
feat(mobile): tag analytics with the running update

### DIFF
--- a/apps/mobile/src/services/analytics/ota-properties.test.ts
+++ b/apps/mobile/src/services/analytics/ota-properties.test.ts
@@ -1,0 +1,98 @@
+import { buildOtaUpdateProperties } from "./ota-properties";
+
+/**
+ * The builder is the only thing standing between a readout that can prove an
+ * update arrived and one that reports `undefined` for every device. Its whole
+ * job is the awkward cases: a development client where the native module
+ * answers nothing, and a `Date` that PostHog would otherwise store as an
+ * object.
+ */
+describe("buildOtaUpdateProperties", () => {
+  it("reports the update a downloaded bundle came from", () => {
+    expect(
+      buildOtaUpdateProperties({
+        updateId: "0c2f3f10-6f2b-4a54-9f0f-9d0a1c3b7e21",
+        isEmbeddedLaunch: false,
+        runtimeVersion: "1.6.2",
+        channel: "production",
+        createdAt: new Date("2026-09-04T12:30:00.000Z"),
+      }),
+    ).toStrictEqual({
+      ota_update_id: "0c2f3f10-6f2b-4a54-9f0f-9d0a1c3b7e21",
+      ota_is_embedded: false,
+      runtime_version: "1.6.2",
+      ota_channel: "production",
+      ota_created_at: "2026-09-04T12:30:00.000Z",
+    });
+  });
+
+  it("keeps the embedded launch distinguishable from a downloaded one", () => {
+    // A store install that has not fetched anything yet still has an update id
+    // and a creation date: they describe the bundle baked into the binary.
+    expect(
+      buildOtaUpdateProperties({
+        updateId: "embedded-update-id",
+        isEmbeddedLaunch: true,
+        runtimeVersion: "1.6.2",
+        channel: "production",
+        createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      }).ota_is_embedded,
+    ).toBe(true);
+  });
+
+  it("returns nulls in a development client where nothing is defined", () => {
+    expect(buildOtaUpdateProperties({})).toStrictEqual({
+      ota_update_id: null,
+      ota_is_embedded: null,
+      runtime_version: null,
+      ota_channel: null,
+      ota_created_at: null,
+    });
+  });
+
+  it("does not turn an unknown embedded state into a false one", () => {
+    // `false` would be a claim that the device downloaded an update. Silence is
+    // the honest answer when the module is disabled.
+    expect(buildOtaUpdateProperties({}).ota_is_embedded).toBeNull();
+    expect(
+      buildOtaUpdateProperties({ isEmbeddedLaunch: false }).ota_is_embedded,
+    ).toBe(false);
+  });
+
+  it("treats explicit nulls the same as missing values", () => {
+    expect(
+      buildOtaUpdateProperties({
+        updateId: null,
+        runtimeVersion: null,
+        channel: null,
+        createdAt: null,
+      }),
+    ).toStrictEqual({
+      ota_update_id: null,
+      ota_is_embedded: null,
+      runtime_version: null,
+      ota_channel: null,
+      ota_created_at: null,
+    });
+  });
+
+  it("drops empty strings so they cannot look like a real update", () => {
+    expect(
+      buildOtaUpdateProperties({ updateId: "", runtimeVersion: "" }),
+    ).toMatchObject({ ota_update_id: null, runtime_version: null });
+  });
+
+  it("accepts a creation date that already arrived as a string", () => {
+    expect(
+      buildOtaUpdateProperties({ createdAt: "2026-09-04T12:30:00.000Z" })
+        .ota_created_at,
+    ).toBe("2026-09-04T12:30:00.000Z");
+  });
+
+  it("ignores an unusable date rather than sending Invalid Date", () => {
+    expect(
+      buildOtaUpdateProperties({ createdAt: new Date("nonsense") })
+        .ota_created_at,
+    ).toBeNull();
+  });
+});

--- a/apps/mobile/src/services/analytics/ota-properties.ts
+++ b/apps/mobile/src/services/analytics/ota-properties.ts
@@ -1,0 +1,74 @@
+/**
+ * Which over the air update a device is actually running.
+ *
+ * `$app_version` comes from the binary, so every device that installed 1.6.2
+ * from the store reports 1.6.2 forever, whether it is running the JavaScript
+ * that shipped inside that binary or an `eas update` published months later.
+ * That makes "did the fix reach anyone?" unanswerable. These properties answer
+ * it: `ota_update_id` names the exact bundle, `ota_is_embedded` separates a
+ * device still on the shipped bundle from one that has downloaded an update,
+ * and `runtime_version` is the compatibility line an update was published
+ * against.
+ *
+ * Registered as super properties, so they ride along on every event rather
+ * than on the handful of call sites someone remembered to annotate.
+ */
+
+/**
+ * The shape read off `expo-updates`.
+ *
+ * Every field is optional even though the module's own types promise
+ * `string | null`: in a development client the constants are backed by a
+ * disabled native module and come back `undefined`, and Expo Go has no
+ * updates module at all. Typing the source honestly is what keeps the guards
+ * below from being dead code.
+ */
+export type OtaUpdateSource = {
+  updateId?: string | null;
+  isEmbeddedLaunch?: boolean | null;
+  runtimeVersion?: string | null;
+  channel?: string | null;
+  createdAt?: Date | string | null;
+};
+
+export type OtaUpdateProperties = {
+  ota_update_id: string | null;
+  ota_is_embedded: boolean | null;
+  runtime_version: string | null;
+  ota_channel: string | null;
+  ota_created_at: string | null;
+};
+
+/** `undefined` and empty strings both mean "nothing to report", not a value. */
+const text = (value: string | null | undefined) =>
+  typeof value === "string" && value.length > 0 ? value : null;
+
+/**
+ * PostHog stores whatever it is given, so a `Date` would land as an object on
+ * some transports and a locale string on others. ISO 8601 sorts and filters.
+ */
+const timestamp = (value: Date | string | null | undefined) => {
+  if (typeof value === "string") return text(value);
+  if (!(value instanceof Date)) return null;
+
+  const time = value.getTime();
+  return Number.isNaN(time) ? null : value.toISOString();
+};
+
+/**
+ * `null` rather than `false` when the module is not reporting, because
+ * "running the embedded bundle" and "we cannot tell" are different answers and
+ * the readout counts them separately.
+ */
+export const buildOtaUpdateProperties = (
+  source: OtaUpdateSource,
+): OtaUpdateProperties => ({
+  ota_update_id: text(source.updateId),
+  ota_is_embedded:
+    typeof source.isEmbeddedLaunch === "boolean"
+      ? source.isEmbeddedLaunch
+      : null,
+  runtime_version: text(source.runtimeVersion),
+  ota_channel: text(source.channel),
+  ota_created_at: timestamp(source.createdAt),
+});

--- a/apps/mobile/src/services/observability.ts
+++ b/apps/mobile/src/services/observability.ts
@@ -2,6 +2,7 @@ import * as Updates from "expo-updates";
 
 import { getExpoPostHog, initExpo } from "magic-observability/expo";
 
+import { buildOtaUpdateProperties } from "@/services/analytics/ota-properties";
 import { config } from "@/services/config";
 
 /**
@@ -47,6 +48,18 @@ export const observability = initExpo({
   sessionReplay: false,
   posthogOptions: { captureAppLifecycleEvents: false },
 });
+
+/**
+ * Every event carries the update the device is running, not just the binary
+ * version it was installed from.
+ *
+ * Store users sit on build 1.6.2 while `main` publishes to a newer runtime, so
+ * `$app_version` alone cannot say whether a fix published as an OTA update has
+ * reached anybody. Registering these once, here, means the answer is already in
+ * the data by the time somebody thinks to ask, including on the `$exception`
+ * events the error tracker sends without going through `analytics.track`.
+ */
+observability.register(buildOtaUpdateProperties(Updates));
 
 /**
  * The raw `posthog-react-native` instance, or `null` when telemetry is off.

--- a/scripts/metrics/daily.mjs
+++ b/scripts/metrics/daily.mjs
@@ -24,6 +24,7 @@ import {
   buildActiveUsersQuery,
   buildBreakdownQuery,
   buildDeckSupplyQuery,
+  buildOtaUpdatesQuery,
   buildPushAttributedReturnsQuery,
   buildTotalsQuery,
   buildWindows,
@@ -78,6 +79,7 @@ export async function runDailyMetrics({
     activeUsersByCity,
     activeUsersByVersion,
     deckSupply,
+    otaUpdates,
     totals,
     pushReturnsCurrent,
     pushReturnsPrevious,
@@ -93,6 +95,10 @@ export async function runDailyMetrics({
       buildActiveUsersByVersionQuery(windows),
     ),
     run("pegada daily metrics: deck supply", buildDeckSupplyQuery(windows)),
+    run(
+      "pegada daily metrics: ota updates in use",
+      buildOtaUpdatesQuery(windows),
+    ),
     run("pegada daily metrics: event totals", buildTotalsQuery(windows)),
     run(
       "pegada daily metrics: push attributed returns, last 7 days",
@@ -124,6 +130,7 @@ export async function runDailyMetrics({
     breakdowns,
     deckSupply,
     generatedAt: now,
+    otaUpdates,
     pushReturns: {
       current: pushReturnsCurrent,
       previous: pushReturnsPrevious,

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -69,6 +69,22 @@ function fakeWorld({ existingComment = null } = {}) {
           ],
         });
       }
+      if (name.endsWith("ota updates in use")) {
+        return json({
+          columns: [
+            "runtime_version",
+            "update_id",
+            "launched_from",
+            "people",
+            "first_seen",
+          ],
+          results: [
+            ["1.7.2", "a1b2c3d4", "downloaded", 780, "2026-08-27 04:10:00"],
+            ["1.6.2", "9f8e7d6c", "embedded", 300, "2026-08-26 12:05:00"],
+            ["1.6.2", "4b5c6d7e", "downloaded", 40, "2026-09-02 06:45:00"],
+          ],
+        });
+      }
       if (name.includes("push attributed returns")) {
         return json({
           columns: ["people"],
@@ -160,7 +176,7 @@ test("a dry run renders the comment and never touches GitHub", async () => {
 test("one query goes out per metric block", async () => {
   const fetchImpl = fakeWorld();
   await runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW });
-  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 7);
+  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 8);
 });
 
 test("both push return windows are asked for separately and land in the table", async () => {
@@ -272,4 +288,27 @@ test("one broken query fails the whole run", async () => {
     runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW }),
     /rejected the query "pegada daily metrics: event totals" with status 400/,
   );
+});
+
+test("the readout carries the updates in use through to the comment", async () => {
+  const fetchImpl = fakeWorld();
+  const { body } = await runDailyMetrics({
+    argv: ["--dry-run"],
+    env: { ...ENV, GITHUB_TOKEN: "" },
+    fetchImpl,
+    now: NOW,
+  });
+
+  assert.ok(body.includes("### OTA updates in use"));
+  assert.match(
+    body,
+    /\| 1\.6\.2 \| 4b5c6d7e \| downloaded \| 40 \| 2026-09-02 06:45 UTC \|/,
+  );
+  assert.match(body, /\| 1\.6\.2 \| 9f8e7d6c \| embedded \| 300 \|/);
+
+  const query = fetchImpl.calls.find((call) =>
+    call.body?.name?.endsWith("ota updates in use"),
+  );
+  assert.ok(query, "the readout never asked PostHog which updates are in use");
+  assert.match(query.body.query.query, /properties\.ota_update_id/);
 });

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -46,7 +46,9 @@ export const COUNTED_EVENTS = Object.values(EVENTS).sort();
  * keeps a new server integration out of the activity number by default rather
  * than letting it in until somebody notices.
  */
-export const CLIENT_LIBS = ["posthog-react-native", "web"];
+export const MOBILE_LIB = "posthog-react-native";
+
+export const CLIENT_LIBS = [MOBILE_LIB, "web"];
 
 /**
  * Events emitted from `packages/api`, listed so they can be excluded.
@@ -319,6 +321,69 @@ export function buildActiveUsersByVersionQuery(windows) {
     `  AND ${clientEventFilter()}`,
     "GROUP BY bucket, period",
     "ORDER BY bucket, period",
+  ].join("\n");
+}
+
+/**
+ * How much of an update id the readout prints.
+ *
+ * The full value is a uuid, and eight characters is already unique across every
+ * update pegada has ever published while leaving the table narrow enough to
+ * read on a phone. It is also the prefix `eas update:list` shows, so a row here
+ * can be matched to a publish without trimming anything by hand.
+ */
+export const OTA_ID_PREFIX_LENGTH = 8;
+
+/** Where a device the readout cannot place lands, in every column of the table. */
+export const OTA_UNKNOWN_BUCKET = "unknown";
+
+/**
+ * Which over the air update the people using the app are actually running.
+ *
+ * `$app_version` comes from the binary, so a store user who installed 1.6.2
+ * reports 1.6.2 whether they are running the JavaScript that shipped inside it
+ * or an update published this morning. Publishing a fix to the 1.6.2 runtime
+ * and then watching this table is the difference between knowing it arrived and
+ * assuming it did.
+ *
+ * The embedded column is the half that answers the question. A device on
+ * runtime 1.6.2 still launching the embedded bundle has not taken the update;
+ * one reporting `downloaded` has. Devices sending nothing here are on a build
+ * that predates these properties, and they age out as people update.
+ *
+ * One window only. This is a "what is out there right now" table, and a
+ * comparison against a week ago would just repeat the previous column of the
+ * app version table above it. The site is left out rather than swept into the
+ * unknown bucket: only the app runs on an update.
+ */
+export function buildOtaUpdatesQuery(windows) {
+  const unknown = quote(OTA_UNKNOWN_BUCKET);
+  const runtime = `ifNull(nullIf(toString(properties.runtime_version), ''), ${unknown})`;
+  const update = `ifNull(nullIf(substring(toString(properties.ota_update_id), 1, ${OTA_ID_PREFIX_LENGTH}), ''), ${unknown})`;
+  // Compared as text because the property crosses the wire as JSON: a boolean
+  // from the SDK and the string a replayed export carries both land here, and
+  // an absent one falls through to the unknown bucket rather than to `false`.
+  const embedded = [
+    "multiIf(",
+    `    toString(properties.ota_is_embedded) = 'true', 'embedded',`,
+    `    toString(properties.ota_is_embedded) = 'false', 'downloaded',`,
+    `    ${unknown})`,
+  ].join("\n  ");
+
+  return [
+    "SELECT",
+    `  ${runtime} AS runtime_version,`,
+    `  ${update} AS update_id,`,
+    `  ${embedded} AS launched_from,`,
+    "  count(DISTINCT person_id) AS people,",
+    "  min(timestamp) AS first_seen",
+    "FROM events",
+    `WHERE timestamp >= toDateTime(${quote(clickhouseTime(windows.currentStart))}, 'UTC')`,
+    `  AND timestamp < toDateTime(${quote(clickhouseTime(windows.currentEnd))}, 'UTC')`,
+    `  AND properties.$lib = ${quote(MOBILE_LIB)}`,
+    `  AND event NOT IN (${SERVER_EVENTS.map(quote).join(", ")})`,
+    "GROUP BY runtime_version, update_id, launched_from",
+    "ORDER BY people DESC, runtime_version, update_id",
   ].join("\n");
 }
 

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -17,6 +17,7 @@ import {
   STORE_BUILD_COVERAGE,
   buildActiveUsersByCityQuery,
   buildActiveUsersByVersionQuery,
+  buildOtaUpdatesQuery,
   buildActiveUsersQuery,
   buildBreakdownQuery,
   buildDeckSupplyQuery,
@@ -466,4 +467,47 @@ test("the coverage list leaves out the events the store build does send", () => 
   ]) {
     assert.equal(STORE_BUILD_COVERAGE.missingEvents.includes(event), false);
   }
+});
+
+test("the update split counts distinct people per runtime and update prefix", () => {
+  const query = buildOtaUpdatesQuery(buildWindows(NOW));
+  assert.match(
+    query,
+    /ifNull\(nullIf\(toString\(properties\.runtime_version\), ''\), 'unknown'\) AS runtime_version/,
+  );
+  assert.match(
+    query,
+    /ifNull\(nullIf\(substring\(toString\(properties\.ota_update_id\), 1, 8\), ''\), 'unknown'\) AS update_id/,
+  );
+  assert.match(query, /count\(DISTINCT person_id\) AS people/);
+  assert.match(query, /min\(timestamp\) AS first_seen/);
+  assert.match(query, /GROUP BY runtime_version, update_id, launched_from/);
+});
+
+test("the update split separates a downloaded bundle from the embedded one", () => {
+  const query = buildOtaUpdatesQuery(buildWindows(NOW));
+  assert.match(
+    query,
+    /toString\(properties\.ota_is_embedded\) = 'true', 'embedded'/,
+  );
+  assert.match(
+    query,
+    /toString\(properties\.ota_is_embedded\) = 'false', 'downloaded'/,
+  );
+  // A device that reports nothing is not a device on the embedded bundle.
+  assert.match(query, /'downloaded',\n\s+'unknown'\) AS launched_from/);
+});
+
+test("the update split reads one window and only the app", () => {
+  const query = buildOtaUpdatesQuery(buildWindows(NOW));
+  assert.match(
+    query,
+    /timestamp >= toDateTime\('2026-08-26 12:00:00', 'UTC'\)/,
+  );
+  assert.match(query, /timestamp < toDateTime\('2026-09-02 12:00:00', 'UTC'\)/);
+  // No period column: this table describes right now, not a comparison.
+  assert.equal(query.includes("'current', 'previous'"), false);
+  assert.match(query, /properties\.\$lib = 'posthog-react-native'/);
+  assert.equal(query.includes("'web'"), false);
+  assert.match(query, /event NOT IN \('Deck Served'/);
 });

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -12,6 +12,7 @@ import {
   CITY_UNKNOWN_BUCKET,
   DECK_TIERS,
   EVENTS,
+  OTA_UNKNOWN_BUCKET,
   PUSH_RETURN_WINDOW_MINUTES,
   STORE_BUILD_COVERAGE,
 } from "./queries.mjs";
@@ -263,6 +264,82 @@ function breakdownTable(
   ].join("\n");
 }
 
+/** How many update rows the readout prints before it stops. */
+const MAX_OTA_ROWS = 12;
+
+/**
+ * `min(timestamp)` comes back in whatever shape the transport chose: a string
+ * from the query API, a `Date` from a replayed fixture. Both become the same
+ * minute stamp, and anything else becomes a dash rather than `Invalid Date`.
+ *
+ * ClickHouse writes `2026-09-02 06:45:00` with no zone, and `new Date` reads
+ * that as local time. On a machine in Sao Paulo that silently moves every row
+ * three hours, which is exactly the resolution the "did it arrive today"
+ * question is asked at, so the zone is spelled out before parsing.
+ */
+function firstSeen(value) {
+  if (value === null || value === undefined || value === "") {
+    return "-";
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? "-" : utcStamp(value);
+  }
+  const text = String(value).trim().replace(" ", "T");
+  const zoned = /(Z|[+-]\d{2}:?\d{2})$/.test(text) ? text : `${text}Z`;
+  const date = new Date(zoned);
+  return Number.isNaN(date.getTime()) ? "-" : utcStamp(date);
+}
+
+/**
+ * Which update the app is running, per runtime.
+ *
+ * The row that matters on a backport day is a runtime the store build is on
+ * with a `downloaded` launch: that is somebody who took the update, and the
+ * first seen column says when the first one did. Sorted by people so the
+ * bundle most devices are on leads, which is also the one a regression would
+ * hit hardest.
+ */
+export function otaUpdatesTable(rows, { limit = MAX_OTA_ROWS } = {}) {
+  const ordered = (rows ?? [])
+    .map((row) => ({
+      firstSeen: firstSeen(row.first_seen),
+      launchedFrom: row.launched_from || OTA_UNKNOWN_BUCKET,
+      people: Number(row.people ?? 0),
+      runtime: row.runtime_version || OTA_UNKNOWN_BUCKET,
+      update: row.update_id || OTA_UNKNOWN_BUCKET,
+    }))
+    .sort(
+      (a, b) =>
+        b.people - a.people ||
+        a.runtime.localeCompare(b.runtime) ||
+        a.update.localeCompare(b.update),
+    )
+    .slice(0, limit);
+
+  if (ordered.length === 0) {
+    return "No app events in the last 7 days.";
+  }
+
+  return [
+    "| Runtime | Update | Launched from | People | First seen |",
+    "| --- | --- | --- | ---: | --- |",
+    ...ordered.map(
+      (row) =>
+        `| ${row.runtime} | ${row.update} | ${row.launchedFrom} | ${number(row.people)} | ${row.firstSeen} |`,
+    ),
+  ].join("\n");
+}
+
+/**
+ * What the unknown rows mean, said once so nobody reads them as a broken query.
+ *
+ * Every device on a build that predates these properties reports nothing here,
+ * and that is most of them on the day this ships. The bucket shrinking week
+ * over week is the update landing.
+ */
+export const OTA_SOURCE_NOTE =
+  "Update is the first 8 characters of the update id the device launched. Unknown rows are devices on a build published before the app started reporting this.";
+
 /**
  * Where the city in the table comes from, said once under it.
  *
@@ -300,6 +377,7 @@ export function noCityLine(rows, activeCurrent, activePrevious) {
  * @param {Record<string, Array>} input.breakdowns rows per breakdown id
  * @param {Array} input.deckSupply rows from the deck supply query, one per window
  * @param {Date} input.generatedAt when the job ran
+ * @param {Array} input.otaUpdates rows from the over the air update split
  * @param {{ current: Array, previous: Array }} input.pushReturns rows from the push attributed returns query, one per window
  * @param {Array} input.totals rows from the totals query
  * @param {{ currentEnd: Date, currentStart: Date, previousStart: Date }} input.windows
@@ -311,6 +389,7 @@ export function buildReport({
   breakdowns,
   deckSupply,
   generatedAt,
+  otaUpdates,
   pushReturns,
   totals,
   windows,
@@ -505,6 +584,12 @@ export function buildReport({
       field: "people",
       header: "App version",
     }),
+    "",
+    "### OTA updates in use",
+    "",
+    otaUpdatesTable(otaUpdates),
+    "",
+    OTA_SOURCE_NOTE,
     "",
     "### Active users by city",
     "",

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -5,6 +5,7 @@ import { STORE_BUILD_COVERAGE, buildWindows } from "./queries.mjs";
 import {
   CITY_SOURCE_NOTE,
   COMMENT_MARKER,
+  OTA_SOURCE_NOTE,
   buildReport,
   coverageNote,
   formatAverageDelta,
@@ -34,6 +35,18 @@ function versions(rows) {
 
 /** The city split comes back in the same shape as the version split. */
 const cities = versions;
+
+function otaRows(rows) {
+  return rows.map(
+    ([runtime_version, update_id, launched_from, people, first_seen]) => ({
+      first_seen,
+      launched_from,
+      people,
+      runtime_version,
+      update_id,
+    }),
+  );
+}
 
 function deck(rows) {
   return rows.map(
@@ -92,6 +105,12 @@ const FIXTURE = {
     ["1.3.2", "previous", 870],
     ["unknown", "current", 20],
     ["unknown", "previous", 20],
+  ]),
+  otaUpdates: otaRows([
+    ["1.7.2", "a1b2c3d4", "downloaded", 780, "2026-08-27 04:10:00"],
+    ["1.6.2", "9f8e7d6c", "embedded", 300, "2026-08-26 12:05:00"],
+    ["1.6.2", "4b5c6d7e", "downloaded", 40, "2026-09-02 06:45:00"],
+    ["unknown", "unknown", "unknown", 12, null],
   ]),
   breakdowns: {
     fake_door_feature: breakdown([
@@ -687,4 +706,58 @@ test("the coverage note leaves the exception out when no update has shipped", ()
 test("the coverage note says so plainly once the store build sends everything", () => {
   const note = coverageNote({ missingEvents: [], version: "1.8.0" });
   assert.match(note, /build 1\.8\.0 emits every event in this readout/);
+});
+
+test("the update table says which bundle each runtime is actually running", () => {
+  const body = buildReport(FIXTURE);
+  assert.ok(body.includes("### OTA updates in use"));
+  const [, otaSection] = body.split("### OTA updates in use");
+  assert.match(
+    otaSection,
+    /\| Runtime \| Update \| Launched from \| People \| First seen \|/,
+  );
+  assert.match(
+    otaSection,
+    /\| 1\.7\.2 \| a1b2c3d4 \| downloaded \| 780 \| 2026-08-27 04:10 UTC \|/,
+  );
+  // The row that answers the backport question: people on the store runtime who
+  // are no longer launching the bundle that shipped inside the binary.
+  assert.match(
+    otaSection,
+    /\| 1\.6\.2 \| 4b5c6d7e \| downloaded \| 40 \| 2026-09-02 06:45 UTC \|/,
+  );
+  assert.match(
+    otaSection,
+    /\| 1\.6\.2 \| 9f8e7d6c \| embedded \| 300 \| 2026-08-26 12:05 UTC \|/,
+  );
+  assert.ok(body.includes(OTA_SOURCE_NOTE));
+});
+
+test("the busiest update leads the table and a device with no timestamp gets a dash", () => {
+  const body = buildReport(FIXTURE);
+  const [, otaSection] = body.split("### OTA updates in use");
+  assert.ok(
+    otaSection.indexOf("| 1.7.2 | a1b2c3d4 |") <
+      otaSection.indexOf("| 1.6.2 | 9f8e7d6c |"),
+  );
+  assert.match(otaSection, /\| unknown \| unknown \| unknown \| 12 \| - \|/);
+});
+
+test("the update table sits above the city table so the two are not confused", () => {
+  const body = buildReport(FIXTURE);
+  assert.ok(
+    body.indexOf("### OTA updates in use") <
+      body.indexOf("### Active users by city"),
+  );
+});
+
+test("a week with no app events says so instead of rendering an empty update table", () => {
+  const body = buildReport({ ...FIXTURE, otaUpdates: [] });
+  const [, otaSection] = body.split("### OTA updates in use");
+  assert.match(otaSection, /^\n\nNo app events in the last 7 days\./);
+});
+
+test("the update table survives a run made before the query existed", () => {
+  const body = buildReport({ ...FIXTURE, otaUpdates: undefined });
+  assert.ok(body.includes("No app events in the last 7 days."));
 });


### PR DESCRIPTION
## Summary

Every event the app sends now carries which over the air update the device is running, and the daily readout lists them. Until now the only version signal was the binary version, so a fix published to the 1.6.2 runtime could not be shown to have reached anybody.

## Details

- The analytics client registers five super properties when it starts: `ota_update_id`, `ota_is_embedded`, `runtime_version`, `ota_channel` and `ota_created_at`. Super properties ride along on every event, including the `$exception` events the error tracker sends without going through a call site.
- The values come from `expo-updates`, already a dependency, so nothing was added. In a development client the native module answers nothing and every property lands as `null` rather than as `false`, because "running the bundle that shipped with the app" and "we cannot tell" are different answers and the readout counts them separately.
- `ota_created_at` is normalised to an ISO string, so PostHog stores something sortable instead of a date object that each transport would render its own way.
- The daily readout on issue #188 gains a section called "OTA updates in use": distinct app users over the last 7 days, grouped by runtime version and the first 8 characters of the update id, split by whether the device launched the embedded bundle or a downloaded one, with the first time each was seen.
- That table reads app events only. The site never runs on an update, so folding it into an unknown bucket would only make the numbers wrong.
- Hypothesis: the readout proves an update arrived within hours of being published, instead of leaving it to guesswork. Baseline is none, since today there is no way to tell at all.
- How it will be read: issue #188, section "OTA updates in use". A backport published to runtime 1.6.2 shows up as a new update id on that runtime with `downloaded` in the launched from column, and the first seen stamp says when the first device picked it up. The unknown row is everyone on a build that predates these properties, and it shrinks as people update.

## Testing steps

1. Open the app. Nothing on screen changes.
2. Wait for the daily readout comment on issue 188 to refresh, or run the readout by hand.
3. Find the section called "OTA updates in use". Each row is one bundle people are running: the runtime it was published for, a short id, whether it came inside the app or was downloaded afterwards, how many people are on it, and when the first one was seen.
4. After the next update goes out to people on the store build, a new row for that runtime appears with "downloaded" in it. That row is the proof it landed.

## Screenshots

Nothing visible changed in the app. The new readout section looks like this:

```
### OTA updates in use

| Runtime | Update | Launched from | People | First seen |
| --- | --- | --- | ---: | --- |
| 1.7.2 | a1b2c3d4 | downloaded | 780 | 2026-08-27 04:10 UTC |
| 1.6.2 | 9f8e7d6c | embedded | 300 | 2026-08-26 12:05 UTC |
| 1.6.2 | 4b5c6d7e | downloaded | 40 | 2026-09-02 06:45 UTC |
| unknown | unknown | unknown | 12 | - |
```
