### PR TITLE
feat(api): make the free daily like limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,8 +86,8 @@ APPLE_MAGIC_EMAIL=
 APPLE_MAGIC_CODE=
 
 # How many likes a free account gets in a rolling 24 hours. Optional: unset,
-# blank or unreadable keeps the value the app ships with. Read per request, so
-# changing it takes effect without a deploy.
+# blank or unreadable keeps the value the app ships with. Parsed once at boot
+# like every other variable here, so a change takes effect on the next deploy.
 FREE_DAILY_LIKE_LIMIT=
 
 # Maestro E2E — set to "1" ONLY for the E2E suite (CI). Unlocks the

--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,11 @@ POSTHOG_CLI_PROJECT_ID=
 APPLE_MAGIC_EMAIL=
 APPLE_MAGIC_CODE=
 
+# How many likes a free account gets in a rolling 24 hours. Optional: unset,
+# blank or unreadable keeps the value the app ships with. Read per request, so
+# changing it takes effect without a deploy.
+FREE_DAILY_LIKE_LIMIT=
+
 # Maestro E2E — set to "1" ONLY for the E2E suite (CI). Unlocks the
 # dev-only payment.maestroGrantPremium tRPC mutation used by
 # apps/mobile/.maestro/25-upgrade-journey.yaml. Refuses to run in

--- a/apps/mobile/src/components/LikeLimitReached/index.tsx
+++ b/apps/mobile/src/components/LikeLimitReached/index.tsx
@@ -22,11 +22,13 @@ import {
 import { CloseIcon, styles as pickerStyles } from "@/components/Picker/styles";
 import { Text } from "@/components/text";
 import { analytics } from "@/services/analytics";
+import { getFreeDailyLikeLimit } from "@/services/free-daily-like-limit";
 import { SceneName } from "@/types/scene-name";
 
 import { PinnedCloseButton } from "./styles";
 
 const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
+  likeLimit = FREE_DAILY_SWIPE_LIMIT,
   likeLimitResetAt,
 }) => {
   const timeLeft = useCountdown(likeLimitResetAt);
@@ -51,7 +53,7 @@ const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
             components={{
               b: <Text key="b" fontWeight="semibold" />,
             }}
-            values={{ count: FREE_DAILY_SWIPE_LIMIT }}
+            values={{ count: likeLimit }}
           />
         </Description>
       </View>
@@ -87,12 +89,18 @@ const LikeLimitReached: React.FC<LikeLimitReachedProps> = ({
 };
 
 export const showLikeLimitReached = (props: LikeLimitReachedProps) => {
+  // Resolved once so the number in the copy and the number on the event are
+  // the same number, whichever source it came from.
+  const likeLimit = props.likeLimit ?? getFreeDailyLikeLimit();
+
   analytics.track({
     event_type: "Like Limit Reached",
     event_properties: {
-      likeLimit: FREE_DAILY_SWIPE_LIMIT,
+      likeLimit,
       likeLimitResetAt: props.likeLimitResetAt,
     },
   });
-  return magicModal.show(() => <LikeLimitReached {...props} />);
+  return magicModal.show(() => (
+    <LikeLimitReached {...props} likeLimit={likeLimit} />
+  ));
 };

--- a/apps/mobile/src/components/LikeLimitReached/use-countdown.tsx
+++ b/apps/mobile/src/components/LikeLimitReached/use-countdown.tsx
@@ -3,6 +3,11 @@ import { useEffect, useState } from "react";
 import { differenceInSeconds } from "date-fns/differenceInSeconds";
 
 export type LikeLimitReachedProps = {
+  /**
+   * The allowance the server enforced. Absent when the payload came from a
+   * server that predates the field, which falls back to the shipped default.
+   */
+  likeLimit?: number;
   likeLimitResetAt: Date;
 };
 const formatTimeLeft = (totalSeconds: number) => {

--- a/apps/mobile/src/services/force-update.ts
+++ b/apps/mobile/src/services/force-update.ts
@@ -8,6 +8,7 @@ import { router } from "expo-router";
 
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { sendError } from "@/services/error-tracking";
+import { rememberFreeDailyLikeLimit } from "@/services/free-daily-like-limit";
 import { SceneName } from "@/types/scene-name";
 
 /** The build the user is on, in the same shape the API compares against. */
@@ -60,10 +61,14 @@ export const useForceUpdateOnForeground = () => {
 
       const check = async () => {
         try {
-          const { forceUpdate, minimumSupportedVersion: minimum } =
-            await getTrcpContext().client.echo.get.query();
+          const {
+            forceUpdate,
+            freeDailyLikeLimit,
+            minimumSupportedVersion: minimum,
+          } = await getTrcpContext().client.echo.get.query();
 
           rememberMinimumSupportedVersion(minimum);
+          rememberFreeDailyLikeLimit(freeDailyLikeLimit);
 
           if (!forceUpdate) return;
 

--- a/apps/mobile/src/services/free-daily-like-limit.ts
+++ b/apps/mobile/src/services/free-daily-like-limit.ts
@@ -1,0 +1,18 @@
+import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
+
+/**
+ * The free like allowance the API last reported.
+ *
+ * The server decides this from an environment variable, so the number is
+ * allowed to change without a new build and a shipped constant is only ever a
+ * guess. It starts at the value this build was compiled with, which is the
+ * right answer until the launch query says otherwise and stays the answer on
+ * an older API that does not send the field.
+ */
+let freeDailyLikeLimit = FREE_DAILY_SWIPE_LIMIT;
+
+export const getFreeDailyLikeLimit = () => freeDailyLikeLimit;
+
+export const rememberFreeDailyLikeLimit = (limit?: number) => {
+  if (limit && limit > 0) freeDailyLikeLimit = limit;
+};

--- a/apps/mobile/src/services/get-initial-route-name.ts
+++ b/apps/mobile/src/services/get-initial-route-name.ts
@@ -7,6 +7,7 @@ import Constants from "expo-constants";
 import { getTrcpContext } from "@/contexts/trcp-context";
 import { analytics } from "@/services/analytics";
 import { rememberMinimumSupportedVersion } from "@/services/force-update";
+import { rememberFreeDailyLikeLimit } from "@/services/free-daily-like-limit";
 import { getLoggedUserID } from "@/services/get-logged-user-id";
 import { getData, StorageKeys } from "@/services/storage";
 import {
@@ -162,10 +163,15 @@ const getOfflineRouteName = async () => {
 
 const resolveInitialRouteName = async (deadline: number) => {
   try {
-    const { authenticated, forceUpdate, minimumSupportedVersion } =
-      await withTransientRetry(queryLaunchState, deadline);
+    const {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit,
+      minimumSupportedVersion,
+    } = await withTransientRetry(queryLaunchState, deadline);
 
     rememberMinimumSupportedVersion(minimumSupportedVersion);
+    rememberFreeDailyLikeLimit(freeDailyLikeLimit);
 
     if (forceUpdate) {
       return SceneName.ForceUpdate;

--- a/apps/mobile/src/store/reducers/dogs/swipe.ts
+++ b/apps/mobile/src/store/reducers/dogs/swipe.ts
@@ -21,6 +21,8 @@ type IInitialState = {
     limit: number;
     hasMore: boolean;
     lastCardId?: string;
+    /** The free like allowance the server enforced when it last said no. */
+    likeLimit?: number;
     likeLimitResetAt?: Date;
   };
 };
@@ -35,6 +37,7 @@ export const initialState: IInitialState = {
     limit: 15,
     hasMore: true,
     lastCardId: undefined,
+    likeLimit: undefined,
     likeLimitResetAt: undefined,
   },
 };
@@ -51,7 +54,11 @@ const asyncActions = createAsyncAction(
   SwipeAction.SwipeDogRequest,
   SwipeAction.SwipeDogSuccess,
   SwipeAction.SwipeDogFailure,
-)<{ id: string; swipeType: Swipe }, undefined, { likeLimitResetAt?: Date }>();
+)<
+  { id: string; swipeType: Swipe },
+  undefined,
+  { likeLimit?: number; likeLimitResetAt?: Date }
+>();
 
 const swipeBack = createAction(SwipeAction.SwipeBack)();
 
@@ -92,6 +99,7 @@ const swipeUserError = (
   { payload }: ActionType<typeof asyncActions.failure>,
 ) =>
   produce(state, (draft) => {
+    draft.config.likeLimit = payload.likeLimit;
     draft.config.likeLimitResetAt = payload.likeLimitResetAt;
 
     // We should return to the last dog if we have a failure

--- a/apps/mobile/src/store/sagas/dogs/swipe.ts
+++ b/apps/mobile/src/store/sagas/dogs/swipe.ts
@@ -33,12 +33,12 @@ const swipeUserRequest = function* ({
 
     // If the user is not premium, check if the like limit has been reached
     if (!isPremium && _swipeType !== Swipe.Dislike) {
-      const { likeLimitResetAt } = (yield select(
+      const { likeLimit, likeLimitResetAt } = (yield select(
         (state: RootReducer) => state.dogs.config,
       )) as RootReducer["dogs"]["config"];
 
       if (likeLimitResetAt && isBefore(new Date(), likeLimitResetAt)) {
-        throw new LikeLimitReachedError({ likeLimitResetAt });
+        throw new LikeLimitReachedError({ likeLimit, likeLimitResetAt });
       }
     }
 
@@ -64,12 +64,12 @@ const swipeUserRequest = function* ({
   } catch (error: unknown) {
     const likeLimitReachedError = getError(error, LikeLimitReachedError);
     if (likeLimitReachedError) {
-      const { likeLimitResetAt } = likeLimitReachedError;
-      showLikeLimitReached({ likeLimitResetAt });
+      const { likeLimit, likeLimitResetAt } = likeLimitReachedError;
+      showLikeLimitReached({ likeLimit, likeLimitResetAt });
       // Glanceable countdown outside the app: Dynamic Island/lock screen on
       // iOS, a (promoted) countdown notification on Android.
       yield call(startLikeLimitLiveStatus, likeLimitResetAt);
-      yield put(Actions.dogs.swipe.failure({ likeLimitResetAt }));
+      yield put(Actions.dogs.swipe.failure({ likeLimit, likeLimitResetAt }));
       return;
     }
 

--- a/packages/api/src/routes/echo.test.ts
+++ b/packages/api/src/routes/echo.test.ts
@@ -146,3 +146,22 @@ describe("echo.get force update", () => {
     });
   });
 });
+
+/**
+ * The app puts this number in front of the user, so it has to come from the
+ * same place the server enforces it rather than from whatever the build was
+ * compiled with.
+ */
+describe("echo.get free like limit", () => {
+  const shippedLimit = config.FREE_DAILY_LIKE_LIMIT;
+
+  afterEach(() => {
+    config.FREE_DAILY_LIKE_LIMIT = shippedLimit;
+  });
+
+  it("reports the limit the server is configured with", async () => {
+    config.FREE_DAILY_LIKE_LIMIT = 25;
+
+    await expect(echo({})).resolves.toMatchObject({ freeDailyLikeLimit: 25 });
+  });
+});

--- a/packages/api/src/routes/echo.ts
+++ b/packages/api/src/routes/echo.ts
@@ -20,13 +20,22 @@ export const echoRouter = createTRPCRouter({
       ctx.req.headers.get(RequestHeaders.XAppPlatform),
     ).data;
 
-    const { authenticated, forceUpdate, minimumSupportedVersion } =
-      await EchoService.get({
-        currentAppVersion,
-        platform,
-        userId: ctx.session?.user.id,
-      });
+    const {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit,
+      minimumSupportedVersion,
+    } = await EchoService.get({
+      currentAppVersion,
+      platform,
+      userId: ctx.session?.user.id,
+    });
 
-    return { authenticated, forceUpdate, minimumSupportedVersion };
+    return {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit,
+      minimumSupportedVersion,
+    };
   }),
 });

--- a/packages/api/src/routes/swipe-security.test.ts
+++ b/packages/api/src/routes/swipe-security.test.ts
@@ -11,6 +11,7 @@ import { appRouter } from "../root";
 import { DogService } from "../services/dog-service";
 import { PushNotificationService } from "../services/push-notification-service";
 import { SwipeService } from "../services/swipe-service";
+import { config } from "../shared/config";
 import { createInnerTRPCContext } from "../trpc";
 
 jest.mock("../services/push-notification-service", () => ({
@@ -299,5 +300,71 @@ it("keeps banned and self profiles out of the swipe deck and direct lookup", asy
   ).rejects.toMatchObject({
     code: "NOT_FOUND",
     message: DogUnavailableError.message,
+  });
+});
+
+/**
+ * The ceiling is an environment variable so it can be moved without a deploy,
+ * which only helps if the swipe path reads it per request. Both cases run the
+ * real mutation rather than a stubbed quota, because the number has to hold at
+ * the point where a like is actually written.
+ */
+describe("the configured free like limit", () => {
+  const shippedLimit = config.FREE_DAILY_LIKE_LIMIT;
+
+  afterEach(() => {
+    config.FREE_DAILY_LIKE_LIMIT = shippedLimit;
+  });
+
+  /** Likes exactly `limit` dogs, and hands back one more nobody has liked. */
+  const likeUpToTheCeiling = async (limit: number) => {
+    config.FREE_DAILY_LIKE_LIMIT = limit;
+
+    const requester = await generateFakeUserWithDog();
+    const targets = await Promise.all(
+      Array.from({ length: limit + 1 }, () => generateFakeUserWithDog()),
+    );
+    const caller = callerFor(requester.user.id);
+
+    for (const { dog } of targets.slice(0, limit)) {
+      // Sequential on purpose: the point is the count, not concurrency.
+      // eslint-disable-next-line no-await-in-loop
+      await caller.swipe.swipe({ id: dog.id, swipeType: "INTERESTED" });
+    }
+
+    return { caller, oneMore: targets[limit]!, requester };
+  };
+
+  it("refuses the fourth like when the ceiling is three", async () => {
+    const { caller, oneMore, requester } = await likeUpToTheCeiling(3);
+
+    await expect(
+      caller.swipe.swipe({ id: oneMore.dog.id, swipeType: "INTERESTED" }),
+    ).rejects.toMatchObject({ code: "TOO_MANY_REQUESTS", likeLimit: 3 });
+
+    await expect(
+      prisma.interest.count({ where: { requesterId: requester.dog.id } }),
+    ).resolves.toBe(3);
+  });
+
+  it("lets six through, and refuses the seventh, when the ceiling is six", async () => {
+    const { caller, oneMore, requester } = await likeUpToTheCeiling(6);
+
+    await expect(
+      caller.swipe.swipe({ id: oneMore.dog.id, swipeType: "INTERESTED" }),
+    ).rejects.toMatchObject({ code: "TOO_MANY_REQUESTS", likeLimit: 6 });
+
+    await expect(
+      prisma.interest.count({ where: { requesterId: requester.dog.id } }),
+    ).resolves.toBe(6);
+  });
+
+  it("reports the configured ceiling on the remaining quota", async () => {
+    config.FREE_DAILY_LIKE_LIMIT = 25;
+    const { user } = await generateFakeUserWithDog();
+
+    await expect(
+      new SwipeService({}).getRemainingDailyLikes({ userId: user.id }),
+    ).resolves.toMatchObject({ likeLimit: 25, remainingSwipes: 25 });
   });
 });

--- a/packages/api/src/routes/swipe-security.test.ts
+++ b/packages/api/src/routes/swipe-security.test.ts
@@ -304,10 +304,10 @@ it("keeps banned and self profiles out of the swipe deck and direct lookup", asy
 });
 
 /**
- * The ceiling is an environment variable so it can be moved without a deploy,
- * which only helps if the swipe path reads it per request. Both cases run the
- * real mutation rather than a stubbed quota, because the number has to hold at
- * the point where a like is actually written.
+ * The ceiling is an environment variable, parsed once at boot, so it reaches
+ * the swipe path on the next deploy. Both cases run the real mutation rather
+ * than a stubbed quota, because the number has to hold at the point where a
+ * like is actually written.
  */
 describe("the configured free like limit", () => {
   const shippedLimit = config.FREE_DAILY_LIKE_LIMIT;

--- a/packages/api/src/services/echo-service.ts
+++ b/packages/api/src/services/echo-service.ts
@@ -62,6 +62,14 @@ export class EchoService {
       authenticated = Boolean(user);
     }
 
-    return { authenticated, forceUpdate, minimumSupportedVersion };
+    // The like allowance rides along on the query every launch already waits
+    // on, so the number the app puts on screen is the number the server will
+    // actually enforce, without a second round trip or a new deploy.
+    return {
+      authenticated,
+      forceUpdate,
+      freeDailyLikeLimit: config.FREE_DAILY_LIKE_LIMIT,
+      minimumSupportedVersion,
+    };
   }
 }

--- a/packages/api/src/services/echo-service.ts
+++ b/packages/api/src/services/echo-service.ts
@@ -64,7 +64,7 @@ export class EchoService {
 
     // The like allowance rides along on the query every launch already waits
     // on, so the number the app puts on screen is the number the server will
-    // actually enforce, without a second round trip or a new deploy.
+    // actually enforce, without a second round trip or a new app build.
     return {
       authenticated,
       forceUpdate,

--- a/packages/api/src/services/swipe-service.ts
+++ b/packages/api/src/services/swipe-service.ts
@@ -3,7 +3,6 @@ import type { Language } from "@pegada/shared/i18n/types/types";
 import type { Prisma } from "@prisma/client";
 
 import prisma from "@pegada/database";
-import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
 import {
   AccountBlockedError,
   DogUnavailableError,
@@ -15,6 +14,7 @@ import { addDays } from "date-fns/addDays";
 import { subDays } from "date-fns/subDays";
 
 import { sendError } from "../errors/errors";
+import { config } from "../shared/config";
 import MatchService from "./match-service";
 import { PushNotificationService } from "./push-notification-service";
 import { TranslationService } from "./translation-service";
@@ -86,8 +86,14 @@ export class SwipeService {
 
     if (!user) throw new AccountBlockedError();
 
+    // Read at call time, not at import time, so changing the environment
+    // variable takes effect on the next request instead of the next deploy.
+    const likeLimit = config.FREE_DAILY_LIKE_LIMIT;
+
     // Only apply daily swipe limit to free users
-    if (user.plan !== PlanType.FREE) return { remainingSwipes: Infinity };
+    if (user.plan !== PlanType.FREE) {
+      return { likeLimit, remainingSwipes: Infinity };
+    }
 
     const windowStart = subDays(new Date(), 1);
     const dailyLikeCount = await db.interest.findMany({
@@ -97,18 +103,19 @@ export class SwipeService {
       },
       orderBy: { lastPositiveAt: "desc" },
       select: { lastPositiveAt: true },
-      take: FREE_DAILY_SWIPE_LIMIT,
+      take: likeLimit,
     });
 
-    const remainingSwipes = FREE_DAILY_SWIPE_LIMIT - dailyLikeCount.length;
+    const remainingSwipes = likeLimit - dailyLikeCount.length;
 
-    if (remainingSwipes > 0) return { remainingSwipes };
+    if (remainingSwipes > 0) return { likeLimit, remainingSwipes };
 
     // If the user has reached their daily swipe limit, return the time at which the limit will reset
     const oldestLike = dailyLikeCount.at(-1);
-    if (!oldestLike?.lastPositiveAt) return { remainingSwipes };
+    if (!oldestLike?.lastPositiveAt) return { likeLimit, remainingSwipes };
 
     return {
+      likeLimit,
       remainingSwipes,
       likeLimitResetAt: addDays(oldestLike.lastPositiveAt, 1),
     };
@@ -194,6 +201,7 @@ export class SwipeService {
 
             if (remainingDailyLikes.likeLimitResetAt) {
               throw new LikeLimitReachedError({
+                likeLimit: remainingDailyLikes.likeLimit,
                 likeLimitResetAt: remainingDailyLikes.likeLimitResetAt,
               });
             }

--- a/packages/api/src/services/swipe-service.ts
+++ b/packages/api/src/services/swipe-service.ts
@@ -86,8 +86,10 @@ export class SwipeService {
 
     if (!user) throw new AccountBlockedError();
 
-    // Read at call time, not at import time, so changing the environment
-    // variable takes effect on the next request instead of the next deploy.
+    // Read off `config` here rather than captured at module scope, so a test
+    // can move the ceiling the same way an operator moves the variable. The
+    // environment itself is parsed once at boot, so a change to the variable
+    // reaches this line on the next deploy.
     const likeLimit = config.FREE_DAILY_LIKE_LIMIT;
 
     // Only apply daily swipe limit to free users

--- a/packages/api/src/shared/config.test.ts
+++ b/packages/api/src/shared/config.test.ts
@@ -1,0 +1,35 @@
+import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
+
+import { freeDailyLikeLimitSchema } from "./config";
+
+/**
+ * This value gates whether a swipe is accepted, and it is typed into a hosting
+ * dashboard by hand. Every shape a person can leave in that box has to resolve
+ * to a usable number, because the alternative is an API that will not boot.
+ */
+describe("FREE_DAILY_LIKE_LIMIT parsing", () => {
+  it("takes the number an operator set", () => {
+    expect(freeDailyLikeLimitSchema.parse("25")).toBe(25);
+    expect(freeDailyLikeLimitSchema.parse("1")).toBe(1);
+  });
+
+  it("keeps the shipped default when the variable is not set", () => {
+    expect(freeDailyLikeLimitSchema.parse(undefined)).toBe(
+      FREE_DAILY_SWIPE_LIMIT,
+    );
+  });
+
+  // Clearing the box is how someone turns the experiment off on a host that
+  // keeps a variable once it has been added.
+  it("treats a blank value as unset", () => {
+    expect(freeDailyLikeLimitSchema.parse("")).toBe(FREE_DAILY_SWIPE_LIMIT);
+  });
+
+  it("falls back instead of throwing on a value it cannot use", () => {
+    for (const value of ["abc", "0", "-5", "2.5", null, {}, "1e999"]) {
+      expect(freeDailyLikeLimitSchema.parse(value)).toBe(
+        FREE_DAILY_SWIPE_LIMIT,
+      );
+    }
+  });
+});

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -1,3 +1,4 @@
+import { FREE_DAILY_SWIPE_LIMIT } from "@pegada/shared/constants/constants";
 import semver from "semver";
 import { z } from "zod";
 
@@ -25,6 +26,24 @@ export const optionalSemverSchema = z.preprocess(
   (value) => (value === "" ? undefined : value),
   semverSchema.optional(),
 );
+
+/**
+ * How many likes a free account gets in a rolling 24 hours.
+ *
+ * Never throws. This number decides whether a swipe is accepted, and an
+ * operator fat fingering the variable must not take the whole API down at
+ * boot: anything that is not a positive whole number falls back to the value
+ * the app has always used. Blank counts as unset for the same reason the
+ * version floors do, because Vercel keeps a variable once it has been added
+ * and clearing the box is how someone puts the default back.
+ */
+export const freeDailyLikeLimitSchema = z
+  .preprocess(
+    (value) => (value === "" ? undefined : value),
+    z.coerce.number().int().positive().optional(),
+  )
+  .catch(undefined)
+  .transform((value) => value ?? FREE_DAILY_SWIPE_LIMIT);
 
 const configSchema = z.object({
   /** GENERAL */
@@ -173,6 +192,15 @@ const configSchema = z.object({
   MIN_APP_VERSION: semverSchema,
   MIN_APP_VERSION_IOS: optionalSemverSchema,
   MIN_APP_VERSION_ANDROID: optionalSemverSchema,
+
+  /**
+   * FREE LIKES
+   *
+   * The daily like allowance for free accounts, movable without a deploy so
+   * the ceiling can be tuned against matches per swiper rather than guessed
+   * once and frozen into a build. Unset keeps the value the app shipped with.
+   */
+  FREE_DAILY_LIKE_LIMIT: freeDailyLikeLimitSchema,
 
   /**
    * APPLE MAGIC

--- a/packages/api/src/shared/config.ts
+++ b/packages/api/src/shared/config.ts
@@ -196,9 +196,10 @@ const configSchema = z.object({
   /**
    * FREE LIKES
    *
-   * The daily like allowance for free accounts, movable without a deploy so
-   * the ceiling can be tuned against matches per swiper rather than guessed
-   * once and frozen into a build. Unset keeps the value the app shipped with.
+   * The daily like allowance for free accounts, moved by an environment
+   * variable so the ceiling can be tuned against matches per swiper rather
+   * than guessed once and frozen into a shipped build. Unset keeps the value
+   * the app shipped with.
    */
   FREE_DAILY_LIKE_LIMIT: freeDailyLikeLimitSchema,
 

--- a/packages/shared/errors/errors.ts
+++ b/packages/shared/errors/errors.ts
@@ -45,12 +45,26 @@ export class InvalidOTPCodeError extends IntentionalError {
 
 export class LikeLimitReachedError extends IntentionalError {
   likeLimitResetAt: Date;
+  /**
+   * The allowance that was just used up. It travels with the error because the
+   * server decides it from an environment variable, so a build that hardcoded
+   * the old number would otherwise tell someone they liked ten dogs on a day
+   * they were allowed twenty five. Optional so a client reading a payload from
+   * a server that predates the field can fall back to the shipped default.
+   */
+  likeLimit?: number;
 
   static message = "You have reached the like limit";
   static error_code = "LIKE_LIMIT_REACHED";
   error_code = LikeLimitReachedError.error_code;
 
-  constructor({ likeLimitResetAt }: { likeLimitResetAt: Date }) {
+  constructor({
+    likeLimit,
+    likeLimitResetAt,
+  }: {
+    likeLimit?: number;
+    likeLimitResetAt: Date;
+  }) {
     super({
       code: "TOO_MANY_REQUESTS",
       message: LikeLimitReachedError.message,
@@ -58,6 +72,7 @@ export class LikeLimitReachedError extends IntentionalError {
 
     this.name = "LikeLimitReachedError";
     this.likeLimitResetAt = likeLimitResetAt;
+    this.likeLimit = likeLimit;
   }
 }
 


### PR DESCRIPTION
## Summary

Free accounts get ten likes a day, a number frozen in the code since launch. This moves it to a server setting so it can be raised, and the result read, without a new build.

## Details

- A new server setting, `FREE_DAILY_LIKE_LIMIT`, decides the daily free like allowance. Unset, blank or unreadable keeps the value the app already uses, so nothing changes until someone sets it. It never throws at boot: a bad value falls back rather than taking the API down.
- The swipe path reads the value out of the parsed environment rather than a copy captured at module scope, which is also what lets a test move the ceiling the way an operator does. The environment is read once at boot, so setting the variable in the host takes effect on the next deploy, the same as every other setting in this project.
- The number travels back with the refusal, so the limit sheet names the allowance the server actually enforced. A build that hardcoded ten would otherwise tell someone they liked ten dogs on a day they were allowed twenty five.
- The launch query reports the same number. That gives the app a value before it ever hits the wall, and gives whoever sets the variable a way to confirm what is deployed.
- `Like Limit Reached` carries the effective allowance as `likeLimit`, so the readout can tell people who hit ten apart from people who hit twenty five.
- Paid accounts are untouched. They still have no limit, and the paywall copy sells unlimited likes without naming a number.

**Hypothesis.** The free ceiling starves matches for the most engaged users without producing sales.

**Baseline** (issue #188 readout, seven days to 7 September 2026): 1,595 swipes by 18 people produced 1 match, which is 0.06 matches per swiper. The week before, the limit was hit 28 times by 6 people. Of the 6 paywall views that came from the limit, 0 converted, against 8 conversions from the swipe back trigger. The wall is stopping people who like the product and is not selling anything.

**Readout.** Matches per swiper on the daily readout, plus the count of `Like Limit Reached` split by its `likeLimit` property, and paywall views by trigger.

**Kill criterion.** After 14 days, if matches per swiper has not risen and paywall views have fallen, put the variable back to ten.

## Testing steps

1. Open the app on a free account and like dogs until the daily limit sheet appears.
2. Check that the sheet names the same number of dogs you were actually allowed to like, and that the countdown still runs.
3. Ask someone with access to the server settings to raise the free like allowance, then close and open the app again.
4. Like dogs again. You should get the new, higher number of likes before the sheet shows up, and the sheet should name that new number.
5. Sign in on a paid account and confirm it still has no limit at all.
6. Clear the setting again and confirm the app goes back to ten likes.

## Screenshots

The limit sheet with the server allowance set to three. The number in the copy is the one the server enforced, not the ten the build was compiled with.

<img src="https://raw.githubusercontent.com/GSTJ/pegada/shots/feat/configurable-free-like-limit/shots/like-limit-sheet.png" width="300" />
