### PR TITLE
chore(ci): run the daily readouts earlier so they land before the morning check

### DIFF
--- a/.github/workflows/daily-metrics.yml
+++ b/.github/workflows/daily-metrics.yml
@@ -1,11 +1,12 @@
 name: Daily Metrics
 
-# Noon UTC, which is early morning in Brazil: the readout is waiting before
-# anyone opens the repo, and the window it closes is a whole day rather than a
-# partial one.
+# 08:30 UTC, early morning in Brazil: the readout is waiting before anyone
+# opens the repo. Noon UTC used to be the schedule, but GitHub's shared cron
+# queue delayed it by hours on back to back days, so it moved earlier to
+# leave room for that slack.
 on:
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "30 8 * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/events-audit.yml
+++ b/.github/workflows/events-audit.yml
@@ -1,9 +1,12 @@
 name: Events Audit
 
-# Dispatch only. This is a "what is the tracking actually doing" pass, run when
-# somebody is about to trust a funnel or has just shipped instrumentation, not
-# something worth a comment rewrite every morning.
+# 08:40 UTC, ten minutes after the daily metrics readout, so the two comments
+# land close together in the morning in Brazil. Also runs on dispatch, for
+# when somebody is about to trust a funnel or has just shipped instrumentation
+# and wants a check sooner than the next scheduled run.
 on:
+  schedule:
+    - cron: "40 8 * * *"
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary
The daily metrics readout ran at noon UTC and GitHub's shared cron queue delayed it by about two and a half hours two days in a row, so it was not posted yet when it was read at 12:30 UTC. Moved the schedule earlier and gave the events audit workflow a daily schedule too.

## Details
- Changed daily-metrics.yml cron from 0 12 * * * to 30 8 * * * (05:30 São Paulo) to leave room for cron queue delays.
- Added a schedule of 40 8 * * * to events-audit.yml, which previously only ran on manual dispatch, so both readouts land close together in the morning.
- Kept workflow_dispatch on both workflows for manual runs.
- Updated the comments above each schedule to match the new times.

## Testing steps
Wait for tomorrow's scheduled runs and confirm both the daily metrics comment and the events audit comment are already posted on the tracking issue by the time anyone checks it in the morning in Brazil. No behavior changed besides the time these jobs kick off.

## Screenshots
Not applicable