### PR TITLE
fix(mobile): look again when the keychain is not ready at launch

### DIFF
--- a/apps/mobile/src/services/storage.test.ts
+++ b/apps/mobile/src/services/storage.test.ts
@@ -47,6 +47,39 @@ test("migrates a legacy token when it is first read", async () => {
   expect(asyncStorage.removeItem).toHaveBeenCalledWith(StorageKeys.Token);
 });
 
+test("looks again when the keychain is not ready for the first read", async () => {
+  secureStore.getItemAsync
+    .mockRejectedValueOnce(
+      new Error("Calling the 'getValueWithKeyAsync' function has failed"),
+    )
+    .mockResolvedValueOnce("signed-token");
+
+  await expect(getData(StorageKeys.Token)).resolves.toBe("signed-token");
+  expect(secureStore.getItemAsync).toHaveBeenCalledTimes(2);
+  expect(asyncStorage.getItem).not.toHaveBeenCalled();
+});
+
+test("gives the keychain error back when every read fails", async () => {
+  const failure = new Error(
+    "Calling the 'getValueWithKeyAsync' function has failed",
+  );
+  secureStore.getItemAsync
+    .mockRejectedValueOnce(failure)
+    .mockRejectedValueOnce(failure)
+    .mockRejectedValueOnce(failure);
+
+  await expect(getData(StorageKeys.Token)).rejects.toBe(failure);
+  expect(secureStore.getItemAsync).toHaveBeenCalledTimes(3);
+});
+
+test("does not retry a phone that simply has no token", async () => {
+  secureStore.getItemAsync.mockResolvedValueOnce(null);
+  asyncStorage.getItem.mockResolvedValueOnce(null);
+
+  await expect(getData(StorageKeys.Token)).resolves.toBeNull();
+  expect(secureStore.getItemAsync).toHaveBeenCalledTimes(1);
+});
+
 test("removes current and legacy token copies on logout", async () => {
   await deleteData(StorageKeys.Token);
 

--- a/apps/mobile/src/services/storage.ts
+++ b/apps/mobile/src/services/storage.ts
@@ -48,9 +48,54 @@ export const storeData = async <T extends StorageKeys>(
   return value;
 };
 
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * How many times the keychain is asked for the token before the read is given
+ * up on.
+ *
+ * iOS answers a keychain read with "a required entitlement isn't present" when
+ * the app process is not attached yet, which is what a launch the user did not
+ * start looks like: the system prewarming the app, or a notification waking it
+ * while the phone is still locked. The entitlement is on the build, the check
+ * is just not ready to see it, and it becomes ready a moment later. Three
+ * looks, because the launch is waiting on this answer and a fourth would cost
+ * more than it recovers.
+ */
+const KEYCHAIN_READ_ATTEMPTS = 3;
+
+/** Grows per attempt, so the last look happens well after the first. */
+const KEYCHAIN_RETRY_DELAY_MS = 150;
+
+/**
+ * The keychain read, retried.
+ *
+ * An absent token is not an error here: `getItemAsync` resolves to `null` for
+ * a phone that was never signed in, so a signed out launch never pays for a
+ * single retry. Only a thrown read comes back around, and a read that keeps
+ * throwing still throws, so a genuine misconfiguration stays visible instead
+ * of turning into a silent "no token".
+ */
+const readSecureValue = async (
+  key: StorageKeys,
+  attempt = 1,
+): Promise<string | null> => {
+  try {
+    return await SecureStore.getItemAsync(key);
+  } catch (error) {
+    if (attempt >= KEYCHAIN_READ_ATTEMPTS) throw error;
+
+    await wait(KEYCHAIN_RETRY_DELAY_MS * attempt);
+    return readSecureValue(key, attempt + 1);
+  }
+};
+
 export const getData = async <T extends StorageKeys>(key: T) => {
   if (key === StorageKeys.Token) {
-    const secureValue = await SecureStore.getItemAsync(key);
+    const secureValue = await readSecureValue(key);
     if (secureValue) return secureValue as StorageDataTypes[T];
 
     const legacyValue = await AsyncStorage.getItem(key);


### PR DESCRIPTION
## Summary

Store users on 1.6.2 are hitting an iOS keychain error at launch that sends a signed in person to the sign in screen. The token read now takes a second look before it gives up.

## Details

- The exception is `Calling the 'getValueWithKeyAsync' function has failed. Caused by: Um direito exigido não está presente.` It is the iOS keychain saying "a required entitlement isn't present", and it appeared on the events audit only after last night's updates went out: 10 events over 3 people as a request error, plus 4 events on 1 person as a plain error. The same seven day window read at 01:15 UTC had none. Full trace on #282.
- The entitlement is on the build. The app asks for no keychain access group anywhere in its config, and the App Store profile carries the standard one. iOS also returns this error when the keychain is asked for an item before the process is attached, which is what a launch nobody started looks like: the system prewarming the app, or a notification waking it while the phone is still locked.
- The read that fails is the auth token, and it is the only thing this app keeps in the keychain. Analytics and purchases do not touch it.
- Evidence that it clears on its own: three people failed the read that happens the instant the app starts, but only one of them still failed the second read a few seconds later. By then the app was up and the keychain answered.
- So `getData` now asks up to three times, with a growing pause between attempts. A phone with no token is not affected, because an absent item comes back as an empty answer rather than a failure and never costs a retry. A read that keeps failing still fails, so a real misconfiguration stays visible.
- Worst case this adds 450ms, and only to a launch that was already failing. The per request timeout in the tRPC client starts after the token is in hand, so nothing is taken out of it.
- What it moves: activation and retention for the people it hits. Today a signed in user can land on sign in, where the server answers "Already logged in" and there is no way forward. That loop is in the current audit too, 4 events over 2 people. Read it back on the events audit for issue #188, where success is both `getValueWithKeyAsync` groups falling to zero and the mobile `Already logged in` group falling with them, over the seven day window after this reaches 1.6.2.
- Everyone affected is on the store build, so this needs the 1.6.2 backport branch to reach them.

## Testing steps

1. Sign in on the app and close it.
2. Leave the phone locked and wait for a notification to arrive, then open the app from that notification.
3. The app opens where you left off instead of asking you to sign in again.
4. Sign out, close the app, and open it again. It asks you to sign in, with no extra delay.

## Screenshots

Nothing on screen changes. The fix is in how the app reads its saved login, and the visible effect is the sign in screen no longer appearing for someone who is already signed in.
