### PR TITLE
fix(api): stop the subscriptions webhook credential expiring on its own

### DIFF
--- a/apps/mobile/src/services/payments/index.ts
+++ b/apps/mobile/src/services/payments/index.ts
@@ -464,10 +464,32 @@ const restorePurchases = async () => {
   await Purchases.restorePurchases();
 };
 
+/**
+ * What a completed purchase actually was, for the analytics call site.
+ *
+ * `Upgrade` with `type: "success"` is the only client side signal that somebody
+ * paid, and on its own it cannot tell an App Store charge from a sandbox one or
+ * from the grant the Maestro flows hand themselves. All three read as revenue
+ * in the readout and only one of them is, which is how successful upgrades can
+ * show up with no matching RevenueCat webhook event behind them.
+ *
+ * `null` rather than `false` when the entitlement is missing, because "not a
+ * sandbox purchase" and "we could not read the receipt" are different answers.
+ */
+const describePurchase = (customerInfo?: CustomerInfo | null) => {
+  const entitlement = customerInfo?.entitlements.active[Entitlement.Premium];
+
+  return {
+    is_sandbox: entitlement?.isSandbox ?? null,
+    source: isMaestroMockMode ? ("maestro_mock" as const) : ("store" as const),
+  };
+};
+
 export const payments = {
   init,
   getOfferings,
   purchasePackage,
+  describePurchase,
   getPlan,
   logIn,
   restorePurchases,

--- a/apps/mobile/src/views/UpgradeWall/index.tsx
+++ b/apps/mobile/src/views/UpgradeWall/index.tsx
@@ -104,7 +104,7 @@ const UpgradeWall: React.FC = () => {
         },
       });
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       haptics.success();
 
       analytics.track({
@@ -112,6 +112,11 @@ const UpgradeWall: React.FC = () => {
         event_properties: {
           package: selectedOffering?.product.identifier,
           type: "success",
+          // Says whether the money was real. A sandbox receipt and the grant
+          // the Maestro flows hand themselves both land here otherwise
+          // indistinguishable from an App Store charge, and only the charge
+          // produces a RevenueCat webhook event on the server.
+          ...payments.describePurchase(result?.customerInfo),
         },
       });
       router.back();

--- a/apps/nextjs/src/app/api/webhooks/revenuecat/route.ts
+++ b/apps/nextjs/src/app/api/webhooks/revenuecat/route.ts
@@ -1,10 +1,10 @@
 import type { NextRequest } from "next/server";
 
 import PaymentService from "@pegada/api/services/payment-service";
-import { getSession } from "@pegada/api/trpc";
+import { captureEvent } from "@pegada/api/shared/analytics";
+import { authorizeRevenueCatRequest } from "@pegada/api/shared/revenuecat-auth";
+import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 import { RequestHeaders } from "@pegada/shared/types/types";
-
-const WEBHOOK_USER_ID = "WEBHOOK";
 
 export const OPTIONS = () => {
   const response = new Response(null, {
@@ -21,11 +21,21 @@ export const OPTIONS = () => {
 };
 
 export const POST = async (req: NextRequest) => {
-  const session = getSession(
-    req.headers.get(RequestHeaders.Authorization) ?? "",
+  const failure = authorizeRevenueCatRequest(
+    req.headers.get(RequestHeaders.Authorization),
   );
 
-  if (session?.user.id !== WEBHOOK_USER_ID) {
+  if (failure) {
+    // The refusal is the reading. An empty subscriptions table can mean the
+    // webhook was never set up or that every delivery is being turned away at
+    // the door, and those are different problems with different fixes. There
+    // is no user to attribute this to, so it is captured against the route.
+    captureEvent(
+      "revenuecat-webhook",
+      ANALYTICS_EVENTS.SUBSCRIPTION_WEBHOOK_REJECTED,
+      { reason: failure },
+    );
+
     return new Response(null, { status: 401 });
   }
 

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -142,6 +142,19 @@ const configSchema = z.object({
   CRON_SECRET: z.string().optional(),
 
   /**
+   * REVENUECAT
+   *
+   * The value pasted into the subscriptions webhook's "Authorization header
+   * value" box, sent back to us verbatim on every delivery. A plain shared
+   * secret on purpose: the previous check verified a signed token with a thirty
+   * day maximum age, so a working webhook silently stopped being one a month
+   * after it was set up. Optional so a fresh clone and the test suite boot
+   * without it, and the route still accepts a live legacy token while it is
+   * unset.
+   */
+  REVENUECAT_WEBHOOK_SECRET: z.string().optional(),
+
+  /**
    * APP
    *
    * The oldest build allowed to keep running. Anything below it gets the

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -149,8 +149,8 @@ const configSchema = z.object({
    * secret on purpose: the previous check verified a signed token with a thirty
    * day maximum age, so a working webhook silently stopped being one a month
    * after it was set up. Optional so a fresh clone and the test suite boot
-   * without it, and the route still accepts a live legacy token while it is
-   * unset.
+   * without it. While it is unset the route accepts nothing it did not already
+   * accept: the older token check is the only way in.
    */
   REVENUECAT_WEBHOOK_SECRET: z.string().optional(),
 

--- a/packages/api/src/shared/revenuecat-auth.test.ts
+++ b/packages/api/src/shared/revenuecat-auth.test.ts
@@ -1,0 +1,53 @@
+import { signAccessToken } from "./auth-token";
+import { config } from "./config";
+import { authorizeRevenueCatRequest } from "./revenuecat-auth";
+
+describe("authorizeRevenueCatRequest", () => {
+  const originalSecret = config.REVENUECAT_WEBHOOK_SECRET;
+
+  afterEach(() => {
+    config.REVENUECAT_WEBHOOK_SECRET = originalSecret;
+  });
+
+  it("says a delivery with no header arrived without a credential", () => {
+    expect(authorizeRevenueCatRequest(null)).toBe("missing");
+    expect(authorizeRevenueCatRequest("")).toBe("missing");
+  });
+
+  it("accepts the shared secret the dashboard sends back verbatim", () => {
+    config.REVENUECAT_WEBHOOK_SECRET = "a-long-shared-secret";
+
+    expect(
+      authorizeRevenueCatRequest("Bearer a-long-shared-secret"),
+    ).toBeNull();
+  });
+
+  it("refuses a secret that does not match, whatever its length", () => {
+    config.REVENUECAT_WEBHOOK_SECRET = "a-long-shared-secret";
+
+    expect(authorizeRevenueCatRequest("Bearer wrong")).toBe("rejected");
+    expect(authorizeRevenueCatRequest("Bearer a-long-shared-secrez")).toBe(
+      "rejected",
+    );
+  });
+
+  it("refuses everything while the secret is unset rather than falling open", () => {
+    config.REVENUECAT_WEBHOOK_SECRET = undefined;
+
+    expect(authorizeRevenueCatRequest("Bearer anything")).toBe("rejected");
+  });
+
+  it("still accepts a legacy webhook token that has not aged out", () => {
+    config.REVENUECAT_WEBHOOK_SECRET = undefined;
+    const token = signAccessToken({ sub: "WEBHOOK" });
+
+    expect(authorizeRevenueCatRequest(`Bearer ${token}`)).toBeNull();
+  });
+
+  it("refuses a legacy token that belongs to a person rather than the webhook", () => {
+    config.REVENUECAT_WEBHOOK_SECRET = undefined;
+    const token = signAccessToken({ sub: "some-real-user-id" });
+
+    expect(authorizeRevenueCatRequest(`Bearer ${token}`)).toBe("rejected");
+  });
+});

--- a/packages/api/src/shared/revenuecat-auth.ts
+++ b/packages/api/src/shared/revenuecat-auth.ts
@@ -44,8 +44,10 @@ export type RevenueCatAuthFailure = "missing" | "rejected";
  *
  * The legacy path is still accepted so a token that has not aged out yet keeps
  * working through the deploy. `REVENUECAT_WEBHOOK_SECRET` is the one that does
- * not expire, and an unset secret refuses rather than falling open, because the
- * route behind this changes what people are paying for.
+ * not expire. While it is unset the legacy check is the only way in, so an
+ * unset secret narrows the door rather than opening it: nothing is accepted
+ * that was not already accepted before, which matters because the route behind
+ * this changes what people are paying for.
  */
 export const authorizeRevenueCatRequest = (
   authorizationHeader: string | null | undefined,

--- a/packages/api/src/shared/revenuecat-auth.ts
+++ b/packages/api/src/shared/revenuecat-auth.ts
@@ -1,0 +1,66 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { getSession } from "./auth-token";
+import { config } from "./config";
+
+const WEBHOOK_USER_ID = "WEBHOOK";
+
+/**
+ * Compare two secrets without leaking their common prefix through timing.
+ * `timingSafeEqual` throws on mismatched lengths, so the length check happens
+ * first and is itself the only thing an attacker learns.
+ */
+const secretsMatch = (candidate: string, secret: string) => {
+  const candidateBytes = Buffer.from(candidate);
+  const secretBytes = Buffer.from(secret);
+
+  if (candidateBytes.length !== secretBytes.length) return false;
+
+  return timingSafeEqual(candidateBytes, secretBytes);
+};
+
+/**
+ * Why a webhook delivery was refused, or `null` when it was accepted.
+ *
+ * Named rather than boolean because the two failures need different actions.
+ * `missing` is a delivery that arrived with no credential, which points at the
+ * dashboard. `rejected` is one that arrived with a credential we do not
+ * recognise, which points at a value that no longer matches, and until this
+ * file existed that was the same silent 401 as everything else.
+ */
+export type RevenueCatAuthFailure = "missing" | "rejected";
+
+/**
+ * Is this request a genuine RevenueCat webhook delivery?
+ *
+ * RevenueCat sends whatever is pasted into the "Authorization header value"
+ * box on every delivery, unchanged, forever. That is the whole reason this is
+ * a shared secret rather than a signed token: the previous check ran the value
+ * through {@link getSession}, which verifies a JWT with a thirty day maximum
+ * age. A token pasted into the dashboard therefore worked for a month and then
+ * started failing on its own, with no deploy and no error, because nothing
+ * refreshes a value that lives in somebody else's dashboard. Every delivery
+ * after that is a 401 nobody sees.
+ *
+ * The legacy path is still accepted so a token that has not aged out yet keeps
+ * working through the deploy. `REVENUECAT_WEBHOOK_SECRET` is the one that does
+ * not expire, and an unset secret refuses rather than falling open, because the
+ * route behind this changes what people are paying for.
+ */
+export const authorizeRevenueCatRequest = (
+  authorizationHeader: string | null | undefined,
+): RevenueCatAuthFailure | null => {
+  if (!authorizationHeader) return "missing";
+
+  const secret = config.REVENUECAT_WEBHOOK_SECRET;
+
+  if (secret && authorizationHeader.startsWith("Bearer ")) {
+    const candidate = authorizationHeader.slice("Bearer ".length);
+    if (secretsMatch(candidate, secret)) return null;
+  }
+
+  const session = getSession(authorizationHeader);
+  if (session?.user.id === WEBHOOK_USER_ID) return null;
+
+  return "rejected";
+};

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -419,7 +419,21 @@ export type MobileEventProperties = {
     minimum_version: string;
   };
   [ANALYTICS_EVENTS.UPGRADE]: {
+    /**
+     * Whether the receipt behind a successful upgrade was a sandbox one.
+     * `null` when the entitlement could not be read, which is a different
+     * answer from `false` and is counted separately.
+     */
+    is_sandbox?: boolean | null;
     package?: string;
+    /**
+     * Where a successful upgrade came from. `store` is a real purchase through
+     * RevenueCat, which is the only one that also produces a `Subscription
+     * Event` on the server. `maestro_mock` is the premium grant the end to end
+     * flows hand themselves, which produces nothing server side and is not
+     * revenue.
+     */
+    source?: "maestro_mock" | "store";
     trial?: boolean | null;
     type: "cancel" | "error" | "start" | "success";
   };

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -77,6 +77,7 @@ export const ANALYTICS_EVENTS = {
   SKIP_COMPLETE_DOG_PROFILE: "Skip Complete Dog Profile",
   STORE_REDIRECT: "Store Redirect",
   SUBSCRIPTION_EVENT: "Subscription Event",
+  SUBSCRIPTION_WEBHOOK_REJECTED: "Subscription Webhook Rejected",
   SWIPE: "Swipe",
   SWIPE_BACK: "Swipe Back",
   UPDATE_REQUIRED_SHOWN: "Update Required Shown",
@@ -715,6 +716,21 @@ export type ServerEventProperties = {
     store: SubscriptionStore;
     type: SubscriptionEventType;
   };
+  /**
+   * A delivery to the subscriptions webhook that never reached the handler.
+   *
+   * Without this row a refused delivery and a webhook nobody ever set up look
+   * identical from the readout: both are an empty `Subscription Event` table.
+   * They need opposite actions, so the refusal is a row of its own rather than
+   * a silence to be interpreted.
+   *
+   * `missing` means the delivery carried no credential at all. `rejected`
+   * means it carried one we do not recognise, which is what an expired or
+   * rotated value looks like from here.
+   */
+  [ANALYTICS_EVENTS.SUBSCRIPTION_WEBHOOK_REJECTED]: {
+    reason: "missing" | "rejected";
+  };
 };
 
 export type ServerEventName = keyof ServerEventProperties;
@@ -857,6 +873,7 @@ export const SERVER_EVENT_NAMES = [
   ANALYTICS_EVENTS.SIGNUP_ATTRIBUTED,
   ANALYTICS_EVENTS.STORE_REDIRECT,
   ANALYTICS_EVENTS.SUBSCRIPTION_EVENT,
+  ANALYTICS_EVENTS.SUBSCRIPTION_WEBHOOK_REJECTED,
 ] as const;
 
 export const WEB_EVENT_NAMES = [

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -32,6 +32,7 @@ export const EVENTS = {
   SHARE_TAPPED: "Share Tapped",
   SIGNUP_ATTRIBUTED: "Signup Attributed",
   SUBSCRIPTION_EVENT: "Subscription Event",
+  SUBSCRIPTION_WEBHOOK_REJECTED: "Subscription Webhook Rejected",
   SWIPE: "Swipe",
   UPGRADE: "Upgrade",
 };
@@ -72,6 +73,7 @@ export const SERVER_EVENTS = [
   "Reengagement Push Suppressed",
   "Signup Attributed",
   "Subscription Event",
+  "Subscription Webhook Rejected",
 ].sort();
 
 /**
@@ -270,6 +272,17 @@ export const BREAKDOWNS = [
     event: EVENTS.SUBSCRIPTION_EVENT,
     property: "product_id",
     title: "Subscription Event by product",
+  },
+  // Why the subscription tables above are empty, when they are. A webhook
+  // nobody ever configured sends nothing at all, so this table is empty too. A
+  // webhook whose credential no longer matches sends every delivery straight
+  // into a refusal, and they land here. Reading an empty subscription table
+  // without this one cannot tell those apart.
+  {
+    id: "subscription_webhook_rejected",
+    event: EVENTS.SUBSCRIPTION_WEBHOOK_REJECTED,
+    property: "reason",
+    title: "Subscription Webhook Rejected by reason",
   },
 ];
 

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -140,6 +140,44 @@ export const BREAKDOWNS = [
     property: "type",
     title: "Upgrade by type",
   },
+  // What the successful upgrades actually bought, and whether the money was
+  // real. `Upgrade` is a client event: the app fires it the moment the purchase
+  // sheet resolves, with no server confirmation behind it. A sandbox receipt, a
+  // TestFlight purchase and the premium grant the end to end flows hand
+  // themselves all resolve the same way, so a week can show successful upgrades
+  // while `Subscription Event by type` stays empty because RevenueCat never
+  // charged anybody. These three tables are what separates the cases.
+  //
+  // `unknown` in the source and sandbox tables is a build that predates the
+  // properties, not a purchase we failed to classify.
+  {
+    id: "upgrade_package",
+    event: EVENTS.UPGRADE,
+    property: "package",
+    title: "Upgrade by package",
+  },
+  {
+    id: "upgrade_source",
+    event: EVENTS.UPGRADE,
+    property: "source",
+    title: "Upgrade by source",
+  },
+  {
+    id: "upgrade_sandbox",
+    event: EVENTS.UPGRADE,
+    property: "is_sandbox",
+    title: "Upgrade by sandbox",
+  },
+  // Which build the upgrade came from, scoped to the event rather than to the
+  // whole population. The over the air table below counts people across every
+  // event, so it cannot say whether a given upgrade came from a phone in the
+  // store or from a release build one of us was driving on a simulator.
+  {
+    id: "upgrade_app_version",
+    event: EVENTS.UPGRADE,
+    property: APP_VERSION_PROPERTY,
+    title: "Upgrade by app version",
+  },
   {
     id: "share_option",
     event: EVENTS.SHARE_COMPLETED,

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -207,6 +207,48 @@ test("every breakdown names an event the totals query also counts", () => {
   assert.equal(new Set(ids).size, ids.length);
 });
 
+const breakdownById = (id) =>
+  BREAKDOWNS.find((breakdown) => breakdown.id === id);
+
+test("the upgrade breakdowns say what was bought and whether it was real", () => {
+  const pkg = breakdownById("upgrade_package");
+  assert.equal(pkg.event, EVENTS.UPGRADE);
+  assert.equal(pkg.property, "package");
+
+  const source = breakdownById("upgrade_source");
+  assert.equal(source.event, EVENTS.UPGRADE);
+  assert.equal(source.property, "source");
+
+  const sandbox = breakdownById("upgrade_sandbox");
+  assert.equal(sandbox.event, EVENTS.UPGRADE);
+  assert.equal(sandbox.property, "is_sandbox");
+
+  const version = breakdownById("upgrade_app_version");
+  assert.equal(version.event, EVENTS.UPGRADE);
+  assert.equal(version.property, "$app_version");
+
+  const query = buildBreakdownQuery(buildWindows(NOW), source);
+  assert.match(query, /AND event = 'Upgrade'/);
+  assert.match(
+    query,
+    /ifNull\(nullIf\(toString\(properties\.source\), ''\), 'unknown'\) AS bucket/,
+  );
+
+  // The app writes one of these two, so a third bucket means the vocabulary
+  // moved and the table stopped separating revenue from a test grant.
+  const cataloguePath = fileURLToPath(
+    new URL("../../packages/shared/analytics/events.ts", import.meta.url),
+  );
+  const catalogue = readFileSync(cataloguePath, "utf8");
+  for (const name of ["is_sandbox", "source"]) {
+    assert.ok(
+      catalogue.includes(name),
+      `${name} is missing from the catalogue`,
+    );
+  }
+  assert.match(catalogue, /source\?: "maestro_mock" \| "store";/);
+});
+
 test("the suppression breakdown reads why a nudge was withheld", () => {
   const suppressed = BREAKDOWNS.find(
     (breakdown) => breakdown.id === "push_suppressed_reason",


### PR DESCRIPTION
## Summary
The subscriptions webhook checked a credential that expires thirty days after it is created, so a working webhook stops being one a month later with no deploy and no error. This makes the credential permanent and makes a refused delivery visible.

## Details
- The route ran the incoming header through the same check used for a signed in person, which verifies a token with a thirty day maximum age. RevenueCat sends whatever was pasted into its dashboard back to us unchanged, forever, and nothing refreshes a value that lives in somebody else's dashboard. A month after setup every delivery starts failing.
- The check is now a shared secret compared in constant time, the same shape the scheduled jobs already use. A token that has not aged out yet is still accepted, so nothing breaks during the deploy.
- While the secret is unset, the older token check is the only way in, so nothing is accepted that was not already accepted before. The route behind it changes what people are paying for, so it never widens on a missing variable.
- A refused delivery is now reported, split by whether it arrived with no credential at all or with one we do not recognise. Until now a webhook nobody configured and a webhook being turned away at the door both showed up as the same empty table, and they need opposite fixes.
- New readout table for those refusals, so the next daily run answers the question instead of leaving it open.
- Stacked on #290. Merge that one first.
- Needs `REVENUECAT_WEBHOOK_SECRET` set in the deployment and the same value pasted into the subscriptions webhook authorization field, prefixed with the word Bearer and a space.

## Testing steps
1. Set the new secret in the deployment and paste the matching value into the subscriptions provider, in the authorization field, after the word Bearer and a space.
2. Send a test event from the provider dashboard. It should report success rather than an unauthorized response.
3. In the daily readout, the subscription tables should start filling in as people buy, renew and cancel.
4. If they stay empty, the new refusals table says whether deliveries are arriving and being turned away or not arriving at all.

## Screenshots
Nothing on screen changes. The diff is server side authorization, one analytics event and one readout query.

