### PR TITLE
fix(ci): show what upgrades bought and where subscription events go missing

### DIFF
--- a/apps/mobile/src/services/payments/index.ts
+++ b/apps/mobile/src/services/payments/index.ts
@@ -464,10 +464,32 @@ const restorePurchases = async () => {
   await Purchases.restorePurchases();
 };
 
+/**
+ * What a completed purchase actually was, for the analytics call site.
+ *
+ * `Upgrade` with `type: "success"` is the only client side signal that somebody
+ * paid, and on its own it cannot tell an App Store charge from a sandbox one or
+ * from the grant the Maestro flows hand themselves. All three read as revenue
+ * in the readout and only one of them is, which is how successful upgrades can
+ * show up with no matching RevenueCat webhook event behind them.
+ *
+ * `null` rather than `false` when the entitlement is missing, because "not a
+ * sandbox purchase" and "we could not read the receipt" are different answers.
+ */
+const describePurchase = (customerInfo?: CustomerInfo | null) => {
+  const entitlement = customerInfo?.entitlements.active[Entitlement.Premium];
+
+  return {
+    is_sandbox: entitlement?.isSandbox ?? null,
+    source: isMaestroMockMode ? ("maestro_mock" as const) : ("store" as const),
+  };
+};
+
 export const payments = {
   init,
   getOfferings,
   purchasePackage,
+  describePurchase,
   getPlan,
   logIn,
   restorePurchases,

--- a/apps/mobile/src/views/UpgradeWall/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/index.tsx
@@ -104,7 +104,7 @@ const UpgradeWall: React.FC = () => {
         },
       });
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       haptics.success();
 
       analytics.track({
@@ -112,6 +112,11 @@ const UpgradeWall: React.FC = () => {
         event_properties: {
           package: selectedOffering?.product.identifier,
           type: "success",
+          // Says whether the money was real. A sandbox receipt and the grant
+          // the Maestro flows hand themselves both land here otherwise
+          // indistinguishable from an App Store charge, and only the charge
+          // produces a RevenueCat webhook event on the server.
+          ...payments.describePurchase(result?.customerInfo),
         },
       });
       router.back();

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -419,7 +419,21 @@ export type MobileEventProperties = {
     minimum_version: string;
   };
   [ANALYTICS_EVENTS.UPGRADE]: {
+    /**
+     * Whether the receipt behind a successful upgrade was a sandbox one.
+     * `null` when the entitlement could not be read, which is a different
+     * answer from `false` and is counted separately.
+     */
+    is_sandbox?: boolean | null;
     package?: string;
+    /**
+     * Where a successful upgrade came from. `store` is a real purchase through
+     * RevenueCat, which is the only one that also produces a `Subscription
+     * Event` on the server. `maestro_mock` is the premium grant the end to end
+     * flows hand themselves, which produces nothing server side and is not
+     * revenue.
+     */
+    source?: "maestro_mock" | "store";
     trial?: boolean | null;
     type: "cancel" | "error" | "start" | "success";
   };

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -140,6 +140,44 @@ export const BREAKDOWNS = [
     property: "type",
     title: "Upgrade by type",
   },
+  // What the successful upgrades actually bought, and whether the money was
+  // real. `Upgrade` is a client event: the app fires it the moment the purchase
+  // sheet resolves, with no server confirmation behind it. A sandbox receipt, a
+  // TestFlight purchase and the premium grant the end to end flows hand
+  // themselves all resolve the same way, so a week can show successful upgrades
+  // while `Subscription Event by type` stays empty because RevenueCat never
+  // charged anybody. These three tables are what separates the cases.
+  //
+  // `unknown` in the source and sandbox tables is a build that predates the
+  // properties, not a purchase we failed to classify.
+  {
+    id: "upgrade_package",
+    event: EVENTS.UPGRADE,
+    property: "package",
+    title: "Upgrade by package",
+  },
+  {
+    id: "upgrade_source",
+    event: EVENTS.UPGRADE,
+    property: "source",
+    title: "Upgrade by source",
+  },
+  {
+    id: "upgrade_sandbox",
+    event: EVENTS.UPGRADE,
+    property: "is_sandbox",
+    title: "Upgrade by sandbox",
+  },
+  // Which build the upgrade came from, scoped to the event rather than to the
+  // whole population. The over the air table below counts people across every
+  // event, so it cannot say whether a given upgrade came from a phone in the
+  // store or from a release build one of us was driving on a simulator.
+  {
+    id: "upgrade_app_version",
+    event: EVENTS.UPGRADE,
+    property: APP_VERSION_PROPERTY,
+    title: "Upgrade by app version",
+  },
   {
     id: "share_option",
     event: EVENTS.SHARE_COMPLETED,

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -207,6 +207,48 @@ test("every breakdown names an event the totals query also counts", () => {
   assert.equal(new Set(ids).size, ids.length);
 });
 
+const breakdownById = (id) =>
+  BREAKDOWNS.find((breakdown) => breakdown.id === id);
+
+test("the upgrade breakdowns say what was bought and whether it was real", () => {
+  const pkg = breakdownById("upgrade_package");
+  assert.equal(pkg.event, EVENTS.UPGRADE);
+  assert.equal(pkg.property, "package");
+
+  const source = breakdownById("upgrade_source");
+  assert.equal(source.event, EVENTS.UPGRADE);
+  assert.equal(source.property, "source");
+
+  const sandbox = breakdownById("upgrade_sandbox");
+  assert.equal(sandbox.event, EVENTS.UPGRADE);
+  assert.equal(sandbox.property, "is_sandbox");
+
+  const version = breakdownById("upgrade_app_version");
+  assert.equal(version.event, EVENTS.UPGRADE);
+  assert.equal(version.property, "$app_version");
+
+  const query = buildBreakdownQuery(buildWindows(NOW), source);
+  assert.match(query, /AND event = 'Upgrade'/);
+  assert.match(
+    query,
+    /ifNull\(nullIf\(toString\(properties\.source\), ''\), 'unknown'\) AS bucket/,
+  );
+
+  // The app writes one of these two, so a third bucket means the vocabulary
+  // moved and the table stopped separating revenue from a test grant.
+  const cataloguePath = fileURLToPath(
+    new URL("../../packages/shared/analytics/events.ts", import.meta.url),
+  );
+  const catalogue = readFileSync(cataloguePath, "utf8");
+  for (const name of ["is_sandbox", "source"]) {
+    assert.ok(
+      catalogue.includes(name),
+      `${name} is missing from the catalogue`,
+    );
+  }
+  assert.match(catalogue, /source\?: "maestro_mock" \| "store";/);
+});
+
 test("the suppression breakdown reads why a nudge was withheld", () => {
   const suppressed = BREAKDOWNS.find(
     (breakdown) => breakdown.id === "push_suppressed_reason",


### PR DESCRIPTION
## Summary
The daily readout on issue #188 shows two successful upgrades in the last seven days while every `Subscription Event` table is empty. This makes the readout able to say which of those two things is wrong.

## Details
- The successful upgrade event is fired by the app the moment the purchase sheet resolves, with nothing from the server behind it. A sandbox receipt, a TestFlight purchase and the premium grant the end to end flows hand themselves all resolve exactly like a real charge, so the number can be non zero in a week nobody paid.
- The upgrade event now carries whether the receipt was a sandbox one and where the purchase came from, either the store or the mock grant used by the end to end flows. Missing entitlement reads as unknown rather than as a real purchase.
- Four new readout tables: upgrade by package, by source, by sandbox and by app version. The first says which plan was bought without needing RevenueCat access, the next two say whether the money was real, and the last says whether the upgrade came from a phone in the store or from a release build being driven on a simulator here.
- No server change. The webhook handler records the subscription event and sends it to analytics before the switch, for every event type including TEST and TRANSFER, with no early return in front of it. If a RevenueCat delivery had reached the handler at all, the tables would not be empty.
- The production webhook route answers 401 to an unauthenticated request and 404 only for a path that does not exist, so the route is deployed and reachable. The empty tables therefore point at deliveries that never arrived or that were rejected before the handler ran, which can only be settled in the RevenueCat dashboard.
- Both mobile changes are JavaScript only, so they reach the current store build through an over the air update.

## Testing steps
1. Open the daily readout issue after the next scheduled run.
2. Under the upgrade section there are now four extra tables: by package, by source, by sandbox and by app version.
3. Read the source table. Anything in the store bucket is a real purchase; anything in the mock bucket came from the automated test flows and is not revenue.
4. Read the sandbox table next to it. A sandbox purchase never produces a charge, so it should never be counted as one.
5. Read the package table to see which plan was bought.
6. Compare those against the subscription tables further down. Real store purchases and subscription events should move together; if they do not, the gap is on the RevenueCat side rather than in the app.

## Screenshots
Nothing on screen changes. The whole diff is analytics properties and readout queries.
