### PR TITLE
feat(mobile): say whether an upgrade was a real purchase

### DIFF
--- a/apps/mobile/src/services/payments/index.ts
+++ b/apps/mobile/src/services/payments/index.ts
@@ -441,10 +441,32 @@ const restorePurchases = async () => {
   await Purchases.restorePurchases();
 };
 
+/**
+ * What a completed purchase actually was, for the analytics call site.
+ *
+ * `Upgrade` with `type: "success"` is the only client side signal that somebody
+ * paid, and on its own it cannot tell an App Store charge from a sandbox one or
+ * from the grant the Maestro flows hand themselves. All three read as revenue
+ * in the readout and only one of them is, which is how successful upgrades can
+ * show up with no matching RevenueCat webhook event behind them.
+ *
+ * `null` rather than `false` when the entitlement is missing, because "not a
+ * sandbox purchase" and "we could not read the receipt" are different answers.
+ */
+const describePurchase = (customerInfo?: CustomerInfo | null) => {
+  const entitlement = customerInfo?.entitlements.active[Entitlement.Premium];
+
+  return {
+    is_sandbox: entitlement?.isSandbox ?? null,
+    source: isMaestroMockMode ? ("maestro_mock" as const) : ("store" as const),
+  };
+};
+
 export const payments = {
   init,
   getOfferings,
   purchasePackage,
+  describePurchase,
   getPlan,
   logIn,
   restorePurchases,

--- a/apps/mobile/src/views/UpgradeWall/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/index.tsx
@@ -102,7 +102,7 @@ const UpgradeWall: React.FC = () => {
         },
       });
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       haptics.success();
 
       analytics.track({
@@ -110,6 +110,11 @@ const UpgradeWall: React.FC = () => {
         event_properties: {
           package: selectedOffering?.product.identifier,
           type: "success",
+          // Says whether the money was real. A sandbox receipt and the grant
+          // the Maestro flows hand themselves both land here otherwise
+          // indistinguishable from an App Store charge, and only the charge
+          // produces a RevenueCat webhook event on the server.
+          ...payments.describePurchase(result?.customerInfo),
         },
       });
       router.back();

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -255,7 +255,21 @@ export type MobileEventProperties = {
     minimum_version: string;
   };
   [ANALYTICS_EVENTS.UPGRADE]: {
+    /**
+     * Whether the receipt behind a successful upgrade was a sandbox one.
+     * `null` when the entitlement could not be read, which is a different
+     * answer from `false` and is counted separately.
+     */
+    is_sandbox?: boolean | null;
     package?: string;
+    /**
+     * Where a successful upgrade came from. `store` is a real purchase through
+     * RevenueCat, which is the only one that also produces a `Subscription
+     * Event` on the server. `maestro_mock` is the premium grant the end to end
+     * flows hand themselves, which produces nothing server side and is not
+     * revenue.
+     */
+    source?: "maestro_mock" | "store";
     trial?: boolean | null;
     type: "cancel" | "error" | "start" | "success";
   };


### PR DESCRIPTION
## Summary
Carries the upgrade purchase properties from #290 onto the 1.6.2 runtime, which is where every upgrade in the last seven days actually came from.

## Details
- The successful upgrade event now says whether the receipt was a sandbox one and whether the purchase came from the store or from the premium grant the automated flows hand themselves.
- This is the same mobile change as #290 with the readout half left out, since the readout queries do not live on this branch.
- The events audit for the last seven days shows every upgrade arriving from a phone reporting 1.6.2, so the new properties are only useful once they reach that runtime. On the main branch alone they would read as unknown for the people who are actually buying.
- JavaScript only. No native module and no new dependency, so an over the air update carries it.

## Testing steps
1. Publish the update to the 1.6.2 runtime.
2. Buy a plan on a phone running that build and confirm the app still takes you back to where you were after the purchase.
3. In the daily readout, the upgrade tables should start splitting real store purchases apart from sandbox ones instead of putting everything in the unknown bucket.

## Screenshots
Nothing on screen changes. The diff only adds properties to an analytics event.
