### PR TITLE
feat(ci): explain push silence and date exceptions in the readouts

### DIFF
--- a/scripts/metrics/daily.mjs
+++ b/scripts/metrics/daily.mjs
@@ -26,6 +26,7 @@ import {
   buildDeckSupplyQuery,
   buildOtaUpdatesQuery,
   buildPushAttributedReturnsQuery,
+  buildReengagementCronQuery,
   buildTotalsQuery,
   buildWindows,
 } from "./queries.mjs";
@@ -78,6 +79,7 @@ export async function runDailyMetrics({
     activeUsers,
     activeUsersByCity,
     activeUsersByVersion,
+    cronRun,
     deckSupply,
     otaUpdates,
     totals,
@@ -93,6 +95,10 @@ export async function runDailyMetrics({
     run(
       "pegada daily metrics: active users by app version",
       buildActiveUsersByVersionQuery(windows),
+    ),
+    run(
+      "pegada daily metrics: reengagement cron runs",
+      buildReengagementCronQuery(windows),
     ),
     run("pegada daily metrics: deck supply", buildDeckSupplyQuery(windows)),
     run(
@@ -128,6 +134,7 @@ export async function runDailyMetrics({
     activeUsersByCity,
     activeUsersByVersion,
     breakdowns,
+    cronRun,
     deckSupply,
     generatedAt: now,
     otaUpdates,

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -91,6 +91,21 @@ function fakeWorld({ existingComment = null } = {}) {
           results: [[name.includes("previous") ? 160 : 200]],
         });
       }
+      if (name.endsWith("reengagement cron runs")) {
+        return json({
+          columns: [
+            "runs",
+            "last_run_at",
+            "last_users_in_weekly_floor",
+            "last_candidates",
+            "last_sent",
+            "last_suppressed",
+            "candidates",
+            "sent",
+          ],
+          results: [[168, "2026-09-02 11:00:00", 512, 3, 1, 2, 24, 9]],
+        });
+      }
       if (name.endsWith("deck supply")) {
         return json({
           columns: [
@@ -176,7 +191,7 @@ test("a dry run renders the comment and never touches GitHub", async () => {
 test("one query goes out per metric block", async () => {
   const fetchImpl = fakeWorld();
   await runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW });
-  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 8);
+  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 9);
 });
 
 test("both push return windows are asked for separately and land in the table", async () => {
@@ -311,4 +326,23 @@ test("the readout carries the updates in use through to the comment", async () =
   );
   assert.ok(query, "the readout never asked PostHog which updates are in use");
   assert.match(query.body.query.query, /properties\.ota_update_id/);
+});
+
+test("the cron heartbeat reaches the push section", async () => {
+  const fetchImpl = fakeWorld();
+  const result = await runDailyMetrics({
+    argv: ["--dry-run"],
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  const call = fetchImpl.calls.find((entry) =>
+    entry.body?.name?.endsWith("reengagement cron runs"),
+  );
+  assert.match(call.body.query.query, /AND event = 'Reengagement Cron Ran'/);
+  assert.match(result.body, /#### Reengagement cron/);
+  assert.match(result.body, /\| Last run \| 2026-09-02 11:00 UTC \|/);
+  assert.match(result.body, /\| Users in weekly floor \(last run\) \| 512 \|/);
+  assert.match(result.body, /\| Sent \(last 7 days\) \| 9 \|/);
 });

--- a/scripts/metrics/events-audit-queries.mjs
+++ b/scripts/metrics/events-audit-queries.mjs
@@ -300,6 +300,13 @@ function topFrameExpression() {
  * reason the libraries are: one fault reached by two paths is still one fault.
  * `max` picks one of them and prefers a real one, since a blank sorts below
  * every name.
+ *
+ * `first_seen` and `last_seen` are what make a seven day window readable on the
+ * day after a fix. A group counted over a week looks identical whether it is
+ * still throwing or stopped on Monday, so a total on its own turns a shipped
+ * fix into a row that appears unchanged. The two ends of the group say which
+ * one it is, and a first sighting inside the last day is a fault that arrived
+ * with something recent rather than one that has been there all along.
  */
 export function buildExceptionGroupsQuery(
   window,
@@ -327,7 +334,9 @@ export function buildExceptionGroupsQuery(
     "  count() AS total,",
     "  count(DISTINCT person_id) AS people,",
     `  arrayStringConcat(arraySort(groupUniqArray(${lib})), ', ') AS libs,`,
-    `  arrayStringConcat(arraySort(groupUniqArrayIf(${version}, ${lib} IN (${clientLibs}))), ', ') AS app_versions`,
+    `  arrayStringConcat(arraySort(groupUniqArrayIf(${version}, ${lib} IN (${clientLibs}))), ', ') AS app_versions,`,
+    "  min(timestamp) AS first_seen,",
+    "  max(timestamp) AS last_seen",
     "FROM events",
     `WHERE ${windowFilter(window)}`,
     "  AND event = '$exception'",

--- a/scripts/metrics/events-audit-queries.test.mjs
+++ b/scripts/metrics/events-audit-queries.test.mjs
@@ -395,3 +395,12 @@ test("the exception query truncates the frame and keeps it out of the group", ()
     false,
   );
 });
+
+test("the exception query brings back both ends of every group", () => {
+  const query = buildExceptionGroupsQuery(buildAuditWindow(NOW));
+  assert.match(query, /min\(timestamp\) AS first_seen/);
+  assert.match(query, /max\(timestamp\) AS last_seen/);
+  // Collected inside the group, not grouped on: splitting a fault by the
+  // minute it happened would turn one fault into a row per event.
+  assert.match(query, /GROUP BY exception_type, message/);
+});

--- a/scripts/metrics/events-audit-report.mjs
+++ b/scripts/metrics/events-audit-report.mjs
@@ -11,6 +11,7 @@ import {
   LIB_BUCKETS,
   MAX_EXCEPTION_GROUPS,
 } from "./events-audit-queries.mjs";
+import { parseTimestamp, utcMoment, utcStamp } from "./timestamps.mjs";
 
 export const COMMENT_MARKER = "<!-- pegada-events-audit -->";
 
@@ -22,10 +23,6 @@ const OTHER_LIB = "other";
 
 function number(value) {
   return Number(value ?? 0).toLocaleString("en-US");
-}
-
-function utcStamp(date) {
-  return `${date.toISOString().slice(0, 16).replace("T", " ")} UTC`;
 }
 
 function percent(part, whole) {
@@ -451,6 +448,37 @@ export function codeCell(value) {
 }
 
 /**
+ * How recent the first sighting has to be for the table to call a group new.
+ *
+ * A day, so a fault that arrived with last night's deploy is marked on the
+ * morning readout rather than blending into a week of history.
+ */
+export const NEW_EXCEPTION_HOURS = 24;
+
+/** What the table puts next to a group nobody had seen a day ago. */
+export const NEW_EXCEPTION_MARKER = "(new)";
+
+/**
+ * The first sighting, marked when it is recent enough to be news.
+ *
+ * The mark goes on the stamp rather than in a column of its own: the reader is
+ * already looking at the date it is about, and a tenth column earns its width
+ * only if it says something the ninth cannot.
+ */
+function firstSeenCell(value, now) {
+  const stamp = utcMoment(value);
+  const seen = parseTimestamp(value);
+  const asOf = parseTimestamp(now);
+  if (seen === null || asOf === null) {
+    return stamp;
+  }
+  const age = asOf.getTime() - seen.getTime();
+  return age < NEW_EXCEPTION_HOURS * 60 * 60 * 1000
+    ? `${stamp} ${NEW_EXCEPTION_MARKER}`
+    : stamp;
+}
+
+/**
  * The exception table.
  *
  * Last on purpose: everything above it is about whether the instrumentation is
@@ -459,7 +487,7 @@ export function codeCell(value) {
  * the number that matters is how many people a single fault reached, and that
  * is the column a fix gets prioritised on.
  */
-function exceptionSection(exceptions) {
+function exceptionSection(exceptions, generatedAt) {
   const rows = exceptions.map((row) => [
     codeCell(row.exception_type),
     codeCell(row.message),
@@ -468,11 +496,15 @@ function exceptionSection(exceptions) {
     number(row.people),
     libLabel(row.libs),
     codeCell(row.app_versions) || "n/a",
+    firstSeenCell(row.first_seen, generatedAt),
+    utcMoment(row.last_seen),
   ]);
   return [
     "### 5. Exceptions",
     "",
     `The ${number(MAX_EXCEPTION_GROUPS)} busiest \`$exception\` groups in the window, by exception type and message. Messages are cut at ${number(EXCEPTION_MESSAGE_LENGTH)} characters, and the grouping is on the cut value, so two failures that differ only in a trailing id count as one. Frame is the line that threw, on one of the events in the group, and \`n/a\` when the exception arrived without a stack. App version is the build the phone was running, and \`n/a\` on anything the server threw.`,
+    "",
+    `First seen and last seen are the ends of the group inside the window, to the minute in UTC. They are how a fix reads: a total covering seven days looks the same whether the fault is still throwing or stopped on Monday, and a last seen several days old is one that stopped. A group first seen in the last ${number(NEW_EXCEPTION_HOURS)} hours is marked ${NEW_EXCEPTION_MARKER}.`,
     "",
     table(
       [
@@ -483,6 +515,8 @@ function exceptionSection(exceptions) {
         "People",
         "Library",
         "App version",
+        "First seen",
+        "Last seen",
       ],
       rows,
       "No exceptions in the window.",
@@ -527,6 +561,6 @@ export function buildReport({
     "",
     propertySection(summary, funnelEvents),
     "",
-    exceptionSection(exceptions),
+    exceptionSection(exceptions, generatedAt),
   ].join("\n");
 }

--- a/scripts/metrics/events-audit-report.test.mjs
+++ b/scripts/metrics/events-audit-report.test.mjs
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   COMMENT_MARKER,
+  NEW_EXCEPTION_HOURS,
   buildFindings,
   buildReport,
   codeCell,
@@ -195,7 +196,9 @@ export const EXCEPTIONS = [
   {
     app_versions: "1.6.2, 1.7.2",
     exception_type: "TypeError",
+    first_seen: "2026-08-28 13:20:00",
     frame: "DogCard in src/components/DogCard.tsx",
+    last_seen: "2026-09-04 11:50:00",
     libs: "posthog-react-native",
     message: "undefined is not an object (evaluating 'dog.photos[0].url')",
     people: 14,
@@ -204,7 +207,9 @@ export const EXCEPTIONS = [
   {
     app_versions: "",
     exception_type: "PrismaClientKnownRequestError",
+    first_seen: "2026-08-29 02:05:00",
     frame: "listDogs in packages/api/src/router/dog.ts",
+    last_seen: "2026-08-31 07:10:00",
     libs: "posthog-node",
     message: "Timed out fetching a new connection from the connection pool",
     people: 6,
@@ -213,7 +218,9 @@ export const EXCEPTIONS = [
   {
     app_versions: "1.6.2",
     exception_type: "Error",
+    first_seen: "2026-09-04 06:30:00",
     frame: "",
+    last_seen: "2026-09-04 11:00:00",
     libs: "posthog-node, posthog-react-native",
     message: "Request failed | GET /api/trpc/dog.list\nstatus `500`",
     people: 3,
@@ -483,9 +490,9 @@ test("an exception seen from both sides names both", () => {
 test("a message cannot break the row it sits in", () => {
   const body = buildReport(FIXTURE);
   const row = body.split("\n").find((line) => line.includes("Request failed"));
-  // Seven columns means eight pipes. A raw pipe or a newline in the message
+  // Nine columns means ten pipes. A raw pipe or a newline in the message
   // would silently shift every column after it.
-  assert.equal(row.split(/(?<!\\)\|/u).length - 1, 8);
+  assert.equal(row.split(/(?<!\\)\|/u).length - 1, 10);
   assert.equal(row.includes("\n"), false);
   assert.match(row, /Request failed \\\| GET/);
 });
@@ -523,4 +530,52 @@ test("no exceptions in the window says so", () => {
     body,
     /### 5\. Exceptions\n\n.+\n\nNo exceptions in the window\./s,
   );
+});
+
+test("the exception table carries both ends of every group", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(body, /\| Library \| App version \| First seen \| Last seen \|/);
+  // The fault that stopped on Monday: still in the seven day total, but its
+  // last event is three days old.
+  const settled = body
+    .split("\n")
+    .find((line) => line.includes("PrismaClientKnownRequestError"));
+  assert.match(settled, /\| 2026-08-29 02:05 UTC \| 2026-08-31 07:10 UTC \|/);
+});
+
+test("a group first seen inside the last day is marked new", () => {
+  const body = buildReport(FIXTURE);
+  assert.equal(NEW_EXCEPTION_HOURS, 24);
+  const fresh = body
+    .split("\n")
+    .find((line) => line.includes("Request failed"));
+  assert.match(fresh, /\| 2026-09-04 06:30 UTC \(new\) \|/);
+});
+
+test("a group that has been there all week is not marked new", () => {
+  const body = buildReport(FIXTURE);
+  const old = body.split("\n").find((line) => line.includes("DogCard"));
+  assert.match(old, /\| 2026-08-28 13:20 UTC \| 2026-09-04 11:50 UTC \|/);
+  assert.equal(old.includes("(new)"), false);
+});
+
+test("a group with no timestamps on it still gets a row", () => {
+  const body = buildReport(FIXTURE);
+  const bare = body
+    .split("\n")
+    .find((line) => line.includes("| unknown | `unknown` |"));
+  assert.match(bare, /\| - \| - \|/);
+  assert.equal(bare.includes("(new)"), false);
+});
+
+test("a timestamp with no zone on it is read as UTC before it is marked", () => {
+  // ClickHouse sends `2026-09-04 06:30:00` with no zone. Read as local time in
+  // Sao Paulo that lands three hours out, which is enough to move a group in
+  // or out of the last day.
+  const body = buildReport({
+    ...FIXTURE,
+    exceptions: [{ ...EXCEPTIONS[0], first_seen: "2026-09-04 06:30:00" }],
+    generatedAt: new Date("2026-09-04T12:03:00.000Z"),
+  });
+  assert.match(body, /\| 2026-09-04 06:30 UTC \(new\) \|/);
 });

--- a/scripts/metrics/events-audit.test.mjs
+++ b/scripts/metrics/events-audit.test.mjs
@@ -75,6 +75,8 @@ function fakeWorld({ existingComment = null, swipeName = "Swipe" } = {}) {
             "people",
             "libs",
             "app_versions",
+            "first_seen",
+            "last_seen",
           ],
           results: [
             [
@@ -85,6 +87,8 @@ function fakeWorld({ existingComment = null, swipeName = "Swipe" } = {}) {
               4,
               "posthog-react-native",
               "1.6.2",
+              "2026-09-04 09:15:00",
+              "2026-09-04 10:40:00",
             ],
           ],
         });

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -624,6 +624,64 @@ export function buildPushAttributedReturnsQuery({ end, start }) {
 }
 
 /**
+ * The five ways the cron can decide against a nudge it had ready.
+ *
+ * Summed into one number for the run table rather than split: the split
+ * already has a table of its own further down the readout, and the question
+ * this row answers is only how much of the run was held back.
+ */
+export const CRON_SUPPRESSION_PROPERTIES = [
+  "suppressed_cooldown",
+  "suppressed_dead_token",
+  "suppressed_gave_up",
+  "suppressed_monthly_cap",
+  "suppressed_window",
+];
+
+/**
+ * The hourly heartbeat of the reengagement cron, for the current window only.
+ *
+ * The push table above it counts sends, and a week of zero sends has two very
+ * different causes that it cannot tell apart: a cron that stopped running, and
+ * a cron that ran every hour and found everybody already inside their weekly
+ * floor. This row is what separates them. No rows at all means the job did not
+ * report, a last run inside the hour with a large floor means the cadence is
+ * holding people back on purpose.
+ *
+ * `argMax` reads the latest run rather than an average of the window, because
+ * the floor is a level and not a flow: averaging it across a week describes a
+ * population that no longer exists. The two sums beside it are flows, so they
+ * are summed over the same seven days the rest of the readout uses.
+ *
+ * One window and no comparison. The previous week of a heartbeat is the push
+ * table's job; this one answers "is it alive right now, and what did it see".
+ */
+export function buildReengagementCronQuery(windows) {
+  const candidates = numericProperty("candidates");
+  const sent = numericProperty("sent");
+  const floor = numericProperty("users_in_weekly_floor");
+  const suppressed = CRON_SUPPRESSION_PROPERTIES.map(
+    (property) => `ifNull(${numericProperty(property)}, 0)`,
+  ).join(" + ");
+
+  return [
+    "SELECT",
+    "  count() AS runs,",
+    "  max(timestamp) AS last_run_at,",
+    `  argMax(${floor}, timestamp) AS last_users_in_weekly_floor,`,
+    `  argMax(${candidates}, timestamp) AS last_candidates,`,
+    `  argMax(${sent}, timestamp) AS last_sent,`,
+    `  argMax(${suppressed}, timestamp) AS last_suppressed,`,
+    `  sum(${candidates}) AS candidates,`,
+    `  sum(${sent}) AS sent`,
+    "FROM events",
+    `WHERE timestamp >= toDateTime(${quote(clickhouseTime(windows.currentStart))}, 'UTC')`,
+    `  AND timestamp < toDateTime(${quote(clickhouseTime(windows.currentEnd))}, 'UTC')`,
+    `  AND event = ${quote(EVENTS.REENGAGEMENT_CRON_RAN)}`,
+  ].join("\n");
+}
+
+/**
  * The four tiers a card can come from, in the order the deck falls back
  * through them.
  *

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   BREAKDOWNS,
   CITY_TABLE_ROWS,
+  CRON_SUPPRESSION_PROPERTIES,
   CITY_UNKNOWN_BUCKET,
   CLIENT_LIBS,
   COUNTED_EVENTS,
@@ -22,6 +23,7 @@ import {
   buildBreakdownQuery,
   buildDeckSupplyQuery,
   buildPushAttributedReturnsQuery,
+  buildReengagementCronQuery,
   buildTotalsQuery,
   buildWindows,
   quote,
@@ -552,4 +554,58 @@ test("the update split reads one window and only the app", () => {
   assert.match(query, /properties\.\$lib = 'posthog-react-native'/);
   assert.equal(query.includes("'web'"), false);
   assert.match(query, /event NOT IN \('Deck Served'/);
+});
+
+test("the cron heartbeat reads the latest run and the window sums", () => {
+  const query = buildReengagementCronQuery(buildWindows(NOW));
+  assert.match(query, /AND event = 'Reengagement Cron Ran'/);
+  assert.match(query, /count\(\) AS runs/);
+  assert.match(query, /max\(timestamp\) AS last_run_at/);
+  // The floor is a level, so the latest value is the only honest one to print.
+  assert.match(
+    query,
+    /argMax\(toFloat64OrNull\(toString\(properties\.users_in_weekly_floor\)\), timestamp\) AS last_users_in_weekly_floor/,
+  );
+  assert.match(
+    query,
+    /argMax\(.+properties\.candidates.+\) AS last_candidates/,
+  );
+  assert.match(query, /argMax\(.+properties\.sent.+\) AS last_sent/);
+  // Candidates and sends are flows, so they are summed over the same week.
+  assert.match(
+    query,
+    /sum\(toFloat64OrNull\(toString\(properties\.candidates\)\)\) AS candidates/,
+  );
+  assert.match(
+    query,
+    /sum\(toFloat64OrNull\(toString\(properties\.sent\)\)\) AS sent/,
+  );
+});
+
+test("the cron heartbeat adds up every suppression reason the event carries", () => {
+  const query = buildReengagementCronQuery(buildWindows(NOW));
+  assert.deepEqual(CRON_SUPPRESSION_PROPERTIES, [
+    "suppressed_cooldown",
+    "suppressed_dead_token",
+    "suppressed_gave_up",
+    "suppressed_monthly_cap",
+    "suppressed_window",
+  ]);
+  for (const property of CRON_SUPPRESSION_PROPERTIES) {
+    assert.match(query, new RegExp(`properties\\.${property}`));
+  }
+  // A run that never carried one of them is a zero rather than a null that
+  // would swallow the whole sum.
+  assert.match(query, /ifNull\(toFloat64OrNull/);
+});
+
+test("the cron heartbeat reads one window and no comparison", () => {
+  const query = buildReengagementCronQuery(buildWindows(NOW));
+  assert.match(
+    query,
+    /timestamp >= toDateTime\('2026-08-26 12:00:00', 'UTC'\)/,
+  );
+  assert.match(query, /timestamp < toDateTime\('2026-09-02 12:00:00', 'UTC'\)/);
+  assert.equal(query.includes("'current', 'previous'"), false);
+  assert.equal(query.includes("GROUP BY"), false);
 });

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -16,6 +16,7 @@ import {
   PUSH_RETURN_WINDOW_MINUTES,
   STORE_BUILD_COVERAGE,
 } from "./queries.mjs";
+import { utcMoment, utcStamp } from "./timestamps.mjs";
 
 export const COMMENT_MARKER = "<!-- pegada-daily-metrics -->";
 
@@ -23,10 +24,6 @@ const MAX_BREAKDOWN_ROWS = 12;
 
 function number(value) {
   return Number(value ?? 0).toLocaleString("en-US");
-}
-
-function utcStamp(date) {
-  return `${date.toISOString().slice(0, 16).replace("T", " ")} UTC`;
 }
 
 /**
@@ -268,29 +265,6 @@ function breakdownTable(
 const MAX_OTA_ROWS = 12;
 
 /**
- * `min(timestamp)` comes back in whatever shape the transport chose: a string
- * from the query API, a `Date` from a replayed fixture. Both become the same
- * minute stamp, and anything else becomes a dash rather than `Invalid Date`.
- *
- * ClickHouse writes `2026-09-02 06:45:00` with no zone, and `new Date` reads
- * that as local time. On a machine in Sao Paulo that silently moves every row
- * three hours, which is exactly the resolution the "did it arrive today"
- * question is asked at, so the zone is spelled out before parsing.
- */
-function firstSeen(value) {
-  if (value === null || value === undefined || value === "") {
-    return "-";
-  }
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? "-" : utcStamp(value);
-  }
-  const text = String(value).trim().replace(" ", "T");
-  const zoned = /(Z|[+-]\d{2}:?\d{2})$/.test(text) ? text : `${text}Z`;
-  const date = new Date(zoned);
-  return Number.isNaN(date.getTime()) ? "-" : utcStamp(date);
-}
-
-/**
  * Which update the app is running, per runtime.
  *
  * The row that matters on a backport day is a runtime the store build is on
@@ -302,7 +276,7 @@ function firstSeen(value) {
 export function otaUpdatesTable(rows, { limit = MAX_OTA_ROWS } = {}) {
   const ordered = (rows ?? [])
     .map((row) => ({
-      firstSeen: firstSeen(row.first_seen),
+      firstSeen: utcMoment(row.first_seen),
       launchedFrom: row.launched_from || OTA_UNKNOWN_BUCKET,
       people: Number(row.people ?? 0),
       runtime: row.runtime_version || OTA_UNKNOWN_BUCKET,
@@ -327,6 +301,64 @@ export function otaUpdatesTable(rows, { limit = MAX_OTA_ROWS } = {}) {
       (row) =>
         `| ${row.runtime} | ${row.update} | ${row.launchedFrom} | ${number(row.people)} | ${row.firstSeen} |`,
     ),
+  ].join("\n");
+}
+
+/**
+ * What an empty heartbeat means, which is the one reading the table cannot
+ * print as a number.
+ *
+ * The cron reports one row an hour whatever it decides, so no rows at all is
+ * the job itself rather than a week when nobody was due a nudge.
+ */
+export const CRON_SILENT_LINE =
+  "No cron run reported in the last 7 days. The job sends one row an hour whatever it decides, so nothing here is the cron rather than a quiet week.";
+
+/**
+ * What the readings mean, said once under the table.
+ *
+ * The point of the whole section is that the push rows above it can read zero
+ * for two opposite reasons, so the note names both rather than leaving the
+ * reader to work out which one they are looking at.
+ */
+export const CRON_SOURCE_NOTE =
+  "The cron reports one row an hour. Users in weekly floor is how many people had already been notified inside the last week when it last ran, and they are never candidates, so a large floor next to zero sends is the cadence holding people rather than a broken job. A last run several hours old is the job.";
+
+/**
+ * The reengagement cron heartbeat.
+ *
+ * The last run rather than a window average, because the floor is a level: the
+ * count of people it was holding on Tuesday says nothing about today. The two
+ * sums beside it are flows, so they cover the same seven days as everything
+ * else in the readout.
+ */
+export function reengagementCronTable(rows) {
+  const row = rows?.[0];
+  const runs = Number(row?.runs ?? 0);
+  if (!row || runs === 0) {
+    return CRON_SILENT_LINE;
+  }
+
+  // The counts cross the wire as JSON and come back through `sum`, so they
+  // arrive as floats. They are counts of people, so they are printed as whole
+  // numbers rather than with a stray decimal.
+  const count = (value) => number(Math.round(Number(value ?? 0)));
+
+  const readings = [
+    ["Last run", utcMoment(row.last_run_at)],
+    ["Runs in the last 7 days", number(runs)],
+    ["Users in weekly floor (last run)", count(row.last_users_in_weekly_floor)],
+    ["Candidates (last run)", count(row.last_candidates)],
+    ["Sent (last run)", count(row.last_sent)],
+    ["Suppressed (last run)", count(row.last_suppressed)],
+    ["Candidates (last 7 days)", count(row.candidates)],
+    ["Sent (last 7 days)", count(row.sent)],
+  ];
+
+  return [
+    "| Reading | Value |",
+    "| --- | ---: |",
+    ...readings.map(([label, value]) => `| ${label} | ${value} |`),
   ].join("\n");
 }
 
@@ -375,6 +407,7 @@ export function noCityLine(rows, activeCurrent, activePrevious) {
  * @param {Array} input.activeUsersByCity rows from the city split
  * @param {Array} input.activeUsersByVersion rows from the version split
  * @param {Record<string, Array>} input.breakdowns rows per breakdown id
+ * @param {Array} input.cronRun the one row heartbeat of the reengagement cron
  * @param {Array} input.deckSupply rows from the deck supply query, one per window
  * @param {Date} input.generatedAt when the job ran
  * @param {Array} input.otaUpdates rows from the over the air update split
@@ -387,6 +420,7 @@ export function buildReport({
   activeUsersByCity,
   activeUsersByVersion,
   breakdowns,
+  cronRun = [],
   deckSupply,
   generatedAt,
   otaUpdates,
@@ -575,6 +609,12 @@ export function buildReport({
     "### Push",
     "",
     push,
+    "",
+    "#### Reengagement cron",
+    "",
+    reengagementCronTable(cronRun),
+    "",
+    CRON_SOURCE_NOTE,
     "",
     coverageNote(),
     "",

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -5,6 +5,8 @@ import { STORE_BUILD_COVERAGE, buildWindows } from "./queries.mjs";
 import {
   CITY_SOURCE_NOTE,
   COMMENT_MARKER,
+  CRON_SILENT_LINE,
+  CRON_SOURCE_NOTE,
   OTA_SOURCE_NOTE,
   buildReport,
   coverageNote,
@@ -12,6 +14,7 @@ import {
   formatDelta,
   formatRateDelta,
   noCityLine,
+  reengagementCronTable,
 } from "./report.mjs";
 
 const NOW = new Date("2026-09-02T12:00:00.000Z");
@@ -195,6 +198,18 @@ const FIXTURE = {
       ["error", "current", 1],
     ]),
   },
+  cronRun: [
+    {
+      candidates: 24,
+      last_candidates: 3,
+      last_run_at: "2026-09-02 11:00:00",
+      last_sent: 1,
+      last_suppressed: 2,
+      last_users_in_weekly_floor: 512,
+      runs: 168,
+      sent: 9,
+    },
+  ],
   deckSupply: deck([
     ["current", 100, 840, 1000, 700, 90, 30, 20, 40],
     ["previous", 80, 560, 800, 560, 0, 0, 0, 48],
@@ -760,4 +775,68 @@ test("a week with no app events says so instead of rendering an empty update tab
 test("the update table survives a run made before the query existed", () => {
   const body = buildReport({ ...FIXTURE, otaUpdates: undefined });
   assert.ok(body.includes("No app events in the last 7 days."));
+});
+
+test("the cron heartbeat prints the latest run beside the window sums", () => {
+  const body = buildReport(FIXTURE);
+  assert.match(body, /#### Reengagement cron/);
+  assert.match(body, /\| Last run \| 2026-09-02 11:00 UTC \|/);
+  assert.match(body, /\| Runs in the last 7 days \| 168 \|/);
+  assert.match(body, /\| Users in weekly floor \(last run\) \| 512 \|/);
+  assert.match(body, /\| Candidates \(last run\) \| 3 \|/);
+  assert.match(body, /\| Sent \(last run\) \| 1 \|/);
+  assert.match(body, /\| Suppressed \(last run\) \| 2 \|/);
+  assert.match(body, /\| Candidates \(last 7 days\) \| 24 \|/);
+  assert.match(body, /\| Sent \(last 7 days\) \| 9 \|/);
+  assert.equal(body.includes(CRON_SOURCE_NOTE), true);
+});
+
+test("the cron heartbeat sits under the push table and above the coverage note", () => {
+  const body = buildReport(FIXTURE);
+  assert.equal(
+    body.indexOf("| Push attributed return rate") <
+      body.indexOf("#### Reengagement cron"),
+    true,
+  );
+  assert.equal(
+    body.indexOf("#### Reengagement cron") < body.indexOf("Coverage note:"),
+    true,
+  );
+});
+
+test("a week with no cron run says the job is the reason, not the week", () => {
+  const body = buildReport({ ...FIXTURE, cronRun: [] });
+  assert.equal(body.includes(CRON_SILENT_LINE), true);
+  assert.equal(body.includes("| Last run |"), false);
+});
+
+test("a heartbeat that reports no runs reads the same as no heartbeat", () => {
+  assert.equal(reengagementCronTable([{ runs: 0 }]), CRON_SILENT_LINE);
+  assert.equal(reengagementCronTable(), CRON_SILENT_LINE);
+});
+
+test("the sums arrive as floats and print as whole people", () => {
+  const table = reengagementCronTable([
+    {
+      candidates: 1240,
+      last_run_at: new Date("2026-09-02T11:30:00.000Z"),
+      last_sent: null,
+      last_users_in_weekly_floor: 512,
+      runs: 168,
+      sent: 9,
+    },
+  ]);
+  assert.match(table, /\| Candidates \(last 7 days\) \| 1,240 \|/);
+  // A run that carried nothing for a reading is a zero, not a blank cell.
+  assert.match(table, /\| Sent \(last run\) \| 0 \|/);
+  assert.match(table, /\| Last run \| 2026-09-02 11:30 UTC \|/);
+});
+
+test("a run timestamp with no zone on it is read as UTC", () => {
+  // ClickHouse sends `2026-09-02 11:00:00` with no zone, and reading that as
+  // local time moves every row by the machine's offset.
+  const table = reengagementCronTable([
+    { last_run_at: "2026-09-02 11:00:00", runs: 1 },
+  ]);
+  assert.match(table, /\| Last run \| 2026-09-02 11:00 UTC \|/);
 });

--- a/scripts/metrics/timestamps.mjs
+++ b/scripts/metrics/timestamps.mjs
@@ -1,0 +1,44 @@
+/**
+ * Timestamps, shared by both readouts.
+ *
+ * The daily readout and the events audit both print ClickHouse timestamps, and
+ * both have to survive the same two shapes: the string the query API returns
+ * and the `Date` a replayed fixture carries. Parsing them in one place is what
+ * stops the zone handling below from being fixed in one readout and left wrong
+ * in the other.
+ */
+
+/** What a column with no timestamp in it prints, instead of `Invalid Date`. */
+export const NO_TIMESTAMP = "-";
+
+/** `2026-09-04 12:03 UTC`, the only stamp shape either readout prints. */
+export function utcStamp(date) {
+  return `${date.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
+
+/**
+ * A ClickHouse timestamp as a `Date`, or null when there is nothing to read.
+ *
+ * ClickHouse writes `2026-09-02 06:45:00` with no zone, and `new Date` reads
+ * that as local time. On a machine in Sao Paulo that silently moves every row
+ * three hours, which is exactly the resolution the "did it arrive today"
+ * question is asked at, so the zone is spelled out before parsing.
+ */
+export function parseTimestamp(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  const text = String(value).trim().replace(" ", "T");
+  const zoned = /(Z|[+-]\d{2}:?\d{2})$/.test(text) ? text : `${text}Z`;
+  const date = new Date(zoned);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** The same value as a minute stamp, or a dash when it cannot be read. */
+export function utcMoment(value) {
+  const date = parseTimestamp(value);
+  return date === null ? NO_TIMESTAMP : utcStamp(date);
+}


### PR DESCRIPTION
## Summary

The daily readout now shows the reengagement cron heartbeat under the push table, so a week of zero sends reads as the cadence holding people inside their week rather than as a dead job.
The events audit now dates every exception group and marks the ones nobody had seen a day ago, so a bug that was fixed on Monday stops looking unchanged inside a seven day window.

## Details

- Daily readout, push section: a new `Reengagement cron` block built from the hourly `Reengagement Cron Ran` server event. It prints the latest run in the window (time, users in weekly floor, candidates, sent, suppressed) beside the run count and the seven day sums of candidates and sent.
- The floor is read with `argMax` on the latest run rather than averaged, because it is a level and not a flow: how many people it was holding on Tuesday says nothing about today. Candidates and sends are flows, so they are summed over the same seven days as the rest of the readout.
- Suppressed on the run row adds up the five reasons the event carries. The split already has a table of its own further down, so the run row only answers how much of the run was held back.
- A window with no rows at all prints a line saying the job did not report, which is the one case the table cannot say with a number. The cron sends a row every hour whatever it decides, so silence is the job rather than a quiet week.
- Events audit, exceptions: the query now brings back `min(timestamp)` and `max(timestamp)` per group, and the table gained First seen and Last seen columns to the minute in UTC. A group first seen inside the last 24 hours is marked `(new)`.
- ClickHouse sends timestamps with no zone on them. Reading one as local time moves it by the machine offset, which is enough to push a group in or out of the last day, so the parsing is shared in one place now and both readouts use it.
- Which metric this moves: none directly. It is the readout that decides whether the push cadence and the crash list are worth acting on, and both were unreadable in the two cases above. Read on issue #188 after the next scheduled run.

## Testing steps

Open the tracking issue and look at the daily metrics comment. Under the push numbers there is now a small reengagement cron block giving the time of the last run, how many people were inside their week when it ran, and what that run and the whole week handed out. If the job has not reported at all, a line says so in plain words instead of leaving an empty table.
Then open the events audit comment and scroll to the exception list. Every row now says when that fault was first and last seen, and anything that turned up in the last day is marked as new. A fault that stopped happening a few days ago now shows an old last seen date instead of looking exactly like one still happening today.

## Screenshots

Both readouts are markdown comments, so the samples below are the rendered output.

Daily readout, the new block under the push table:

```markdown
#### Reengagement cron

| Reading | Value |
| --- | ---: |
| Last run | 2026-09-06 11:00 UTC |
| Runs in the last 7 days | 168 |
| Users in weekly floor (last run) | 512 |
| Candidates (last run) | 0 |
| Sent (last run) | 0 |
| Suppressed (last run) | 0 |
| Candidates (last 7 days) | 24 |
| Sent (last 7 days) | 9 |

The cron reports one row an hour. Users in weekly floor is how many people had already been notified inside the last week when it last ran, and they are never candidates, so a large floor next to zero sends is the cadence holding people rather than a broken job. A last run several hours old is the job.
```

The same block when the job itself stopped reporting:

```markdown
#### Reengagement cron

No cron run reported in the last 7 days. The job sends one row an hour whatever it decides, so nothing here is the cron rather than a quiet week.
```

Events audit, the exception table with both ends of each group:

```markdown
| Type | Message | Frame | Events | People | Library | App version | First seen | Last seen |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `TypeError` | `undefined is not an object (evaluating 'dog.photos[0].url')` | `DogCard in src/components/DogCard.tsx` | 31 | 14 | mobile | `1.6.2, 1.7.2` | 2026-08-28 13:20 UTC | 2026-09-04 11:50 UTC |
| `PrismaClientKnownRequestError` | `Timed out fetching a new connection from the connection pool` | `listDogs in packages/api/src/router/dog.ts` | 12 | 6 | server | n/a | 2026-08-29 02:05 UTC | 2026-08-31 07:10 UTC |
| `Error` | `` Request failed \| GET /api/trpc/dog.list status `500` `` | n/a | 5 | 3 | server, mobile | `1.6.2` | 2026-09-04 06:30 UTC (new) | 2026-09-04 11:00 UTC |
```

The middle row is the case that motivated this: twelve events still inside the seven day total, but nothing since 31 August, so it is a fault that stopped.
