### PR TITLE
fix(api): accept real match ids in the chat routes

### DIFF
--- a/packages/api/src/routes/input-schemas.ts
+++ b/packages/api/src/routes/input-schemas.ts
@@ -1,33 +1,48 @@
 import { MAX_IMAGE_BYTES } from "@pegada/shared/constants/constants";
 import { z } from "zod";
 
+/**
+ * Ids in this database do not share one format. Prisma mints cuids for Dog and
+ * User and uuids for Match and Message, and the rows carried over from the
+ * previous system have ids in neither shape, so a format specific check like
+ * `.uuid()` or `.cuid()` rejects real traffic from real people. Bound the
+ * length and the alphabet instead and let the lookup decide whether the row
+ * exists.
+ */
+export const recordIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Za-z0-9_-]+$/);
+
 export const signedUploadInputSchema = z.object({
   contentLength: z.number().int().min(1).max(MAX_IMAGE_BYTES),
   contentType: z.literal("image/webp"),
 });
 
 export const messageListInputSchema = z.object({
-  matchId: z.string().uuid(),
+  matchId: recordIdSchema,
   limit: z.coerce.number().int().min(1).max(100).optional().default(10),
   gt: z.coerce.date().optional(),
   lt: z.coerce.date().optional(),
 });
 
 export const messageSendInputSchema = z.object({
-  matchId: z.string().uuid(),
+  matchId: recordIdSchema,
   content: z.string().trim().min(1).max(2_000),
 });
 
 export const messageDeleteInputSchema = z.object({
-  messageId: z.string().uuid(),
+  messageId: recordIdSchema,
 });
 
 export const swipeQueryInputSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional().default(10),
-  notIn: z.array(z.string().cuid()).max(500).optional(),
+  notIn: z.array(recordIdSchema).max(500).optional(),
 });
 
 export const swipeInputSchema = z.object({
-  id: z.string().cuid(),
+  id: recordIdSchema,
   swipeType: z.enum(["NOT_INTERESTED", "MAYBE", "INTERESTED"]),
 });

--- a/packages/api/src/routes/input-validation.test.ts
+++ b/packages/api/src/routes/input-validation.test.ts
@@ -1,14 +1,83 @@
 import { MAX_IMAGE_BYTES } from "@pegada/shared/constants/constants";
 
 import {
+  messageDeleteInputSchema,
   messageListInputSchema,
   messageSendInputSchema,
+  recordIdSchema,
   signedUploadInputSchema,
+  swipeInputSchema,
   swipeQueryInputSchema,
 } from "./input-schemas";
 
 const matchId = "550e8400-e29b-41d4-a716-446655440000";
 const dogId = "clh9u9mqh0000qw3i5g2h4q7p";
+
+/**
+ * Every shape a real id takes in this database. The legacy one is an actual
+ * Match id carried over from the previous system, and it is the reason the
+ * chat routes cannot ask for a uuid.
+ */
+const realIds = {
+  uuid: "550e8400-e29b-41d4-a716-446655440000",
+  cuid: "clh9u9mqh0000qw3i5g2h4q7p",
+  cuid2: "cmtjbfxz60002s0iq2lttngx9",
+  legacy: "y3dgn1l5epev33kztknonkwe",
+  seed: "seed-dog-matchme",
+};
+
+describe("record ids", () => {
+  it("accepts every id shape the database actually holds", () => {
+    for (const [shape, id] of Object.entries(realIds)) {
+      expect([shape, recordIdSchema.safeParse(id).success]).toEqual([
+        shape,
+        true,
+      ]);
+    }
+  });
+
+  it("still rejects junk", () => {
+    expect(recordIdSchema.safeParse("").success).toBe(false);
+    expect(recordIdSchema.safeParse("   ").success).toBe(false);
+    expect(recordIdSchema.safeParse("a".repeat(65)).success).toBe(false);
+    expect(recordIdSchema.safeParse("has space").success).toBe(false);
+    expect(recordIdSchema.safeParse("drop/../table").success).toBe(false);
+    expect(recordIdSchema.safeParse(42).success).toBe(false);
+  });
+});
+
+describe("chat routes accept real match ids", () => {
+  it("lists, sends and deletes against any id shape", () => {
+    for (const [shape, id] of Object.entries(realIds)) {
+      expect([
+        shape,
+        messageListInputSchema.safeParse({ matchId: id }).success,
+      ]).toEqual([shape, true]);
+      expect([
+        shape,
+        messageSendInputSchema.safeParse({ matchId: id, content: "oi" })
+          .success,
+      ]).toEqual([shape, true]);
+      expect([
+        shape,
+        messageDeleteInputSchema.safeParse({ messageId: id }).success,
+      ]).toEqual([shape, true]);
+    }
+  });
+
+  it("swipes against any dog id shape", () => {
+    for (const [shape, id] of Object.entries(realIds)) {
+      expect([
+        shape,
+        swipeInputSchema.safeParse({ id, swipeType: "INTERESTED" }).success,
+      ]).toEqual([shape, true]);
+      expect([
+        shape,
+        swipeQueryInputSchema.safeParse({ notIn: [id] }).success,
+      ]).toEqual([shape, true]);
+    }
+  });
+});
 
 describe("message input limits", () => {
   it("bounds pagination", () => {


### PR DESCRIPTION
## Summary

Opening a conversation and sending a message failed for people whose match was stored under an older id format, because the server rejected the id before it ever looked it up. Twenty different people hit this in the last seven days.

## Details

- The chat routes required the match id and the message id to be a uuid, and the swipe route required the dog id to be a cuid. Neither check matches what the database actually holds.
- Ids in this database come in three shapes at once: uuids on match and message rows, cuids on dog and user rows, and a shorter form on the rows carried over from the previous system. Any format specific check rejects some share of real traffic.
- Both checks are replaced with one shared id rule that bounds the length and the alphabet and lets the lookup decide whether the row exists. Junk, blank values, oversized values and path traversal attempts are still refused.
- The existing test passed a hand written uuid, which is why this reached production. The tests now run every id shape the database holds through all four inputs.
- Hypothesis and baseline: the last seven days show 3 matches, 0 messages sent, and 20 people on 20 devices hitting this validation error. Expect message volume to appear within days of the deploy, and expect this error to drop off the exceptions table.
- Readout: the Message Sent event and the exceptions table in the daily metrics issue. Message Sent only fires once the server accepts the message, so it stayed silent for everyone caught by this.
- Chat Opened is unaffected either way, since it is sent when the screen appears rather than after the server replies.
- Server side, so it reaches everyone on the current store build as soon as it deploys. No app update needed.

## Testing steps

1. Open the app and sign in.
2. Like a dog that has already liked you, so a match appears.
3. On the match screen, choose to send a message. The conversation opens instead of failing to load.
4. Type a message and send it. It shows in the thread with the delivered marks.
5. Leave the conversation and open it again. The message is still there.
6. Repeat on an older conversation, one that existed before the data was moved over. It behaves the same.

## Screenshots

Match created from the swipe deck:

![Match screen](https://raw.githubusercontent.com/GSTJ/pegada/shots/match-uuid/shots/match.png)

Message sent and delivered in a conversation stored under the older id format:

![Message delivered](https://raw.githubusercontent.com/GSTJ/pegada/shots/match-uuid/shots/message-sent.png)
