### PR TITLE
fix(api): moderate photos with a model the API key can call

### DIFF
--- a/packages/api/src/services/image-moderation-service.test.ts
+++ b/packages/api/src/services/image-moderation-service.test.ts
@@ -6,7 +6,7 @@
  */
 const config = {
   IMAGE_MODERATION_MODE: "shadow" as string,
-  IMAGE_MODERATION_MODEL: "google/gemini-2.5-flash-lite",
+  IMAGE_MODERATION_MODEL: "google/gemini-3.5-flash-lite",
   GOOGLE_GENERATIVE_AI_API_KEY: "google-key" as string | undefined,
   OPENAI_API_KEY: "openai-key" as string | undefined,
 };
@@ -47,6 +47,9 @@ const createOpenAI = jest.fn((..._options: unknown[]) => createOpenAiModel);
 jest.mock("@ai-sdk/openai", () => ({
   createOpenAI: (...args: unknown[]) => createOpenAI(...args),
 }));
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import sharp from "sharp";
 
@@ -95,7 +98,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  config.IMAGE_MODERATION_MODEL = "google/gemini-2.5-flash-lite";
+  config.IMAGE_MODERATION_MODEL = "google/gemini-3.5-flash-lite";
   config.GOOGLE_GENERATIVE_AI_API_KEY = "google-key";
   config.OPENAI_API_KEY = "openai-key";
   sendError.mockClear();
@@ -111,12 +114,12 @@ describe("ImageModerationService.moderate", () => {
       score: 0.02,
       reason: "none",
       containsDog: true,
-      model: "google/gemini-2.5-flash-lite",
+      model: "google/gemini-3.5-flash-lite",
       inputTokens: 300,
       outputTokens: 20,
     });
-    // 300 in at $0.10/M plus 20 out at $0.40/M.
-    expect(result.costUsdEstimate).toBeCloseTo(0.000038, 9);
+    // 300 in at $0.30/M plus 20 out at $2.50/M.
+    expect(result.costUsdEstimate).toBeCloseTo(0.00014, 9);
     expect(result.latencyMs).toBeGreaterThanOrEqual(0);
     expect(sendError).not.toHaveBeenCalled();
   });
@@ -198,7 +201,7 @@ describe("ImageModerationService.moderate", () => {
     expect(result).toMatchObject({
       verdict: "error",
       reason: "missing_api_key",
-      model: "google/gemini-2.5-flash-lite",
+      model: "google/gemini-3.5-flash-lite",
     });
     expect(generateText).not.toHaveBeenCalled();
     // A key that was never configured is a deployment fact, not an incident.
@@ -351,7 +354,7 @@ describe("estimateCostUsd", () => {
 
 describe("parseModelSetting", () => {
   it.each([
-    ["google/gemini-2.5-flash-lite", "google", "gemini-2.5-flash-lite"],
+    ["google/gemini-3.5-flash-lite", "google", "gemini-3.5-flash-lite"],
     ["openai/gpt-5-nano", "openai", "gpt-5-nano"],
     ["google/models/one/two", "google", "models/one/two"],
   ])("splits %s on the first slash", (setting, provider, modelId) => {
@@ -365,5 +368,33 @@ describe("parseModelSetting", () => {
     "cohere/command",
   ])("refuses %s", (setting) => {
     expect(parseModelSetting(setting)).toBeNull();
+  });
+});
+
+/**
+ * The model id lives in `config.ts` as a default, so it is the string
+ * production runs unless somebody sets the variable, and nothing else in the
+ * codebase checks it. Both ways it can be wrong are silent: a retired id
+ * turns every verdict into `error` and photos keep publishing, and an id with
+ * no entry in the rate table turns the cost estimate into nulls. Reading the
+ * file as text rather than importing it keeps this off the environment
+ * validation that runs on import.
+ */
+describe("the model shipped as the default", () => {
+  const setting =
+    /IMAGE_MODERATION_MODEL: z\.string\(\)\.default\("([^"]+)"\)/.exec(
+      readFileSync(join(__dirname, "../shared/config.ts"), "utf8"),
+    )?.[1] ?? "";
+
+  it("names a provider and a model this file can call", () => {
+    expect(parseModelSetting(setting)).not.toBeNull();
+  });
+
+  it("names a model the cost estimate has a published rate for", () => {
+    const modelId = parseModelSetting(setting)?.modelId ?? "";
+
+    expect(
+      estimateCostUsd({ modelId, inputTokens: 510, outputTokens: 40 }),
+    ).toBeGreaterThan(0);
   });
 });

--- a/packages/api/src/services/image-moderation-service.ts
+++ b/packages/api/src/services/image-moderation-service.ts
@@ -96,6 +96,7 @@ const RATES_USD_PER_MILLION_TOKENS: Record<
   { input: number; output: number }
 > = {
   "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
+  "gemini-3.5-flash-lite": { input: 0.3, output: 2.5 },
   "gpt-4.1-nano": { input: 0.1, output: 0.4 },
   "gpt-5-nano": { input: 0.05, output: 0.4 },
 };

--- a/packages/api/src/services/image-processing-service.test.ts
+++ b/packages/api/src/services/image-processing-service.test.ts
@@ -5,7 +5,7 @@
  */
 const config = {
   IMAGE_MODERATION_MODE: "off" as string,
-  IMAGE_MODERATION_MODEL: "google/gemini-2.5-flash-lite",
+  IMAGE_MODERATION_MODEL: "google/gemini-3.5-flash-lite",
 };
 
 jest.mock("../shared/config", () => ({
@@ -55,7 +55,7 @@ const verdict = (value: "approve" | "error" | "reject") => ({
   score: value === "reject" ? 0.9 : 0.01,
   reason: value === "reject" ? "gore" : "none",
   containsDog: true,
-  model: "google/gemini-2.5-flash-lite",
+  model: "google/gemini-3.5-flash-lite",
   latencyMs: 420,
   costUsdEstimate: 0.00004,
   inputTokens: 300,

--- a/packages/api/src/services/image-processing-service.test.ts
+++ b/packages/api/src/services/image-processing-service.test.ts
@@ -234,6 +234,23 @@ describe("ImageProcessingService.moderateImage", () => {
     expect(moderate).not.toHaveBeenCalled();
   });
 
+  it("asks again when the row only carries a failure from an earlier run", async () => {
+    config.IMAGE_MODERATION_MODE = "enforce";
+    getStoredModerationVerdict.mockResolvedValue({
+      moderationVerdict: "error",
+    });
+
+    const outcome = await ImageProcessingService.moderateImage({
+      arrayBuffer,
+      imageId,
+    });
+
+    // Nobody was billed for the failed run, so there is nothing to save by
+    // reusing it, and reusing it would leave the photo unchecked forever.
+    expect(moderate).toHaveBeenCalledWith(arrayBuffer);
+    expect(outcome.result?.verdict).toBe("approve");
+  });
+
   it("does not look up a stored verdict when it would not call anyone", async () => {
     config.IMAGE_MODERATION_MODE = "off";
 

--- a/packages/api/src/services/image-processing-service.ts
+++ b/packages/api/src/services/image-processing-service.ts
@@ -25,6 +25,16 @@ export type ImageModerationOutcome = {
   mode: ImageModerationMode;
 };
 
+/**
+ * Whether a stored verdict is a decision a model actually made.
+ *
+ * `error` is written to the row like any other verdict so the failure is
+ * visible in the data, but it is not an answer and nobody was billed for it.
+ * Reusing it would mean one bad afternoon at the provider leaves a photo
+ * permanently unmoderated, with no second chance on any later redelivery.
+ */
+const isDecided = (verdict: string) => verdict !== "error";
+
 /** Only `enforce` can turn a rejection into a status. */
 const statusFor = (mode: ImageModerationMode, verdict: string) =>
   mode === "enforce" && verdict === "reject"
@@ -105,12 +115,13 @@ export class ImageProcessingService {
   }): Promise<ImageModerationOutcome> => {
     // The queue delivers at least once, and the job can also be retried after
     // the write that follows this call fails. A row that already carries a
-    // verdict has already been paid for, so the redelivery re-derives the
-    // status from it instead of buying a second opinion. The read only happens
-    // on jobs that would otherwise call a provider, so the `off` path is still
-    // a single query.
+    // decided verdict has been paid for, so the redelivery re-derives the
+    // status from it instead of buying a second opinion. A row carrying only
+    // an `error` is the one case worth asking again about. The read only
+    // happens on jobs that would otherwise call a provider, so the `off` path
+    // is still a single query.
     const stored = await ImageService.getStoredModerationVerdict(imageId);
-    if (stored?.moderationVerdict) {
+    if (stored?.moderationVerdict && isDecided(stored.moderationVerdict)) {
       return {
         status: statusFor(mode, stored.moderationVerdict),
         result: null,

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -114,8 +114,14 @@ const configSchema = z.object({
   /**
    * `<provider>/<model-id>`, resolved in `image-moderation-service.ts`.
    * Swapping providers is an environment change rather than a deploy.
+   *
+   * Pinned to a model id rather than an alias such as
+   * `gemini-flash-lite-latest`, because the cost estimate is keyed on this
+   * exact string: an alias that moves under us prices every photo wrong
+   * without anything failing. The cost of pinning is that a retired id has to
+   * be replaced here, which is what happened to `gemini-2.5-flash-lite`.
    */
-  IMAGE_MODERATION_MODEL: z.string().default("google/gemini-2.5-flash-lite"),
+  IMAGE_MODERATION_MODEL: z.string().default("google/gemini-3.5-flash-lite"),
   /**
    * Provider keys, both optional: whichever one the configured model needs
    * has to be set, and a missing key is reported as a moderation error rather

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -179,6 +179,17 @@ export const BREAKDOWNS = [
     property: "verdict",
     title: "Image Moderation Result by verdict",
   },
+  // The verdict table alone cannot tell a provider outage from a model id we
+  // retired out from under ourselves, because moderation publishes the photo
+  // either way and both land in the same `error` bucket. The reason is the
+  // column that separates them, so it gets its own table rather than waiting
+  // for somebody to go reading exceptions.
+  {
+    id: "moderation_reason",
+    event: EVENTS.IMAGE_MODERATION_RESULT,
+    property: "reason",
+    title: "Image Moderation Result by reason",
+  },
   {
     id: "subscription_type",
     event: EVENTS.SUBSCRIPTION_EVENT,


### PR DESCRIPTION
## Summary
Photo moderation has been failing on every call since it went live, because Google retired the model it asks for. It now asks for a model the key can actually reach.

## Details
- Every moderation verdict in production is `error`. Seven results over the seven days to 2026-09-05 21:38 UTC, none of them an approval or a rejection. Photos were never affected, since an error publishes the photo, but nothing was being checked.
- The cause is in the exceptions table of the same audit: seven server exceptions saying `This model models/gemini-2.5-flash-lite is no longer available to new users`, one for each verdict. The key works and the API is enabled. Google gates that model id on projects created after it was superseded, and ours is new.
- Default model moves to `gemini-3.5-flash-lite`, the current stable model of that class, with its published rate added so the cost estimate keeps working. Cost goes from roughly 0.07 US dollars per thousand photos to roughly 0.25, still far under what a photo is worth.
- The id stays pinned rather than moving to a floating alias, because the cost estimate is keyed on the exact string and an alias that changes underneath prices every photo wrong without failing.
- Two tests now read the shipped default out of the config file and assert it is a model the service can route and a model the rate table prices. Both ways this can break are silent, so nothing else would have caught it.
- A photo whose only stored verdict is a failure now gets asked about again on a later delivery. Until now an error was cached like a real answer, so a bad afternoon at the provider left that photo unchecked for good. Nobody is billed for a failed call, so there was nothing to save by keeping it.
- The daily readout gains a table of moderation results by reason. Verdicts alone cannot tell a provider outage from a retired model id, since both publish the photo and both land in the same error bucket. This one was only findable by reading exceptions.

## Testing steps
Add a photo to a dog profile. It publishes as before, with or without this change.

To see the fix working, open the daily readout comment on the tracking issue after the next run. The moderation results by verdict table should show approvals rather than errors, and the new results by reason table should stop being entirely failures. The measure is the share of moderation results that come back as an error: it is 100 percent today and should sit near zero.

## Screenshots
Nothing visible changes. This is a server side call the app never renders.
