### PR TITLE
fix(api): account for every reengagement candidate

### DIFF
--- a/packages/api/src/services/reengagement-candidates.ts
+++ b/packages/api/src/services/reengagement-candidates.ts
@@ -1,0 +1,629 @@
+import type { ReengagementPushKind } from "@pegada/shared/analytics/events";
+
+import prisma from "@pegada/database";
+import { Language } from "@pegada/shared/i18n/types/types";
+import { Prisma } from "@prisma/client";
+
+import { MIN_GAP_DAYS } from "./reengagement-cadence";
+import { TranslationService } from "./translation-service";
+
+/**
+ * Who the re-engagement cron could nudge right now, and why.
+ *
+ * Split from the service so the two halves can be read apart: everything here
+ * answers "who is due", and the service answers "who actually gets it". They
+ * share nothing but the `Candidate` rows that cross between them, and the
+ * split is one directional, so a selector can never reach back into the
+ * sending rules it is supposed to be independent of.
+ */
+
+/**
+ * `satisfies` rather than a bare `as const`: the catalogue restates these three
+ * values (it cannot import them without a cycle), and this is what makes a new
+ * kind added here a compile error until the catalogue knows about it too.
+ */
+export const REENGAGEMENT_KINDS = {
+  UNANSWERED_MATCH: "unanswered_match",
+  NEW_DOGS_NEARBY: "new_dogs_nearby",
+  LIKES_WAITING: "likes_waiting",
+} as const satisfies Record<string, ReengagementPushKind>;
+
+export type ReengagementKind =
+  (typeof REENGAGEMENT_KINDS)[keyof typeof REENGAGEMENT_KINDS];
+
+/** Hours after a silent match at which the two sides get nudged. */
+export const UNANSWERED_MATCH_HOURS = [24, 72] as const;
+
+/**
+ * How far back each unanswered-match bucket reaches. Without a floor, the
+ * first run after deploy would nudge every silent match ever created; with it,
+ * a match is only ever eligible inside the window that follows its own
+ * threshold.
+ */
+const UNANSWERED_MATCH_MAX_AGE_HOURS = 14 * 24;
+
+/** Days without a positive swipe that make a user eligible for new dogs. */
+export const INACTIVE_DAYS = [3, 7] as const;
+
+/**
+ * How recently someone has to have used the app to be left alone.
+ *
+ * Every selector below infers "gone quiet" from a proxy (no positive swipe, a
+ * match nobody spoke on, a like nobody answered), and each proxy misses the
+ * person who is in the app right now doing something else. `lastActiveAt` is
+ * the direct signal, written on authenticated requests, so it is the guard that
+ * keeps a win-back push off the screen of someone who never left.
+ */
+export const RECENT_ACTIVITY_HOURS = 24;
+
+/** New dogs that have to exist nearby before the nudge is worth sending. */
+export const MIN_NEW_DOGS = 3;
+
+/** How old a like has to be before it counts as waiting. */
+const LIKES_WAITING_HOURS = 24;
+
+/**
+ * When a user has never swiped positively there is no anchor to count new dogs
+ * from, so the count starts here instead.
+ *
+ * This doubles as how often that cohort may be nudged again. Every other user
+ * is rate limited by their own anchor moving, which needs them to do something;
+ * someone who has never swiped has nothing that moves, so without a period in
+ * the key they would be a one-time audience forever. A calendar-aligned bucket
+ * rather than a sliding window, because the dedupe key has to name the same
+ * period the already-sent filter is testing.
+ */
+const NEW_DOGS_FALLBACK_WINDOW_DAYS = 30;
+
+/**
+ * Above this, `preferredMaxDistance` means "anywhere" and no distance filter
+ * is applied. Same threshold the swipe deck uses in SuggestionService, so the
+ * count in the copy matches the deck the user lands on.
+ */
+const UNLIMITED_DISTANCE_KM = 295;
+
+/**
+ * Bounds one invocation so a backlog cannot outrun the function budget.
+ *
+ * Worth reading next to {@link SEND_WINDOW_HOURS}: a user is only eligible in
+ * two of the twenty four runs a day, and Brazil is one offset, so the whole
+ * base shares those two runs and the real daily ceiling is twice this number.
+ * The 200 the incident sent was this cap being hit, so a backlog does exist.
+ * Raise this before widening the window if the queue stops draining.
+ */
+export const MAX_CANDIDATES_PER_QUERY = 500;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export type Candidate = {
+  kind: ReengagementKind;
+  userId: string;
+  pushToken: string;
+  longitude: number | null;
+  dedupeKey: string;
+  title: string;
+  body: string;
+  url: string;
+  /** Set on the "tell me when a new dog shows up" path, cleared once sent. */
+  clearsNewDogsAlert?: boolean;
+};
+
+/**
+ * The instant before which a user counts as away.
+ *
+ * A null `lastActiveAt` is unknown rather than active: the column is only
+ * written once a user makes an authenticated request after #217 shipped, so
+ * reading null as "here" would mute the whole cron until everyone came back on
+ * their own. The proxy each selector already applies decides those users.
+ */
+const recentActivityFloor = (now: Date) =>
+  new Date(now.getTime() - RECENT_ACTIVITY_HOURS * HOUR_MS);
+
+const isRecentlyActive = (lastActiveAt: Date | null, now: Date) =>
+  lastActiveAt !== null && lastActiveAt > recentActivityFloor(now);
+
+/** The same rule in SQL, for the selectors that run as raw queries. */
+const notRecentlyActive = (now: Date) => Prisma.sql`
+  (
+    "User"."lastActiveAt" IS NULL
+    OR "User"."lastActiveAt" <= ${recentActivityFloor(now)}
+  )
+`;
+
+type ReengagementCopyKey =
+  | "server:notification.reengagement.unansweredMatch.title"
+  | "server:notification.reengagement.unansweredMatch.body"
+  | "server:notification.reengagement.newDogsNearby.title"
+  | "server:notification.reengagement.newDogsNearby.body"
+  | "server:notification.reengagement.likesWaiting.title"
+  | "server:notification.reengagement.likesWaiting.body";
+
+/**
+ * The cron has no request to read a language from and `User` has no language
+ * column, so every re-engagement push goes out in pt-BR, which is where
+ * essentially all of the users are. A per-user language is the follow up, and
+ * it belongs on the model rather than being guessed at here.
+ */
+const translate = (
+  key: ReengagementCopyKey,
+  replace?: Record<string, unknown>,
+): string => TranslationService.translate(key, { lng: Language.PtBr, replace });
+
+/**
+ * A user we can actually reach.
+ *
+ * The empty string matters: `UserService.blacklistPushToken` clears a dead
+ * token by writing `""` rather than null, so `IS NOT NULL` alone would keep
+ * re-selecting users whose device has already been rejected by Expo, burning
+ * their daily cap and inflating the sent count this whole change exists to
+ * measure.
+ */
+const REACHABLE_USER = Prisma.sql`
+  "User"."deletedAt" IS NULL
+  AND "User"."pushToken" IS NOT NULL
+  AND "User"."pushToken" <> ''
+`;
+
+/**
+ * The same rule, for the one selector that goes through Prisma rather than
+ * raw SQL. Both halves are needed for the same reason the SQL needs both.
+ */
+const REACHABLE_USER_WHERE = {
+  deletedAt: null,
+  pushToken: { not: null },
+  NOT: { pushToken: "" },
+} satisfies Prisma.UserWhereInput;
+
+/**
+ * Matches that went silent, one candidate per side that can be reached.
+ *
+ * Both sides get the nudge because either of them can break the silence and
+ * neither knows the other is waiting.
+ */
+export const selectUnansweredMatchCandidates = async (
+  now: Date,
+): Promise<Candidate[]> => {
+  const buckets = await Promise.all(
+    UNANSWERED_MATCH_HOURS.map(async (hours, index) => {
+      // Each bucket stops where the next one starts, so a four day old silent
+      // match is only ever in the 72 hour bucket and never in both.
+      const upperAgeHours =
+        UNANSWERED_MATCH_HOURS[index + 1] ?? UNANSWERED_MATCH_MAX_AGE_HOURS;
+
+      const olderThan = new Date(now.getTime() - hours * HOUR_MS);
+      const newerThan = new Date(now.getTime() - upperAgeHours * HOUR_MS);
+
+      const dogSelect = {
+        id: true,
+        name: true,
+        user: {
+          select: {
+            id: true,
+            pushToken: true,
+            longitude: true,
+            lastActiveAt: true,
+          },
+        },
+      } as const;
+
+      const matches = await prisma.match.findMany({
+        where: {
+          deletedAt: null,
+          createdAt: { gte: newerThan, lt: olderThan },
+          messages: { none: { deletedAt: null } },
+          requester: {
+            deletedAt: null,
+            banned: false,
+            user: { deletedAt: null },
+          },
+          responder: {
+            deletedAt: null,
+            banned: false,
+            user: { deletedAt: null },
+          },
+          // At least one side has to still have a live token. Either side can
+          // break the silence, so a match is worth pulling for one reachable
+          // half; a match where neither device answers any more is not, and
+          // leaving it in let dead installs fill the per run candidate ceiling
+          // and pushed the reachable people behind them out of the run.
+          OR: [
+            { requester: { user: REACHABLE_USER_WHERE } },
+            { responder: { user: REACHABLE_USER_WHERE } },
+          ],
+        },
+        select: {
+          id: true,
+          requester: { select: dogSelect },
+          responder: { select: dogSelect },
+        },
+        // Newest first. The take is a ceiling on one run, and the rows most
+        // likely to be already claimed by a dedupe key are the oldest ones, so
+        // ordering the other way would let a backlog starve fresh matches.
+        orderBy: { createdAt: "desc" },
+        take: MAX_CANDIDATES_PER_QUERY,
+      });
+
+      return matches.flatMap((match) =>
+        [
+          { self: match.requester, other: match.responder },
+          { self: match.responder, other: match.requester },
+        ].flatMap(({ self, other }) =>
+          self.user.pushToken && !isRecentlyActive(self.user.lastActiveAt, now)
+            ? [
+                {
+                  kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+                  userId: self.user.id,
+                  pushToken: self.user.pushToken,
+                  longitude: self.user.longitude,
+                  dedupeKey: `${REENGAGEMENT_KINDS.UNANSWERED_MATCH}:${match.id}:${self.user.id}:${hours}h`,
+                  title: translate(
+                    "server:notification.reengagement.unansweredMatch.title",
+                    { name: other.name },
+                  ),
+                  body: translate(
+                    "server:notification.reengagement.unansweredMatch.body",
+                    { name: other.name },
+                  ),
+                  url: `chat/${match.id}/${other.id}`,
+                } satisfies Candidate,
+              ]
+            : [],
+        ),
+      );
+    }),
+  );
+
+  return buckets.flat();
+};
+
+/**
+ * Has this user liked anybody since `since`? Correlates against the enclosing
+ * query's `"User"` row, so it only composes inside the candidate select below.
+ */
+const swipedPositivelySince = (since: Date) => Prisma.sql`
+  EXISTS (
+    SELECT 1 FROM "Interest"
+    JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "Interest"."requesterId"
+    WHERE "OwnDog"."userId" = "User"."id"
+    AND "Interest"."lastPositiveAt" > ${since}
+  )
+`;
+
+type NewDogsRow = {
+  userId: string;
+  pushToken: string;
+  longitude: number | null;
+  newDogs: number;
+  requested: boolean;
+  anchor: Date | null;
+};
+
+/**
+ * Users worth pulling back into the deck, with the real number of dogs waiting
+ * for them.
+ *
+ * Two ways in, and they are mutually exclusive so nobody is selected twice.
+ * Either the user asked to be told (`newDogsAlertRequestedAt`, the fake door in
+ * #191), in which case the inactivity rule does not apply and the count is
+ * measured from the moment they asked; or they have gone quiet, in which case
+ * they land in exactly one inactivity bucket. Both still need
+ * {@link MIN_NEW_DOGS} dogs to exist: "come back, there is nothing new" is
+ * worse than silence.
+ *
+ * The dog count mirrors the swipe deck's hard filters (opposite gender, not
+ * banned or deleted, an approved image and no rejected one, inside the
+ * preferred distance, not already swiped). The deck's soft preferences (color,
+ * size, age, breed) are left out, so the number in the copy is an upper bound
+ * when a user has set those.
+ */
+export const selectNewDogsNearbyCandidates = async (
+  now: Date,
+): Promise<Candidate[]> => {
+  // Sliding, so a user who has never swiped is always shown a full window of
+  // new dogs rather than an emptier and emptier one as a period runs out.
+  const newDogsFloor = new Date(
+    now.getTime() - NEW_DOGS_FALLBACK_WINDOW_DAYS * DAY_MS,
+  );
+
+  // Quantised, and used only to decide whether that cohort has already been
+  // told this period. The dedupe key carries the same period number, so the
+  // key and the filter re-admit the user on exactly the same day.
+  const periodMs = NEW_DOGS_FALLBACK_WINDOW_DAYS * DAY_MS;
+  const period = Math.floor(now.getTime() / periodMs);
+  const periodStart = new Date(period * periodMs);
+
+  const buckets = [
+    {
+      label: "requested",
+      eligibility: Prisma.sql`"User"."newDogsAlertRequestedAt" IS NOT NULL`,
+    },
+    ...INACTIVE_DAYS.map((days, index) => {
+      const nextDays = INACTIVE_DAYS[index + 1];
+
+      // Each bucket ends where the next begins: quiet for 3 days but not yet 7
+      // is the 3 day nudge, quiet for 7 or more is the 7 day one. Without the
+      // lower bound a user who has been away a month is in both.
+      const lowerBound = nextDays
+        ? Prisma.sql`AND ${swipedPositivelySince(new Date(now.getTime() - nextDays * DAY_MS))}`
+        : Prisma.empty;
+
+      return {
+        label: `${days}d`,
+        eligibility: Prisma.sql`
+          "User"."newDogsAlertRequestedAt" IS NULL
+          AND ${notRecentlyActive(now)}
+          AND NOT ${swipedPositivelySince(new Date(now.getTime() - days * DAY_MS))}
+          ${lowerBound}
+        `,
+      };
+    }),
+  ];
+
+  const rows = await Promise.all(
+    buckets.map(({ label, eligibility }) =>
+      prisma.$queryRaw<NewDogsRow[]>`
+        WITH "candidate" AS (
+          SELECT
+            "User"."id" AS "userId",
+            "User"."pushToken" AS "pushToken",
+            "User"."longitude" AS "longitude",
+            "User"."latitude" AS "latitude",
+            ("User"."newDogsAlertRequestedAt" IS NOT NULL) AS "requested",
+            /* Count from the moment they asked, otherwise from their last
+               positive swipe, otherwise from a fixed floor. */
+            COALESCE(
+              "User"."newDogsAlertRequestedAt",
+              (
+                SELECT MAX("Interest"."lastPositiveAt")
+                FROM "Interest"
+                JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "Interest"."requesterId"
+                WHERE "OwnDog"."userId" = "User"."id"
+              )
+            ) AS "anchor",
+            /* The viewer's own dog, used for the gender rule and the distance
+               preference. */
+            (
+              SELECT "OwnDog"."id" FROM "Dog" AS "OwnDog"
+              WHERE "OwnDog"."userId" = "User"."id"
+              AND "OwnDog"."deletedAt" IS NULL AND "OwnDog"."banned" = false
+              ORDER BY "OwnDog"."createdAt" ASC LIMIT 1
+            ) AS "ownDogId"
+          FROM "User"
+          WHERE ${REACHABLE_USER}
+          AND (${eligibility})
+        )
+        SELECT
+          "candidate"."userId",
+          "candidate"."pushToken",
+          "candidate"."longitude",
+          "candidate"."requested",
+          "candidate"."anchor",
+          "counted"."newDogs"
+        FROM "candidate"
+        JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "candidate"."ownDogId"
+        CROSS JOIN LATERAL (
+          SELECT COUNT(*)::int AS "newDogs"
+          FROM "Dog"
+          JOIN "User" AS "Owner" ON "Owner"."id" = "Dog"."userId"
+          WHERE "Dog"."userId" <> "candidate"."userId"
+          AND "Dog"."deletedAt" IS NULL
+          AND "Dog"."banned" = false
+          AND "Owner"."deletedAt" IS NULL
+          AND "Dog"."createdAt" > COALESCE("candidate"."anchor", ${newDogsFloor})
+          AND "Dog"."gender" <> "OwnDog"."gender"
+          /* Shadowban gate, same shape as the deck. */
+          AND EXISTS (
+            SELECT 1 FROM "Image"
+            WHERE "Image"."dogId" = "Dog"."id"
+            AND "Image"."status" = 'APPROVED'::"ImageStatus"
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM "Image"
+            WHERE "Image"."dogId" = "Dog"."id"
+            AND "Image"."status" = 'REJECTED'::"ImageStatus"
+          )
+          /* Already swiped is already seen. */
+          AND NOT EXISTS (
+            SELECT 1 FROM "Interest"
+            WHERE "Interest"."requesterId" = "OwnDog"."id"
+            AND "Interest"."responderId" = "Dog"."id"
+          )
+          AND (
+            /* Null and zero both mean "no preference" in SuggestionService,
+               where the filter is only applied when the value is truthy.
+               Reading zero as "within zero kilometres" here would silently
+               empty the count for anyone who has it. */
+            "OwnDog"."preferredMaxDistance" IS NULL
+            OR "OwnDog"."preferredMaxDistance" <= 0
+            OR "OwnDog"."preferredMaxDistance" >= ${UNLIMITED_DISTANCE_KM}
+            OR "candidate"."latitude" IS NULL
+            OR "candidate"."longitude" IS NULL
+            OR "Owner"."latitude" IS NULL
+            OR "Owner"."longitude" IS NULL
+            OR ST_DistanceSphere(
+              ST_MakePoint("Owner"."longitude", "Owner"."latitude"),
+              ST_MakePoint("candidate"."longitude", "candidate"."latitude")
+            ) / 1000 <= "OwnDog"."preferredMaxDistance"
+          )
+        ) AS "counted"
+        WHERE "counted"."newDogs" >= ${MIN_NEW_DOGS}
+        /* Already told since the anchor last moved, so there is nothing new to
+           say. The dedupe key is built from the same anchor, which makes this a
+           faithful pre-filter rather than a second policy: it keeps users who
+           have had their nudge out of the candidate set instead of letting them
+           occupy the limit forever, and it is what stops a cleared alert
+           request from re-qualifying the user under the inactivity rule the
+           next day. */
+        AND NOT EXISTS (
+          SELECT 1 FROM "NotificationLog"
+          WHERE "NotificationLog"."userId" = "candidate"."userId"
+          AND "NotificationLog"."kind" = ${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}
+          AND "NotificationLog"."sentAt" > COALESCE("candidate"."anchor", ${periodStart})
+        )
+        /* Freshest lapsers first, for the same reason matches are ordered
+           newest first. */
+        ORDER BY "candidate"."anchor" DESC NULLS LAST
+        LIMIT ${MAX_CANDIDATES_PER_QUERY}
+      `.then((result) => ({ label, result })),
+    ),
+  );
+
+  return rows.flatMap(({ label, result }) =>
+    result.map((row) => ({
+      kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+      userId: row.userId,
+      pushToken: row.pushToken,
+      longitude: row.longitude,
+      /* Keying on the anchor is what stops the nudge repeating: it only moves
+         once the user swipes positively again or asks again. */
+      dedupeKey: `${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}:${row.userId}:${label}:${row.anchor?.toISOString() ?? `never:${period}`}`,
+      title: translate("server:notification.reengagement.newDogsNearby.title", {
+        amount: row.newDogs,
+      }),
+      body: translate("server:notification.reengagement.newDogsNearby.body"),
+      url: "swipe",
+      clearsNewDogsAlert: row.requested,
+    })),
+  );
+};
+
+type LikesWaitingRow = {
+  userId: string;
+  pushToken: string;
+  longitude: number | null;
+  dogName: string;
+  anchorId: string;
+};
+
+/**
+ * Users sitting on likes they have not answered.
+ *
+ * `Interest` has no seen flag, so "unseen" is read as "not yet reciprocated":
+ * an active like pointing at one of your dogs, older than a day, with no match
+ * and nothing back from you. That is the set worth interrupting someone over.
+ *
+ * The dedupe key is the oldest waiting like, so the nudge does not repeat
+ * until that particular like is dealt with. On its own that was not enough:
+ * a new like arriving is a new oldest-unannounced like, so a popular dormant
+ * dog produced one of these every evening. The weekly floor below is the cap
+ * that actually holds, and it is mirrored here as well as enforced in the run
+ * so those users do not sit in the candidate limit for nothing.
+ */
+export const selectLikesWaitingCandidates = async (
+  now: Date,
+): Promise<Candidate[]> => {
+  const olderThan = new Date(now.getTime() - LIKES_WAITING_HOURS * HOUR_MS);
+
+  const cooldownFloor = new Date(now.getTime() - MIN_GAP_DAYS * DAY_MS);
+
+  const rows = await prisma.$queryRaw<LikesWaitingRow[]>`
+    WITH "waiting" AS (
+      SELECT
+        "User"."id" AS "userId",
+        "User"."pushToken" AS "pushToken",
+        "User"."longitude" AS "longitude",
+        "Dog"."name" AS "dogName",
+        (ARRAY_AGG("Interest"."id" ORDER BY "Interest"."createdAt" ASC))[1] AS "anchorId",
+        MAX("Interest"."createdAt") AS "newestLikeAt"
+      FROM "User"
+      JOIN "Dog" ON "Dog"."userId" = "User"."id"
+        AND "Dog"."deletedAt" IS NULL AND "Dog"."banned" = false
+      JOIN "Interest" ON "Interest"."responderId" = "Dog"."id"
+      /* The dog doing the liking has to be one the deck would still show,
+         otherwise the push names somebody the user can never reach. */
+      JOIN "Dog" AS "Admirer" ON "Admirer"."id" = "Interest"."requesterId"
+        AND "Admirer"."deletedAt" IS NULL AND "Admirer"."banned" = false
+      JOIN "User" AS "AdmirerUser" ON "AdmirerUser"."id" = "Admirer"."userId"
+        AND "AdmirerUser"."deletedAt" IS NULL
+      WHERE ${REACHABLE_USER}
+      AND ${notRecentlyActive(now)}
+      AND "Interest"."deletedAt" IS NULL
+      AND "Interest"."matchId" IS NULL
+      AND "Interest"."swipeType" IN ('INTERESTED'::"SwipeType", 'MAYBE'::"SwipeType")
+      AND "Interest"."createdAt" < ${olderThan}
+      /* Nothing back from this dog means the like is still unanswered. */
+      AND NOT EXISTS (
+        SELECT 1 FROM "Interest" AS "Reply"
+        WHERE "Reply"."requesterId" = "Dog"."id"
+        AND "Reply"."responderId" = "Interest"."requesterId"
+        AND "Reply"."deletedAt" IS NULL
+      )
+      /* Shadowban gate on the admirer, same shape as the deck. */
+      AND EXISTS (
+        SELECT 1 FROM "Image"
+        WHERE "Image"."dogId" = "Admirer"."id"
+        AND "Image"."status" = 'APPROVED'::"ImageStatus"
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM "Image"
+        WHERE "Image"."dogId" = "Admirer"."id"
+        AND "Image"."status" = 'REJECTED'::"ImageStatus"
+      )
+      GROUP BY "User"."id", "User"."pushToken", "User"."longitude", "Dog"."id", "Dog"."name"
+    )
+    SELECT
+      "waiting"."userId",
+      "waiting"."pushToken",
+      "waiting"."longitude",
+      "waiting"."dogName",
+      "waiting"."anchorId"
+    FROM "waiting"
+    /* Rebuilds the dedupe key the caller would compute. A user whose oldest
+       waiting like has already been announced stays out of the candidate set
+       rather than occupying the limit until they finally answer it. */
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "NotificationLog"
+      WHERE "NotificationLog"."dedupeKey" =
+        ${`${REENGAGEMENT_KINDS.LIKES_WAITING}:`} || "waiting"."userId" || ':' || "waiting"."anchorId"
+    )
+    /* The weekly per-user floor, mirrored from the run so the users it holds
+       back never take a slot in the limit below. Every kind counts, because
+       the floor in the run counts every kind. */
+    AND NOT EXISTS (
+      SELECT 1 FROM "NotificationLog"
+      WHERE "NotificationLog"."userId" = "waiting"."userId"
+      AND "NotificationLog"."sentAt" > ${cooldownFloor}
+    )
+    ORDER BY "waiting"."newestLikeAt" DESC
+    LIMIT ${MAX_CANDIDATES_PER_QUERY}
+  `;
+
+  return rows.map((row) => ({
+    kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+    userId: row.userId,
+    pushToken: row.pushToken,
+    longitude: row.longitude,
+    dedupeKey: `${REENGAGEMENT_KINDS.LIKES_WAITING}:${row.userId}:${row.anchorId}`,
+    title: translate("server:notification.reengagement.likesWaiting.title", {
+      name: row.dogName,
+    }),
+    body: translate("server:notification.reengagement.likesWaiting.body"),
+    url: "swipe",
+  }));
+};
+
+/**
+ * Highest value first. A match nobody spoke on is one tap from a conversation;
+ * an empty deck is the weakest of the three, so it only gets the slot when
+ * nothing better is queued for that user.
+ */
+export const collectCandidates = async (now: Date): Promise<Candidate[]> => {
+  const [unansweredMatch, likesWaiting, newDogsNearby] = await Promise.all([
+    selectUnansweredMatchCandidates(now),
+    selectLikesWaitingCandidates(now),
+    selectNewDogsNearbyCandidates(now),
+  ]);
+
+  const byKey = new Map<string, Candidate>();
+  for (const candidate of [
+    ...unansweredMatch,
+    ...likesWaiting,
+    ...newDogsNearby,
+  ]) {
+    if (!byKey.has(candidate.dedupeKey))
+      byKey.set(candidate.dedupeKey, candidate);
+  }
+
+  return [...byKey.values()];
+};

--- a/packages/api/src/services/reengagement-report.ts
+++ b/packages/api/src/services/reengagement-report.ts
@@ -55,6 +55,15 @@ export type ReengagementRunSummary = {
    * their send threw.
    */
   held: number;
+  /**
+   * The run threw before it finished deciding.
+   *
+   * Every other count on a failed run is whatever it had reached, which for a
+   * failure in the selectors or the cadence read is zero across the board, and
+   * that is the same row a quiet evening produces. This is the one field that
+   * tells them apart.
+   */
+  failed: boolean;
   /** Candidate rows, not people, whose dedupe key was already claimed. */
   skippedAlreadySent: number;
   /** Candidate rows, not people, whose token Expo would reject outright. */
@@ -83,6 +92,7 @@ export const emptyRunSummary = (): ReengagementRunSummary => ({
     window: 0,
   },
   held: 0,
+  failed: false,
   skippedAlreadySent: 0,
   skippedUnreachable: 0,
 });
@@ -166,6 +176,7 @@ export const reportRun = async (
       ANALYTICS_EVENTS.REENGAGEMENT_CRON_RAN,
       {
         candidates: summary.candidates,
+        failed: summary.failed,
         held: summary.held,
         people: summary.people,
         sent: summary.sent,

--- a/packages/api/src/services/reengagement-report.ts
+++ b/packages/api/src/services/reengagement-report.ts
@@ -62,6 +62,32 @@ export type ReengagementRunSummary = {
 };
 
 /**
+ * A run that has not decided anything yet.
+ *
+ * Built here rather than at the call site so the counters and the type they
+ * have to satisfy stay next to each other: a reason added to the union is a
+ * compile error in this file rather than a key quietly missing from a literal
+ * three modules away.
+ */
+export const emptyRunSummary = (): ReengagementRunSummary => ({
+  sent: 0,
+  byKind: { likes_waiting: 0, new_dogs_nearby: 0, unanswered_match: 0 },
+  candidates: 0,
+  people: 0,
+  suppressed: {
+    already_sent: 0,
+    cooldown: 0,
+    dead_token: 0,
+    gave_up: 0,
+    monthly_cap: 0,
+    window: 0,
+  },
+  held: 0,
+  skippedAlreadySent: 0,
+  skippedUnreachable: 0,
+});
+
+/**
  * Records one person the run held back: always in the summary, once a day in
  * the events.
  *

--- a/packages/api/src/services/reengagement-report.ts
+++ b/packages/api/src/services/reengagement-report.ts
@@ -8,7 +8,11 @@ import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
 
 import { sendError } from "../errors/errors";
 import { captureEvent } from "../shared/analytics";
-import { MIN_GAP_DAYS } from "./reengagement-cadence";
+import {
+  MIN_GAP_DAYS,
+  POLICY_REPORT_HOUR,
+  WINDOW_REPORT_HOUR,
+} from "./reengagement-cadence";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -26,16 +30,69 @@ const REENGAGEMENT_CRON_ACTOR = "reengagement-cron";
 export type ReengagementRunSummary = {
   sent: number;
   byKind: Record<ReengagementPushKind, number>;
+  /** Candidate rows. One person can hold several, so see `people`. */
   candidates: number;
+  /**
+   * Distinct users those rows belong to, which is the unit `sent`,
+   * `suppressed` and `held` are all counted in.
+   *
+   * The invariant this whole shape exists for: `people` equals `sent` plus
+   * every entry in `suppressed` plus `held`. A run where it does not is a run
+   * that lost somebody.
+   */
+  people: number;
   /**
    * Users who had a nudge waiting and did not get it, by reason. Counted once
    * per user per run, which is not the same as the events: those are reported
    * once a day so they count people rather than passes.
    */
   suppressed: Record<ReengagementSuppressionReason, number>;
+  /**
+   * Users the run reached no decision about at all.
+   *
+   * Kept separate from `suppressed` because a suppression is a decision and
+   * these are the absence of one: the run filled up, the user disappeared, or
+   * their send threw.
+   */
+  held: number;
+  /** Candidate rows, not people, whose dedupe key was already claimed. */
   skippedAlreadySent: number;
+  /** Candidate rows, not people, whose token Expo would reject outright. */
   skippedUnreachable: number;
 };
+
+/**
+ * Records one person the run held back: always in the summary, once a day in
+ * the events.
+ *
+ * The two are counted differently on purpose. The cron runs hourly and a held
+ * back person is held back at every one of those runs, so an event per run
+ * would count passes over a person rather than people, and the report hours in
+ * {@link POLICY_REPORT_HOUR} are what collapse them. The summary has no such
+ * problem: it is read per run because the heartbeat is emitted per run, so it
+ * counts everybody every time, including the people whose event is waiting for
+ * their report hour to come round.
+ */
+export const suppressionRecorder =
+  (summary: ReengagementRunSummary) =>
+  (
+    userId: string,
+    kind: ReengagementPushKind,
+    reason: ReengagementSuppressionReason,
+    localHour: number,
+  ): void => {
+    summary.suppressed[reason] += 1;
+
+    const reportAt =
+      reason === "window" ? WINDOW_REPORT_HOUR : POLICY_REPORT_HOUR;
+
+    if (localHour !== reportAt) return;
+
+    captureEvent(userId, ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SUPPRESSED, {
+      kind,
+      reason,
+    });
+  };
 
 /**
  * How many people are inside the weekly floor right now.
@@ -83,9 +140,12 @@ export const reportRun = async (
       ANALYTICS_EVENTS.REENGAGEMENT_CRON_RAN,
       {
         candidates: summary.candidates,
+        held: summary.held,
+        people: summary.people,
         sent: summary.sent,
         skipped_already_sent: summary.skippedAlreadySent,
         skipped_unreachable: summary.skippedUnreachable,
+        suppressed_already_sent: summary.suppressed.already_sent,
         suppressed_cooldown: summary.suppressed.cooldown,
         suppressed_dead_token: summary.suppressed.dead_token,
         suppressed_gave_up: summary.suppressed.gave_up,

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -1,6 +1,7 @@
 import prisma from "@pegada/database";
 import { breedData } from "@pegada/database/fixtures/breed-data";
 import { generateFakeUserWithDog } from "@pegada/database/fixtures/generate-fake-user-with-dog";
+import { Prisma } from "@prisma/client";
 
 import { cadenceDecision, readCadence } from "./reengagement-cadence";
 import {
@@ -1370,5 +1371,256 @@ describe("Reengagement Cron Ran", () => {
     await ReengagementService.run(NOW);
 
     expect(ranCalls()).toHaveLength(2);
+  });
+});
+
+/**
+ * Every candidate the run looks at leaves it in exactly one state.
+ *
+ * The heartbeat that shipped in #288 read candidates 5, sent 0, suppressed 3
+ * on the run of 2026-09-07 06:19 UTC, and the missing two were not a rounding
+ * error: several branches used to end a person's turn without a send and
+ * without a reason. These pin the arithmetic rather than any one branch, so a
+ * new branch that forgets to count is a failure here rather than a gap in the
+ * readout nobody can see.
+ */
+describe("reengagement run accounting", () => {
+  /** Sao Paulo. Longitude -46.63 rounds to UTC-3, so NOW is 18:00 local. */
+  const SAO_PAULO_LONGITUDE = -46.63;
+  const SAO_PAULO_LATITUDE = -23.55;
+
+  /**
+   * One user who is due right now, with the partner made unreachable so the
+   * silent match yields this user and nobody else.
+   *
+   * Everything the brief asks for is here: inside the evening window, a real
+   * Expo token, last push eight days ago so the weekly floor has passed, and
+   * six days away so the five day dormancy rule is satisfied. A push eight
+   * days ago against a return six days ago also means the streak is zero, so
+   * the schedule starts over rather than owing the ten day gap.
+   */
+  const seedDueUser = async (
+    overrides: Record<string, unknown> = {},
+    pushDaysAgo: number | null = 8,
+  ) => {
+    const inSaoPaulo = reachableUser({
+      latitude: SAO_PAULO_LATITUDE,
+      longitude: SAO_PAULO_LONGITUDE,
+      lastActiveAt: daysAgo(6),
+      ...overrides,
+    });
+
+    const [{ dog: mine, user }, { dog: theirs }] = await Promise.all([
+      seedUserWithDog({ gender: "MALE" }, inSaoPaulo),
+      // No token, so this side is never a candidate and the counts below are
+      // one per seeded user rather than two.
+      seedUserWithDog({ gender: "FEMALE" }, { pushToken: null }),
+    ]);
+
+    const match = await prisma.match.create({
+      data: { requesterId: mine.id, responderId: theirs.id },
+    });
+
+    await prisma.match.update({
+      where: { id: match.id },
+      data: { createdAt: hoursAgo(25) },
+    });
+
+    if (pushDaysAgo !== null) {
+      await prisma.notificationLog.create({
+        data: {
+          userId: user.id,
+          kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+          dedupeKey: `due:${user.id}:${pushDaysAgo}`,
+          sentAt: daysAgo(pushDaysAgo),
+        },
+      });
+    }
+
+    return user;
+  };
+
+  /** The arithmetic the whole change exists to make true. */
+  const expectBalanced = (summary: {
+    held: number;
+    people: number;
+    sent: number;
+    suppressed: Record<string, number>;
+  }) => {
+    const suppressed = Object.values(summary.suppressed).reduce(
+      (total, value) => total + value,
+      0,
+    );
+
+    expect(summary.sent + suppressed + summary.held).toBe(summary.people);
+  };
+
+  it("sends to five people who pass the floor at 18:00 local", async () => {
+    await Promise.all(Array.from({ length: 5 }, () => seedDueUser()));
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary).toMatchObject({
+      candidates: 5,
+      held: 0,
+      people: 5,
+      sent: 5,
+    });
+    expect(Object.values(summary.suppressed)).toEqual([0, 0, 0, 0, 0, 0]);
+    const { enqueuePushNotification } = PushNotificationService;
+
+    expect(enqueuePushNotification).toHaveBeenCalledTimes(5);
+    expectBalanced(summary);
+  });
+
+  it("sends to a user with no coordinates, and to one that has them", async () => {
+    // There is no timezone column on User, so "no timezone" is every user:
+    // the local hour comes from the longitude when there is one and from
+    // America/Sao_Paulo when there is not. Both land inside the window at
+    // 21:00 UTC, so neither of them is where the missing candidates went.
+    await seedDueUser({ latitude: null, longitude: null });
+    await seedDueUser();
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary).toMatchObject({ held: 0, people: 2, sent: 2 });
+    expectBalanced(summary);
+  });
+
+  it("counts a user held by the monthly ceiling", async () => {
+    const capped = await seedDueUser();
+
+    // A second push inside the same thirty days. The weekly floor has passed
+    // and the user is otherwise due, so the ceiling is the only thing holding
+    // them and it has to say so.
+    await prisma.notificationLog.create({
+      data: {
+        userId: capped.id,
+        kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+        dedupeKey: `monthly:${capped.id}`,
+        sentAt: daysAgo(20),
+      },
+    });
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary).toMatchObject({ held: 0, people: 1, sent: 0 });
+    expect(summary.suppressed.monthly_cap).toBe(1);
+    expectBalanced(summary);
+  });
+
+  it("counts a user the app has given up on", async () => {
+    const quiet = await seedDueUser({ lastActiveAt: daysAgo(120) }, null);
+
+    await prisma.notificationLog.createMany({
+      data: [60, 50, 40].map((days) => ({
+        userId: quiet.id,
+        kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
+        dedupeKey: `gave-up:${quiet.id}:${days}`,
+        sentAt: daysAgo(days),
+      })),
+    });
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary).toMatchObject({ held: 0, people: 1, sent: 0 });
+    expect(summary.suppressed.gave_up).toBe(1);
+    expectBalanced(summary);
+  });
+
+  it("counts a token Expo would refuse rather than dropping it", async () => {
+    // Not null and not empty, so the selector still reaches it, and not an
+    // Expo token either, so the send gives up on it. This used to land in
+    // `skippedUnreachable` alone, which is a row count nothing reconciles
+    // against.
+    await seedDueUser({ pushToken: "not-an-expo-token" });
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary).toMatchObject({
+      held: 0,
+      people: 1,
+      sent: 0,
+      skippedUnreachable: 1,
+    });
+    expect(summary.suppressed.dead_token).toBe(1);
+    expectBalanced(summary);
+  });
+
+  it("counts a user whose whole queue was claimed by a racing run", async () => {
+    await seedDueUser();
+
+    const claimed = jest
+      .spyOn(prisma.notificationLog, "create")
+      .mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("claimed", {
+          code: "P2002",
+          clientVersion: "test",
+        }),
+      );
+
+    try {
+      const summary = await ReengagementService.run(NOW);
+
+      expect(summary).toMatchObject({ held: 0, people: 1, sent: 0 });
+      expect(summary.suppressed.already_sent).toBe(1);
+      expectBalanced(summary);
+    } finally {
+      claimed.mockRestore();
+    }
+  });
+
+  it("keeps the run and the heartbeat alive when one send throws", async () => {
+    await Promise.all(Array.from({ length: 3 }, () => seedDueUser()));
+
+    PushNotificationService.enqueuePushNotification.mockRejectedValueOnce(
+      new Error("queue is down"),
+    );
+
+    const summary = await ReengagementService.run(NOW);
+
+    // The two people behind the failure still get theirs, the one that threw
+    // is held rather than lost, and the hour still reports. Before this, the
+    // throw escaped the run and the hour looked exactly like a cron that had
+    // stopped being scheduled.
+    expect(summary).toMatchObject({ held: 1, people: 3, sent: 2 });
+    expectBalanced(summary);
+
+    expect(
+      observability.capture.mock.calls.filter(
+        ([event]) => event === "Reengagement Cron Ran",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("puts the whole accounting on the heartbeat", async () => {
+    const capped = await seedDueUser();
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: capped.id,
+        kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+        dedupeKey: `heartbeat:${capped.id}`,
+        sentAt: daysAgo(20),
+      },
+    });
+
+    await seedDueUser();
+
+    await ReengagementService.run(NOW);
+
+    const ran = observability.capture.mock.calls.find(
+      ([event]) => event === "Reengagement Cron Ran",
+    );
+
+    // `people` is what makes the row readable: `candidates` counts rows and
+    // the rest count people, so the two were never subtractable from each
+    // other. This one is.
+    expect(ran?.[1]).toMatchObject({
+      held: 0,
+      people: 2,
+      sent: 1,
+      suppressed_monthly_cap: 1,
+    });
   });
 });

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -3,6 +3,7 @@ import { breedData } from "@pegada/database/fixtures/breed-data";
 import { generateFakeUserWithDog } from "@pegada/database/fixtures/generate-fake-user-with-dog";
 import { Prisma } from "@prisma/client";
 
+import * as reengagementCadence from "./reengagement-cadence";
 import { cadenceDecision, readCadence } from "./reengagement-cadence";
 import {
   isWithinSendWindow,
@@ -1287,14 +1288,22 @@ describe("Reengagement Push Suppressed", () => {
     const close = await ReengagementService.run(WINDOW_CLOSE);
 
     expect(close.suppressed.cooldown).toBe(1);
-    expect(suppressedCalls()).toEqual([
-      [
-        "Reengagement Push Suppressed",
-        expect.objectContaining({
-          kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
-          reason: "cooldown",
-        }),
-      ],
+
+    // Both sides of the match are accounted for at the close of the window:
+    // the one the cadence held, and the one whose nudge went out in the
+    // earlier run and so has nothing left to claim. One row each, which is
+    // what "once" means here.
+    expect(
+      suppressedCalls()
+        .map(([, properties]) => properties.reason)
+        .sort(),
+    ).toEqual(["already_sent", "cooldown"]);
+    expect(suppressedCalls()).toContainEqual([
+      "Reengagement Push Suppressed",
+      expect.objectContaining({
+        kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+        reason: "cooldown",
+      }),
     ]);
   });
 
@@ -1567,6 +1576,56 @@ describe("reengagement run accounting", () => {
       expectBalanced(summary);
     } finally {
       claimed.mockRestore();
+    }
+  });
+
+  it("counts a user whose only nudge was claimed before the run started", async () => {
+    // The common case on an hourly cron, and the one that used to leave no
+    // trace: the key was claimed by an earlier run, so the person never
+    // reached the loop and appeared in nothing but a row level tally.
+    const told = await seedDueUser();
+
+    const [candidate] = await selectUnansweredMatchCandidates(NOW);
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: told.id,
+        kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+        dedupeKey: candidate?.dedupeKey ?? "",
+        sentAt: hoursAgo(1),
+      },
+    });
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary).toMatchObject({
+      candidates: 1,
+      held: 0,
+      people: 1,
+      sent: 0,
+      skippedAlreadySent: 1,
+    });
+    expect(summary.suppressed.already_sent).toBe(1);
+    expectBalanced(summary);
+  });
+
+  it("holds a user who disappeared between the selector and the decision", async () => {
+    await seedDueUser();
+
+    // The row is gone by the time the cadence is read, which is what a delete
+    // mid run looks like from in here. Nobody is left to suppress and no
+    // reason would be honest, so it is held and still counted.
+    const vanished = jest
+      .spyOn(reengagementCadence, "readCadence")
+      .mockResolvedValue(new Map());
+
+    try {
+      const summary = await ReengagementService.run(NOW);
+
+      expect(summary).toMatchObject({ held: 1, people: 1, sent: 0 });
+      expectBalanced(summary);
+    } finally {
+      vanished.mockRestore();
     }
   });
 

--- a/packages/api/src/services/reengagement-service.test.ts
+++ b/packages/api/src/services/reengagement-service.test.ts
@@ -727,7 +727,11 @@ describe("ReengagementService.run", () => {
     );
 
     expect(summary.sent).toBe(0);
-    expect(summary.suppressed.cooldown).toBe(1);
+    // Both sides, not one. The other side of the first match had its only key
+    // claimed by the earlier run and used to leave this run counted in
+    // nothing at all; the row that claimed the key is also what puts them in
+    // cooldown, so that is the reason they are counted under.
+    expect(summary.suppressed.cooldown).toBe(2);
     // The two from the first run and nothing since.
     expect(
       PushNotificationService.enqueuePushNotification,
@@ -1287,17 +1291,16 @@ describe("Reengagement Push Suppressed", () => {
 
     const close = await ReengagementService.run(WINDOW_CLOSE);
 
-    expect(close.suppressed.cooldown).toBe(1);
+    // Both sides of the match, not one. The side whose nudge went out in the
+    // earlier run is inside the week that push started and used to leave the
+    // run counted in nothing; it is a cadence decision like the other one.
+    expect(close.suppressed.cooldown).toBe(2);
 
-    // Both sides of the match are accounted for at the close of the window:
-    // the one the cadence held, and the one whose nudge went out in the
-    // earlier run and so has nothing left to claim. One row each, which is
-    // what "once" means here.
+    // One row each, which is what "once" means here.
+    expect(suppressedCalls()).toHaveLength(2);
     expect(
-      suppressedCalls()
-        .map(([, properties]) => properties.reason)
-        .sort(),
-    ).toEqual(["already_sent", "cooldown"]);
+      suppressedCalls().map(([, properties]) => properties.reason),
+    ).toEqual(["cooldown", "cooldown"]);
     expect(suppressedCalls()).toContainEqual([
       "Reengagement Push Suppressed",
       expect.objectContaining({
@@ -1580,10 +1583,11 @@ describe("reengagement run accounting", () => {
   });
 
   it("counts a user whose only nudge was claimed before the run started", async () => {
-    // The common case on an hourly cron, and the one that used to leave no
-    // trace: the key was claimed by an earlier run, so the person never
-    // reached the loop and appeared in nothing but a row level tally.
-    const told = await seedDueUser();
+    // The key was claimed by an earlier run, so the person never reached the
+    // loop and appeared in nothing but a row level tally. Claimed eight days
+    // back, which is the case worth naming: the schedule would let them
+    // through today and there is simply nothing left to say to them.
+    const told = await seedDueUser({}, null);
 
     const [candidate] = await selectUnansweredMatchCandidates(NOW);
 
@@ -1592,7 +1596,7 @@ describe("reengagement run accounting", () => {
         userId: told.id,
         kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
         dedupeKey: candidate?.dedupeKey ?? "",
-        sentAt: hoursAgo(1),
+        sentAt: daysAgo(8),
       },
     });
 
@@ -1600,6 +1604,7 @@ describe("reengagement run accounting", () => {
 
     expect(summary).toMatchObject({
       candidates: 1,
+      failed: false,
       held: 0,
       people: 1,
       sent: 0,
@@ -1607,6 +1612,64 @@ describe("reengagement run accounting", () => {
     });
     expect(summary.suppressed.already_sent).toBe(1);
     expectBalanced(summary);
+  });
+
+  it("names the schedule ahead of a claimed key when both apply", async () => {
+    // Most of the base is inside some part of the cadence, and on an hourly
+    // cron most of them also have a claimed key. Reporting the claimed key
+    // first would put `already_sent` on nearly everybody and bury the reason
+    // anybody can act on.
+    const capped = await seedDueUser();
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: capped.id,
+        kind: REENGAGEMENT_KINDS.LIKES_WAITING,
+        dedupeKey: `monthly:${capped.id}`,
+        sentAt: daysAgo(20),
+      },
+    });
+
+    const [candidate] = await selectUnansweredMatchCandidates(NOW);
+
+    await prisma.notificationLog.create({
+      data: {
+        userId: capped.id,
+        kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
+        dedupeKey: candidate?.dedupeKey ?? "",
+        sentAt: hoursAgo(1),
+      },
+    });
+
+    const summary = await ReengagementService.run(NOW);
+
+    expect(summary.suppressed.monthly_cap).toBe(1);
+    expect(summary.suppressed.already_sent).toBe(0);
+    expectBalanced(summary);
+  });
+
+  it("says so on the heartbeat when the run threw before deciding", async () => {
+    await seedDueUser();
+
+    const broken = jest
+      .spyOn(reengagementCadence, "readCadence")
+      .mockRejectedValue(new Error("database is down"));
+
+    try {
+      // The failure still leaves through the route, so the hour reads as an
+      // error rather than as an evening with nobody to nudge.
+      await expect(ReengagementService.run(NOW)).rejects.toThrow(
+        "database is down",
+      );
+    } finally {
+      broken.mockRestore();
+    }
+
+    const ran = observability.capture.mock.calls.find(
+      ([event]) => event === "Reengagement Cron Ran",
+    );
+
+    expect(ran?.[1]).toMatchObject({ failed: true, people: 0, sent: 0 });
   });
 
   it("holds a user who disappeared between the selector and the decision", async () => {

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -145,6 +145,12 @@ export class ReengagementService {
     // out either way and the error still leaves through the route.
     try {
       await ReengagementService.#decide(summary, now);
+    } catch (error) {
+      // Without this the row a failed run emits is all zeroes, which is the
+      // same row a quiet evening emits. The flag is what separates "nothing to
+      // do" from "did not get to find out".
+      summary.failed = true;
+      throw error;
     } finally {
       await reportRun(summary, now);
     }
@@ -223,13 +229,6 @@ export class ReengagementService {
         return;
       }
 
-      // Every nudge they were due had already been claimed, so there is
-      // nothing left to try. That is a decision about them and it has a name.
-      if (queue.length === 0) {
-        suppress(userId, kind, "already_sent", localHour);
-        return;
-      }
-
       try {
         const reason = await ReengagementService.#decideOne(
           facts,
@@ -239,7 +238,11 @@ export class ReengagementService {
           now,
         );
 
-        if (reason) suppress(userId, kind, reason, localHour);
+        // The kind of the nudge actually queued, falling back to the best one
+        // they were due when the queue is empty. Reporting the claimed kind
+        // for a user who still had a second nudge waiting would quietly change
+        // what an existing event property means.
+        if (reason) suppress(userId, queue[0]?.kind ?? kind, reason, localHour);
       } catch (error) {
         // One failed send used to take the run with it, and the run took the
         // heartbeat with it: the hour reported nothing at all, so an outage
@@ -270,12 +273,20 @@ export class ReengagementService {
     summary: ReengagementRunSummary,
     now: Date,
   ): Promise<ReengagementSuppressionReason | null> {
-    // The cadence is decided before the clock, so somebody held back for a
-    // month is not also counted as "wrong hour" twenty-two times a day.
+    // The cadence is decided before the clock, and both before the queue.
+    // Somebody held back for a month is not also counted as "wrong hour"
+    // twenty-two times a day, and somebody the schedule is holding is reported
+    // against the schedule rather than against whichever of their keys a
+    // previous run happened to claim. Ordering it the other way round would
+    // put `already_sent` on most of the base and bury every cadence reason
+    // underneath it, which is the opposite of what the reasons are for.
     const decision = cadenceDecision(facts, now);
 
     if (!decision.allowed) return decision.reason;
     if (!SEND_WINDOW_HOURS.has(localHour)) return "window";
+
+    // Due, inside their own hour, and every nudge they had already claimed.
+    if (queue.length === 0) return "already_sent";
 
     const outcome = await ReengagementService.#sendFirstAvailable(
       queue,

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -1,94 +1,43 @@
 import type { CadenceFacts } from "./reengagement-cadence";
+import type { Candidate, ReengagementKind } from "./reengagement-candidates";
 import type { ReengagementRunSummary } from "./reengagement-report";
-import type {
-  ReengagementPushKind,
-  ReengagementSuppressionReason,
-} from "@pegada/shared/analytics/events";
+import type { ReengagementSuppressionReason } from "@pegada/shared/analytics/events";
 
 import { Expo } from "expo-server-sdk";
 
 import prisma from "@pegada/database";
 import { ANALYTICS_EVENTS } from "@pegada/shared/analytics/events";
-import { Language } from "@pegada/shared/i18n/types/types";
 import { Prisma } from "@prisma/client";
 
 import { sendError } from "../errors/errors";
 import { captureEvent } from "../shared/analytics";
 import { PushNotificationService } from "./push-notification-service";
+import { cadenceDecision, readCadence } from "./reengagement-cadence";
+import { collectCandidates } from "./reengagement-candidates";
 import {
-  cadenceDecision,
-  MIN_GAP_DAYS,
-  readCadence,
-} from "./reengagement-cadence";
-import { reportRun, suppressionRecorder } from "./reengagement-report";
-import { TranslationService } from "./translation-service";
+  emptyRunSummary,
+  reportRun,
+  suppressionRecorder,
+} from "./reengagement-report";
 
+/**
+ * Re-exported rather than moved out of reach. The selectors live in their own
+ * module now, and every caller and test that already imported them from here
+ * still can, so the split costs nothing at the call sites.
+ */
+export type { Candidate, ReengagementKind } from "./reengagement-candidates";
+export {
+  INACTIVE_DAYS,
+  MAX_CANDIDATES_PER_QUERY,
+  MIN_NEW_DOGS,
+  RECENT_ACTIVITY_HOURS,
+  REENGAGEMENT_KINDS,
+  selectLikesWaitingCandidates,
+  selectNewDogsNearbyCandidates,
+  selectUnansweredMatchCandidates,
+  UNANSWERED_MATCH_HOURS,
+} from "./reengagement-candidates";
 export type { ReengagementRunSummary } from "./reengagement-report";
-
-/**
- * `satisfies` rather than a bare `as const`: the catalogue restates these three
- * values (it cannot import them without a cycle), and this is what makes a new
- * kind added here a compile error until the catalogue knows about it too.
- */
-export const REENGAGEMENT_KINDS = {
-  UNANSWERED_MATCH: "unanswered_match",
-  NEW_DOGS_NEARBY: "new_dogs_nearby",
-  LIKES_WAITING: "likes_waiting",
-} as const satisfies Record<string, ReengagementPushKind>;
-
-export type ReengagementKind =
-  (typeof REENGAGEMENT_KINDS)[keyof typeof REENGAGEMENT_KINDS];
-
-/** Hours after a silent match at which the two sides get nudged. */
-export const UNANSWERED_MATCH_HOURS = [24, 72] as const;
-
-/**
- * How far back each unanswered-match bucket reaches. Without a floor, the
- * first run after deploy would nudge every silent match ever created; with it,
- * a match is only ever eligible inside the window that follows its own
- * threshold.
- */
-const UNANSWERED_MATCH_MAX_AGE_HOURS = 14 * 24;
-
-/** Days without a positive swipe that make a user eligible for new dogs. */
-export const INACTIVE_DAYS = [3, 7] as const;
-
-/**
- * How recently someone has to have used the app to be left alone.
- *
- * Every selector below infers "gone quiet" from a proxy (no positive swipe, a
- * match nobody spoke on, a like nobody answered), and each proxy misses the
- * person who is in the app right now doing something else. `lastActiveAt` is
- * the direct signal, written on authenticated requests, so it is the guard that
- * keeps a win-back push off the screen of someone who never left.
- */
-export const RECENT_ACTIVITY_HOURS = 24;
-
-/** New dogs that have to exist nearby before the nudge is worth sending. */
-export const MIN_NEW_DOGS = 3;
-
-/** How old a like has to be before it counts as waiting. */
-const LIKES_WAITING_HOURS = 24;
-
-/**
- * When a user has never swiped positively there is no anchor to count new dogs
- * from, so the count starts here instead.
- *
- * This doubles as how often that cohort may be nudged again. Every other user
- * is rate limited by their own anchor moving, which needs them to do something;
- * someone who has never swiped has nothing that moves, so without a period in
- * the key they would be a one-time audience forever. A calendar-aligned bucket
- * rather than a sliding window, because the dedupe key has to name the same
- * period the already-sent filter is testing.
- */
-const NEW_DOGS_FALLBACK_WINDOW_DAYS = 30;
-
-/**
- * Above this, `preferredMaxDistance` means "anywhere" and no distance filter
- * is applied. Same threshold the swipe deck uses in SuggestionService, so the
- * count in the copy matches the deck the user lands on.
- */
-const UNLIMITED_DISTANCE_KM = 295;
 
 /**
  * The rule, in full: a re-engagement push may only leave inside 18:00 and
@@ -115,55 +64,7 @@ const SEND_WINDOW_HOURS = new Set([18, 19]);
  */
 const FALLBACK_OFFSET_HOURS = -3;
 
-/**
- * Bounds one invocation so a backlog cannot outrun the function budget.
- *
- * Worth reading next to {@link SEND_WINDOW_HOURS}: a user is only eligible in
- * two of the twenty four runs a day, and Brazil is one offset, so the whole
- * base shares those two runs and the real daily ceiling is twice this number.
- * The 200 the incident sent was this cap being hit, so a backlog does exist.
- * Raise this before widening the window if the queue stops draining.
- */
-export const MAX_CANDIDATES_PER_QUERY = 500;
 const MAX_PUSHES_PER_RUN = 200;
-
-const HOUR_MS = 60 * 60 * 1000;
-const DAY_MS = 24 * HOUR_MS;
-
-export type Candidate = {
-  kind: ReengagementKind;
-  userId: string;
-  pushToken: string;
-  longitude: number | null;
-  dedupeKey: string;
-  title: string;
-  body: string;
-  url: string;
-  /** Set on the "tell me when a new dog shows up" path, cleared once sent. */
-  clearsNewDogsAlert?: boolean;
-};
-
-/**
- * The instant before which a user counts as away.
- *
- * A null `lastActiveAt` is unknown rather than active: the column is only
- * written once a user makes an authenticated request after #217 shipped, so
- * reading null as "here" would mute the whole cron until everyone came back on
- * their own. The proxy each selector already applies decides those users.
- */
-const recentActivityFloor = (now: Date) =>
-  new Date(now.getTime() - RECENT_ACTIVITY_HOURS * HOUR_MS);
-
-const isRecentlyActive = (lastActiveAt: Date | null, now: Date) =>
-  lastActiveAt !== null && lastActiveAt > recentActivityFloor(now);
-
-/** The same rule in SQL, for the selectors that run as raw queries. */
-const notRecentlyActive = (now: Date) => Prisma.sql`
-  (
-    "User"."lastActiveAt" IS NULL
-    OR "User"."lastActiveAt" <= ${recentActivityFloor(now)}
-  )
-`;
 
 const hourInOffset = (now: Date, offsetHours: number) =>
   (((now.getUTCHours() + offsetHours) % 24) + 24) % 24;
@@ -214,504 +115,18 @@ export const isWithinSendWindow = (
   now: Date,
 ): boolean => SEND_WINDOW_HOURS.has(localHourFor(longitude, now));
 
-type ReengagementCopyKey =
-  | "server:notification.reengagement.unansweredMatch.title"
-  | "server:notification.reengagement.unansweredMatch.body"
-  | "server:notification.reengagement.newDogsNearby.title"
-  | "server:notification.reengagement.newDogsNearby.body"
-  | "server:notification.reengagement.likesWaiting.title"
-  | "server:notification.reengagement.likesWaiting.body";
-
-/**
- * The cron has no request to read a language from and `User` has no language
- * column, so every re-engagement push goes out in pt-BR, which is where
- * essentially all of the users are. A per-user language is the follow up, and
- * it belongs on the model rather than being guessed at here.
- */
-const translate = (
-  key: ReengagementCopyKey,
-  replace?: Record<string, unknown>,
-): string => TranslationService.translate(key, { lng: Language.PtBr, replace });
-
-/**
- * A user we can actually reach.
- *
- * The empty string matters: `UserService.blacklistPushToken` clears a dead
- * token by writing `""` rather than null, so `IS NOT NULL` alone would keep
- * re-selecting users whose device has already been rejected by Expo, burning
- * their daily cap and inflating the sent count this whole change exists to
- * measure.
- */
-const REACHABLE_USER = Prisma.sql`
-  "User"."deletedAt" IS NULL
-  AND "User"."pushToken" IS NOT NULL
-  AND "User"."pushToken" <> ''
-`;
-
-/**
- * The same rule, for the one selector that goes through Prisma rather than
- * raw SQL. Both halves are needed for the same reason the SQL needs both.
- */
-const REACHABLE_USER_WHERE = {
-  deletedAt: null,
-  pushToken: { not: null },
-  NOT: { pushToken: "" },
-} satisfies Prisma.UserWhereInput;
-
-/**
- * Matches that went silent, one candidate per side that can be reached.
- *
- * Both sides get the nudge because either of them can break the silence and
- * neither knows the other is waiting.
- */
-export const selectUnansweredMatchCandidates = async (
-  now: Date,
-): Promise<Candidate[]> => {
-  const buckets = await Promise.all(
-    UNANSWERED_MATCH_HOURS.map(async (hours, index) => {
-      // Each bucket stops where the next one starts, so a four day old silent
-      // match is only ever in the 72 hour bucket and never in both.
-      const upperAgeHours =
-        UNANSWERED_MATCH_HOURS[index + 1] ?? UNANSWERED_MATCH_MAX_AGE_HOURS;
-
-      const olderThan = new Date(now.getTime() - hours * HOUR_MS);
-      const newerThan = new Date(now.getTime() - upperAgeHours * HOUR_MS);
-
-      const dogSelect = {
-        id: true,
-        name: true,
-        user: {
-          select: {
-            id: true,
-            pushToken: true,
-            longitude: true,
-            lastActiveAt: true,
-          },
-        },
-      } as const;
-
-      const matches = await prisma.match.findMany({
-        where: {
-          deletedAt: null,
-          createdAt: { gte: newerThan, lt: olderThan },
-          messages: { none: { deletedAt: null } },
-          requester: {
-            deletedAt: null,
-            banned: false,
-            user: { deletedAt: null },
-          },
-          responder: {
-            deletedAt: null,
-            banned: false,
-            user: { deletedAt: null },
-          },
-          // At least one side has to still have a live token. Either side can
-          // break the silence, so a match is worth pulling for one reachable
-          // half; a match where neither device answers any more is not, and
-          // leaving it in let dead installs fill the per run candidate ceiling
-          // and pushed the reachable people behind them out of the run.
-          OR: [
-            { requester: { user: REACHABLE_USER_WHERE } },
-            { responder: { user: REACHABLE_USER_WHERE } },
-          ],
-        },
-        select: {
-          id: true,
-          requester: { select: dogSelect },
-          responder: { select: dogSelect },
-        },
-        // Newest first. The take is a ceiling on one run, and the rows most
-        // likely to be already claimed by a dedupe key are the oldest ones, so
-        // ordering the other way would let a backlog starve fresh matches.
-        orderBy: { createdAt: "desc" },
-        take: MAX_CANDIDATES_PER_QUERY,
-      });
-
-      return matches.flatMap((match) =>
-        [
-          { self: match.requester, other: match.responder },
-          { self: match.responder, other: match.requester },
-        ].flatMap(({ self, other }) =>
-          self.user.pushToken && !isRecentlyActive(self.user.lastActiveAt, now)
-            ? [
-                {
-                  kind: REENGAGEMENT_KINDS.UNANSWERED_MATCH,
-                  userId: self.user.id,
-                  pushToken: self.user.pushToken,
-                  longitude: self.user.longitude,
-                  dedupeKey: `${REENGAGEMENT_KINDS.UNANSWERED_MATCH}:${match.id}:${self.user.id}:${hours}h`,
-                  title: translate(
-                    "server:notification.reengagement.unansweredMatch.title",
-                    { name: other.name },
-                  ),
-                  body: translate(
-                    "server:notification.reengagement.unansweredMatch.body",
-                    { name: other.name },
-                  ),
-                  url: `chat/${match.id}/${other.id}`,
-                } satisfies Candidate,
-              ]
-            : [],
-        ),
-      );
-    }),
-  );
-
-  return buckets.flat();
-};
-
-/**
- * Has this user liked anybody since `since`? Correlates against the enclosing
- * query's `"User"` row, so it only composes inside the candidate select below.
- */
-const swipedPositivelySince = (since: Date) => Prisma.sql`
-  EXISTS (
-    SELECT 1 FROM "Interest"
-    JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "Interest"."requesterId"
-    WHERE "OwnDog"."userId" = "User"."id"
-    AND "Interest"."lastPositiveAt" > ${since}
-  )
-`;
-
-type NewDogsRow = {
-  userId: string;
-  pushToken: string;
-  longitude: number | null;
-  newDogs: number;
-  requested: boolean;
-  anchor: Date | null;
-};
-
-/**
- * Users worth pulling back into the deck, with the real number of dogs waiting
- * for them.
- *
- * Two ways in, and they are mutually exclusive so nobody is selected twice.
- * Either the user asked to be told (`newDogsAlertRequestedAt`, the fake door in
- * #191), in which case the inactivity rule does not apply and the count is
- * measured from the moment they asked; or they have gone quiet, in which case
- * they land in exactly one inactivity bucket. Both still need
- * {@link MIN_NEW_DOGS} dogs to exist: "come back, there is nothing new" is
- * worse than silence.
- *
- * The dog count mirrors the swipe deck's hard filters (opposite gender, not
- * banned or deleted, an approved image and no rejected one, inside the
- * preferred distance, not already swiped). The deck's soft preferences (color,
- * size, age, breed) are left out, so the number in the copy is an upper bound
- * when a user has set those.
- */
-export const selectNewDogsNearbyCandidates = async (
-  now: Date,
-): Promise<Candidate[]> => {
-  // Sliding, so a user who has never swiped is always shown a full window of
-  // new dogs rather than an emptier and emptier one as a period runs out.
-  const newDogsFloor = new Date(
-    now.getTime() - NEW_DOGS_FALLBACK_WINDOW_DAYS * DAY_MS,
-  );
-
-  // Quantised, and used only to decide whether that cohort has already been
-  // told this period. The dedupe key carries the same period number, so the
-  // key and the filter re-admit the user on exactly the same day.
-  const periodMs = NEW_DOGS_FALLBACK_WINDOW_DAYS * DAY_MS;
-  const period = Math.floor(now.getTime() / periodMs);
-  const periodStart = new Date(period * periodMs);
-
-  const buckets = [
-    {
-      label: "requested",
-      eligibility: Prisma.sql`"User"."newDogsAlertRequestedAt" IS NOT NULL`,
-    },
-    ...INACTIVE_DAYS.map((days, index) => {
-      const nextDays = INACTIVE_DAYS[index + 1];
-
-      // Each bucket ends where the next begins: quiet for 3 days but not yet 7
-      // is the 3 day nudge, quiet for 7 or more is the 7 day one. Without the
-      // lower bound a user who has been away a month is in both.
-      const lowerBound = nextDays
-        ? Prisma.sql`AND ${swipedPositivelySince(new Date(now.getTime() - nextDays * DAY_MS))}`
-        : Prisma.empty;
-
-      return {
-        label: `${days}d`,
-        eligibility: Prisma.sql`
-          "User"."newDogsAlertRequestedAt" IS NULL
-          AND ${notRecentlyActive(now)}
-          AND NOT ${swipedPositivelySince(new Date(now.getTime() - days * DAY_MS))}
-          ${lowerBound}
-        `,
-      };
-    }),
-  ];
-
-  const rows = await Promise.all(
-    buckets.map(({ label, eligibility }) =>
-      prisma.$queryRaw<NewDogsRow[]>`
-        WITH "candidate" AS (
-          SELECT
-            "User"."id" AS "userId",
-            "User"."pushToken" AS "pushToken",
-            "User"."longitude" AS "longitude",
-            "User"."latitude" AS "latitude",
-            ("User"."newDogsAlertRequestedAt" IS NOT NULL) AS "requested",
-            /* Count from the moment they asked, otherwise from their last
-               positive swipe, otherwise from a fixed floor. */
-            COALESCE(
-              "User"."newDogsAlertRequestedAt",
-              (
-                SELECT MAX("Interest"."lastPositiveAt")
-                FROM "Interest"
-                JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "Interest"."requesterId"
-                WHERE "OwnDog"."userId" = "User"."id"
-              )
-            ) AS "anchor",
-            /* The viewer's own dog, used for the gender rule and the distance
-               preference. */
-            (
-              SELECT "OwnDog"."id" FROM "Dog" AS "OwnDog"
-              WHERE "OwnDog"."userId" = "User"."id"
-              AND "OwnDog"."deletedAt" IS NULL AND "OwnDog"."banned" = false
-              ORDER BY "OwnDog"."createdAt" ASC LIMIT 1
-            ) AS "ownDogId"
-          FROM "User"
-          WHERE ${REACHABLE_USER}
-          AND (${eligibility})
-        )
-        SELECT
-          "candidate"."userId",
-          "candidate"."pushToken",
-          "candidate"."longitude",
-          "candidate"."requested",
-          "candidate"."anchor",
-          "counted"."newDogs"
-        FROM "candidate"
-        JOIN "Dog" AS "OwnDog" ON "OwnDog"."id" = "candidate"."ownDogId"
-        CROSS JOIN LATERAL (
-          SELECT COUNT(*)::int AS "newDogs"
-          FROM "Dog"
-          JOIN "User" AS "Owner" ON "Owner"."id" = "Dog"."userId"
-          WHERE "Dog"."userId" <> "candidate"."userId"
-          AND "Dog"."deletedAt" IS NULL
-          AND "Dog"."banned" = false
-          AND "Owner"."deletedAt" IS NULL
-          AND "Dog"."createdAt" > COALESCE("candidate"."anchor", ${newDogsFloor})
-          AND "Dog"."gender" <> "OwnDog"."gender"
-          /* Shadowban gate, same shape as the deck. */
-          AND EXISTS (
-            SELECT 1 FROM "Image"
-            WHERE "Image"."dogId" = "Dog"."id"
-            AND "Image"."status" = 'APPROVED'::"ImageStatus"
-          )
-          AND NOT EXISTS (
-            SELECT 1 FROM "Image"
-            WHERE "Image"."dogId" = "Dog"."id"
-            AND "Image"."status" = 'REJECTED'::"ImageStatus"
-          )
-          /* Already swiped is already seen. */
-          AND NOT EXISTS (
-            SELECT 1 FROM "Interest"
-            WHERE "Interest"."requesterId" = "OwnDog"."id"
-            AND "Interest"."responderId" = "Dog"."id"
-          )
-          AND (
-            /* Null and zero both mean "no preference" in SuggestionService,
-               where the filter is only applied when the value is truthy.
-               Reading zero as "within zero kilometres" here would silently
-               empty the count for anyone who has it. */
-            "OwnDog"."preferredMaxDistance" IS NULL
-            OR "OwnDog"."preferredMaxDistance" <= 0
-            OR "OwnDog"."preferredMaxDistance" >= ${UNLIMITED_DISTANCE_KM}
-            OR "candidate"."latitude" IS NULL
-            OR "candidate"."longitude" IS NULL
-            OR "Owner"."latitude" IS NULL
-            OR "Owner"."longitude" IS NULL
-            OR ST_DistanceSphere(
-              ST_MakePoint("Owner"."longitude", "Owner"."latitude"),
-              ST_MakePoint("candidate"."longitude", "candidate"."latitude")
-            ) / 1000 <= "OwnDog"."preferredMaxDistance"
-          )
-        ) AS "counted"
-        WHERE "counted"."newDogs" >= ${MIN_NEW_DOGS}
-        /* Already told since the anchor last moved, so there is nothing new to
-           say. The dedupe key is built from the same anchor, which makes this a
-           faithful pre-filter rather than a second policy: it keeps users who
-           have had their nudge out of the candidate set instead of letting them
-           occupy the limit forever, and it is what stops a cleared alert
-           request from re-qualifying the user under the inactivity rule the
-           next day. */
-        AND NOT EXISTS (
-          SELECT 1 FROM "NotificationLog"
-          WHERE "NotificationLog"."userId" = "candidate"."userId"
-          AND "NotificationLog"."kind" = ${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}
-          AND "NotificationLog"."sentAt" > COALESCE("candidate"."anchor", ${periodStart})
-        )
-        /* Freshest lapsers first, for the same reason matches are ordered
-           newest first. */
-        ORDER BY "candidate"."anchor" DESC NULLS LAST
-        LIMIT ${MAX_CANDIDATES_PER_QUERY}
-      `.then((result) => ({ label, result })),
-    ),
-  );
-
-  return rows.flatMap(({ label, result }) =>
-    result.map((row) => ({
-      kind: REENGAGEMENT_KINDS.NEW_DOGS_NEARBY,
-      userId: row.userId,
-      pushToken: row.pushToken,
-      longitude: row.longitude,
-      /* Keying on the anchor is what stops the nudge repeating: it only moves
-         once the user swipes positively again or asks again. */
-      dedupeKey: `${REENGAGEMENT_KINDS.NEW_DOGS_NEARBY}:${row.userId}:${label}:${row.anchor?.toISOString() ?? `never:${period}`}`,
-      title: translate("server:notification.reengagement.newDogsNearby.title", {
-        amount: row.newDogs,
-      }),
-      body: translate("server:notification.reengagement.newDogsNearby.body"),
-      url: "swipe",
-      clearsNewDogsAlert: row.requested,
-    })),
-  );
-};
-
-type LikesWaitingRow = {
-  userId: string;
-  pushToken: string;
-  longitude: number | null;
-  dogName: string;
-  anchorId: string;
-};
-
-/**
- * Users sitting on likes they have not answered.
- *
- * `Interest` has no seen flag, so "unseen" is read as "not yet reciprocated":
- * an active like pointing at one of your dogs, older than a day, with no match
- * and nothing back from you. That is the set worth interrupting someone over.
- *
- * The dedupe key is the oldest waiting like, so the nudge does not repeat
- * until that particular like is dealt with. On its own that was not enough:
- * a new like arriving is a new oldest-unannounced like, so a popular dormant
- * dog produced one of these every evening. The weekly floor below is the cap
- * that actually holds, and it is mirrored here as well as enforced in the run
- * so those users do not sit in the candidate limit for nothing.
- */
-export const selectLikesWaitingCandidates = async (
-  now: Date,
-): Promise<Candidate[]> => {
-  const olderThan = new Date(now.getTime() - LIKES_WAITING_HOURS * HOUR_MS);
-
-  const cooldownFloor = new Date(now.getTime() - MIN_GAP_DAYS * DAY_MS);
-
-  const rows = await prisma.$queryRaw<LikesWaitingRow[]>`
-    WITH "waiting" AS (
-      SELECT
-        "User"."id" AS "userId",
-        "User"."pushToken" AS "pushToken",
-        "User"."longitude" AS "longitude",
-        "Dog"."name" AS "dogName",
-        (ARRAY_AGG("Interest"."id" ORDER BY "Interest"."createdAt" ASC))[1] AS "anchorId",
-        MAX("Interest"."createdAt") AS "newestLikeAt"
-      FROM "User"
-      JOIN "Dog" ON "Dog"."userId" = "User"."id"
-        AND "Dog"."deletedAt" IS NULL AND "Dog"."banned" = false
-      JOIN "Interest" ON "Interest"."responderId" = "Dog"."id"
-      /* The dog doing the liking has to be one the deck would still show,
-         otherwise the push names somebody the user can never reach. */
-      JOIN "Dog" AS "Admirer" ON "Admirer"."id" = "Interest"."requesterId"
-        AND "Admirer"."deletedAt" IS NULL AND "Admirer"."banned" = false
-      JOIN "User" AS "AdmirerUser" ON "AdmirerUser"."id" = "Admirer"."userId"
-        AND "AdmirerUser"."deletedAt" IS NULL
-      WHERE ${REACHABLE_USER}
-      AND ${notRecentlyActive(now)}
-      AND "Interest"."deletedAt" IS NULL
-      AND "Interest"."matchId" IS NULL
-      AND "Interest"."swipeType" IN ('INTERESTED'::"SwipeType", 'MAYBE'::"SwipeType")
-      AND "Interest"."createdAt" < ${olderThan}
-      /* Nothing back from this dog means the like is still unanswered. */
-      AND NOT EXISTS (
-        SELECT 1 FROM "Interest" AS "Reply"
-        WHERE "Reply"."requesterId" = "Dog"."id"
-        AND "Reply"."responderId" = "Interest"."requesterId"
-        AND "Reply"."deletedAt" IS NULL
-      )
-      /* Shadowban gate on the admirer, same shape as the deck. */
-      AND EXISTS (
-        SELECT 1 FROM "Image"
-        WHERE "Image"."dogId" = "Admirer"."id"
-        AND "Image"."status" = 'APPROVED'::"ImageStatus"
-      )
-      AND NOT EXISTS (
-        SELECT 1 FROM "Image"
-        WHERE "Image"."dogId" = "Admirer"."id"
-        AND "Image"."status" = 'REJECTED'::"ImageStatus"
-      )
-      GROUP BY "User"."id", "User"."pushToken", "User"."longitude", "Dog"."id", "Dog"."name"
-    )
-    SELECT
-      "waiting"."userId",
-      "waiting"."pushToken",
-      "waiting"."longitude",
-      "waiting"."dogName",
-      "waiting"."anchorId"
-    FROM "waiting"
-    /* Rebuilds the dedupe key the caller would compute. A user whose oldest
-       waiting like has already been announced stays out of the candidate set
-       rather than occupying the limit until they finally answer it. */
-    WHERE NOT EXISTS (
-      SELECT 1 FROM "NotificationLog"
-      WHERE "NotificationLog"."dedupeKey" =
-        ${`${REENGAGEMENT_KINDS.LIKES_WAITING}:`} || "waiting"."userId" || ':' || "waiting"."anchorId"
-    )
-    /* The weekly per-user floor, mirrored from the run so the users it holds
-       back never take a slot in the limit below. Every kind counts, because
-       the floor in the run counts every kind. */
-    AND NOT EXISTS (
-      SELECT 1 FROM "NotificationLog"
-      WHERE "NotificationLog"."userId" = "waiting"."userId"
-      AND "NotificationLog"."sentAt" > ${cooldownFloor}
-    )
-    ORDER BY "waiting"."newestLikeAt" DESC
-    LIMIT ${MAX_CANDIDATES_PER_QUERY}
-  `;
-
-  return rows.map((row) => ({
-    kind: REENGAGEMENT_KINDS.LIKES_WAITING,
-    userId: row.userId,
-    pushToken: row.pushToken,
-    longitude: row.longitude,
-    dedupeKey: `${REENGAGEMENT_KINDS.LIKES_WAITING}:${row.userId}:${row.anchorId}`,
-    title: translate("server:notification.reengagement.likesWaiting.title", {
-      name: row.dogName,
-    }),
-    body: translate("server:notification.reengagement.likesWaiting.body"),
-    url: "swipe",
-  }));
-};
-
-/**
- * Highest value first. A match nobody spoke on is one tap from a conversation;
- * an empty deck is the weakest of the three, so it only gets the slot when
- * nothing better is queued for that user.
- */
-const collectCandidates = async (now: Date) => {
-  const [unansweredMatch, likesWaiting, newDogsNearby] = await Promise.all([
-    selectUnansweredMatchCandidates(now),
-    selectLikesWaitingCandidates(now),
-    selectNewDogsNearbyCandidates(now),
-  ]);
-
-  const byKey = new Map<string, Candidate>();
-  for (const candidate of [
-    ...unansweredMatch,
-    ...likesWaiting,
-    ...newDogsNearby,
-  ]) {
-    if (!byKey.has(candidate.dedupeKey))
-      byKey.set(candidate.dedupeKey, candidate);
-  }
-
-  return [...byKey.values()];
-};
-
 const PRISMA_UNIQUE_VIOLATION = "P2002";
+
+/**
+ * One user's turn at the run, nudges in priority order. `kind` is the best one
+ * they were due whether or not its key survived, so it still names the reason
+ * when `queue` comes out empty.
+ */
+type PendingUser = {
+  kind: ReengagementKind;
+  longitude: number | null;
+  queue: Candidate[];
+};
 
 export class ReengagementService {
   /**
@@ -721,40 +136,32 @@ export class ReengagementService {
    * can be honoured; this method is what decides who is actually due.
    */
   static async run(now = new Date()): Promise<ReengagementRunSummary> {
-    const summary = await ReengagementService.#decide(now);
+    const summary = emptyRunSummary();
 
-    await reportRun(summary, now);
+    // `finally` rather than a catch: the selectors, the claimed key lookup and
+    // the cadence read all run before any per user handling can catch
+    // anything, so a blip in one of them used to end the run with no heartbeat
+    // at all, and a missing hour is documented as a dead cron. The row goes
+    // out either way and the error still leaves through the route.
+    try {
+      await ReengagementService.#decide(summary, now);
+    } finally {
+      await reportRun(summary, now);
+    }
 
     return summary;
   }
 
   /** Everything the run does, minus the reporting the caller wraps it in. */
-  static async #decide(now: Date): Promise<ReengagementRunSummary> {
+  static async #decide(
+    summary: ReengagementRunSummary,
+    now: Date,
+  ): Promise<void> {
     const candidates = await collectCandidates(now);
 
-    const summary: ReengagementRunSummary = {
-      sent: 0,
-      byKind: {
-        [REENGAGEMENT_KINDS.UNANSWERED_MATCH]: 0,
-        [REENGAGEMENT_KINDS.NEW_DOGS_NEARBY]: 0,
-        [REENGAGEMENT_KINDS.LIKES_WAITING]: 0,
-      },
-      candidates: candidates.length,
-      people: 0,
-      suppressed: {
-        already_sent: 0,
-        cooldown: 0,
-        dead_token: 0,
-        gave_up: 0,
-        monthly_cap: 0,
-        window: 0,
-      },
-      held: 0,
-      skippedAlreadySent: 0,
-      skippedUnreachable: 0,
-    };
+    summary.candidates = candidates.length;
 
-    if (candidates.length === 0) return summary;
+    if (candidates.length === 0) return;
 
     // A claimed key is not a candidate. Dropping those here rather than only
     // discovering them inside #send is what lets a user whose best nudge was
@@ -769,57 +176,57 @@ export class ReengagementService {
 
     const claimedKeys = new Set(claimed.map(({ dedupeKey }) => dedupeKey));
 
-    const unclaimed = candidates.filter((candidate) => {
-      if (!claimedKeys.has(candidate.dedupeKey)) return true;
-      summary.skippedAlreadySent += 1;
-      return false;
-    });
-
     // Priority order survives the grouping, so a user's queue runs best nudge
-    // first. Only one of them will actually go out.
-    const perUser = new Map<
-      string,
-      { longitude: number | null; queue: Candidate[] }
-    >();
-    for (const candidate of unclaimed) {
+    // first, and everybody with a candidate gets an entry. Filtering the
+    // claimed ones out before the grouping is what used to lose people: they
+    // left the run counted in nothing but a row level tally, which on an
+    // hourly cron is most of the people it looks at.
+    const perUser = new Map<string, PendingUser>();
+    for (const candidate of candidates) {
+      const spent = claimedKeys.has(candidate.dedupeKey);
+
+      if (spent) summary.skippedAlreadySent += 1;
+
       const existing = perUser.get(candidate.userId);
 
-      if (existing) existing.queue.push(candidate);
-      else
+      if (existing) {
+        if (!spent) existing.queue.push(candidate);
+      } else {
         perUser.set(candidate.userId, {
+          kind: candidate.kind,
           longitude: candidate.longitude,
-          queue: [candidate],
+          queue: spent ? [] : [candidate],
         });
+      }
     }
-
-    if (perUser.size === 0) return summary;
 
     const cadence = await readCadence([...perUser.keys()], now);
 
     const suppress = suppressionRecorder(summary);
 
-    /**
-     * One person's turn, as a function rather than a loop body so that every
-     * way out of it is a return that has already counted them.
-     */
+    /** One person's turn. Every way out of it has counted them first. */
     const settle = async (
       userId: string,
-      longitude: number | null,
-      queue: Candidate[],
+      { kind, longitude, queue }: PendingUser,
     ): Promise<void> => {
       summary.people += 1;
 
       const facts = cadence.get(userId);
-      const [best] = queue;
       const localHour = localHourFor(longitude, now);
 
-      // Two ways to reach no decision at all. The ceiling means the run is
-      // full and everyone behind it is waiting for the next one; a missing
-      // cadence row means the user was deleted between the selector and here.
-      // Neither is a judgement about the person, so neither gets a reason, and
-      // both are counted rather than walked away from.
-      if (summary.sent >= MAX_PUSHES_PER_RUN || !facts || !best) {
+      // Two ways to reach no decision at all: the run is full and everyone
+      // behind it waits for the next one, or the user was deleted between the
+      // selector and here. Neither is a judgement about the person, so neither
+      // gets a reason, and both are counted rather than walked away from.
+      if (summary.sent >= MAX_PUSHES_PER_RUN || !facts) {
         summary.held += 1;
+        return;
+      }
+
+      // Every nudge they were due had already been claimed, so there is
+      // nothing left to try. That is a decision about them and it has a name.
+      if (queue.length === 0) {
+        suppress(userId, kind, "already_sent", localHour);
         return;
       }
 
@@ -832,7 +239,7 @@ export class ReengagementService {
           now,
         );
 
-        if (reason) suppress(userId, best.kind, reason, localHour);
+        if (reason) suppress(userId, kind, reason, localHour);
       } catch (error) {
         // One failed send used to take the run with it, and the run took the
         // heartbeat with it: the hour reported nothing at all, so an outage
@@ -843,21 +250,18 @@ export class ReengagementService {
       }
     };
 
-    for (const [userId, { longitude, queue }] of perUser) {
+    for (const [userId, entry] of perUser) {
       // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cadence they enforce on each other.
-      await settle(userId, longitude, queue);
+      await settle(userId, entry);
     }
-
-    return summary;
   }
 
   /**
    * What to record against one user, or null when the nudge went out.
    *
-   * Split out of the loop so every path through it returns a reason rather
-   * than falling off the end. The three that used to fall off the end are the
-   * whole bug: a queue another run had claimed, a token Expo will not take,
-   * and a send that threw.
+   * Split out of the loop so every path returns a reason rather than falling
+   * off the end. The three that used to fall off it are the whole bug: a
+   * claimed queue, a token Expo will not take, and a send that threw.
    */
   static async #decideOne(
     facts: CadenceFacts,
@@ -889,9 +293,8 @@ export class ReengagementService {
    * loop is what covers a key claimed *during* it, by another instance racing
    * the same candidate.
    *
-   * The two failures are named rather than collapsed into a false, because the
-   * caller has to record one of them against the user and "it did not go" is
-   * not a reason anybody can act on.
+   * The two failures are named rather than collapsed into a false: the caller
+   * has to record one of them, and "it did not go" is not a reason.
    */
   static async #sendFirstAvailable(
     queue: Candidate[],

--- a/packages/api/src/services/reengagement-service.ts
+++ b/packages/api/src/services/reengagement-service.ts
@@ -1,3 +1,4 @@
+import type { CadenceFacts } from "./reengagement-cadence";
 import type { ReengagementRunSummary } from "./reengagement-report";
 import type {
   ReengagementPushKind,
@@ -17,11 +18,9 @@ import { PushNotificationService } from "./push-notification-service";
 import {
   cadenceDecision,
   MIN_GAP_DAYS,
-  POLICY_REPORT_HOUR,
   readCadence,
-  WINDOW_REPORT_HOUR,
 } from "./reengagement-cadence";
-import { reportRun } from "./reengagement-report";
+import { reportRun, suppressionRecorder } from "./reengagement-report";
 import { TranslationService } from "./translation-service";
 
 export type { ReengagementRunSummary } from "./reengagement-report";
@@ -741,13 +740,16 @@ export class ReengagementService {
         [REENGAGEMENT_KINDS.LIKES_WAITING]: 0,
       },
       candidates: candidates.length,
+      people: 0,
       suppressed: {
+        already_sent: 0,
         cooldown: 0,
         dead_token: 0,
         gave_up: 0,
         monthly_cap: 0,
         window: 0,
       },
+      held: 0,
       skippedAlreadySent: 0,
       skippedUnreachable: 0,
     };
@@ -794,57 +796,90 @@ export class ReengagementService {
 
     const cadence = await readCadence([...perUser.keys()], now);
 
+    const suppress = suppressionRecorder(summary);
+
     /**
-     * Count it always, report it once a day.
-     *
-     * See {@link POLICY_REPORT_HOUR}. The summary is per run because the cron
-     * response is read per run; the event is per person because that is the
-     * number the readout is being asked for.
+     * One person's turn, as a function rather than a loop body so that every
+     * way out of it is a return that has already counted them.
      */
-    const suppress = (
+    const settle = async (
       userId: string,
-      kind: ReengagementKind,
-      reason: ReengagementSuppressionReason,
-      localHour: number,
-    ) => {
-      summary.suppressed[reason] += 1;
-
-      const reportAt =
-        reason === "window" ? WINDOW_REPORT_HOUR : POLICY_REPORT_HOUR;
-
-      if (localHour !== reportAt) return;
-
-      captureEvent(userId, ANALYTICS_EVENTS.REENGAGEMENT_PUSH_SUPPRESSED, {
-        kind,
-        reason,
-      });
-    };
-
-    for (const [userId, { longitude, queue }] of perUser) {
-      if (summary.sent >= MAX_PUSHES_PER_RUN) break;
+      longitude: number | null,
+      queue: Candidate[],
+    ): Promise<void> => {
+      summary.people += 1;
 
       const facts = cadence.get(userId);
       const [best] = queue;
+      const localHour = localHourFor(longitude, now);
 
-      // A missing row means the user was deleted between the selector and here.
-      if (facts && best) {
-        const localHour = localHourFor(longitude, now);
-        const decision = cadenceDecision(facts, now);
-
-        // The cadence is decided before the clock, so somebody held back for a
-        // month is not also counted as "wrong hour" twenty-two times a day.
-        if (!decision.allowed) {
-          suppress(userId, best.kind, decision.reason, localHour);
-        } else if (SEND_WINDOW_HOURS.has(localHour)) {
-          // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cadence they enforce on each other.
-          await ReengagementService.#sendFirstAvailable(queue, summary, now);
-        } else {
-          suppress(userId, best.kind, "window", localHour);
-        }
+      // Two ways to reach no decision at all. The ceiling means the run is
+      // full and everyone behind it is waiting for the next one; a missing
+      // cadence row means the user was deleted between the selector and here.
+      // Neither is a judgement about the person, so neither gets a reason, and
+      // both are counted rather than walked away from.
+      if (summary.sent >= MAX_PUSHES_PER_RUN || !facts || !best) {
+        summary.held += 1;
+        return;
       }
+
+      try {
+        const reason = await ReengagementService.#decideOne(
+          facts,
+          queue,
+          localHour,
+          summary,
+          now,
+        );
+
+        if (reason) suppress(userId, best.kind, reason, localHour);
+      } catch (error) {
+        // One failed send used to take the run with it, and the run took the
+        // heartbeat with it: the hour reported nothing at all, so an outage
+        // read exactly like a cron that had stopped being scheduled. Every
+        // person after this one in the map was lost too.
+        sendError(error);
+        summary.held += 1;
+      }
+    };
+
+    for (const [userId, { longitude, queue }] of perUser) {
+      // oxlint-disable-next-line no-await-in-loop -- Each send claims its dedupe key first; running them in parallel would race the cadence they enforce on each other.
+      await settle(userId, longitude, queue);
     }
 
     return summary;
+  }
+
+  /**
+   * What to record against one user, or null when the nudge went out.
+   *
+   * Split out of the loop so every path through it returns a reason rather
+   * than falling off the end. The three that used to fall off the end are the
+   * whole bug: a queue another run had claimed, a token Expo will not take,
+   * and a send that threw.
+   */
+  static async #decideOne(
+    facts: CadenceFacts,
+    queue: Candidate[],
+    localHour: number,
+    summary: ReengagementRunSummary,
+    now: Date,
+  ): Promise<ReengagementSuppressionReason | null> {
+    // The cadence is decided before the clock, so somebody held back for a
+    // month is not also counted as "wrong hour" twenty-two times a day.
+    const decision = cadenceDecision(facts, now);
+
+    if (!decision.allowed) return decision.reason;
+    if (!SEND_WINDOW_HOURS.has(localHour)) return "window";
+
+    const outcome = await ReengagementService.#sendFirstAvailable(
+      queue,
+      summary,
+      now,
+    );
+
+    return outcome === "sent" ? null : outcome;
   }
 
   /**
@@ -853,12 +888,16 @@ export class ReengagementService {
    * The queue is already free of keys claimed before the run started; this
    * loop is what covers a key claimed *during* it, by another instance racing
    * the same candidate.
+   *
+   * The two failures are named rather than collapsed into a false, because the
+   * caller has to record one of them against the user and "it did not go" is
+   * not a reason anybody can act on.
    */
   static async #sendFirstAvailable(
     queue: Candidate[],
     summary: ReengagementRunSummary,
     now: Date,
-  ): Promise<boolean> {
+  ): Promise<"already_sent" | "dead_token" | "sent"> {
     for (const candidate of queue) {
       // A token Expo will reject is a guaranteed dropped push, and it is the
       // same token for every candidate this user has, so there is nothing left
@@ -866,7 +905,7 @@ export class ReengagementService {
       // open rate, which is the number this whole change exists to produce.
       if (!Expo.isExpoPushToken(candidate.pushToken)) {
         summary.skippedUnreachable += 1;
-        return false;
+        return "dead_token";
       }
 
       // oxlint-disable-next-line no-await-in-loop -- Sequential by design: the next candidate is only tried when this one turns out to be claimed.
@@ -875,13 +914,13 @@ export class ReengagementService {
       if (outcome === "sent") {
         summary.sent += 1;
         summary.byKind[candidate.kind] += 1;
-        return true;
+        return "sent";
       }
 
       summary.skippedAlreadySent += 1;
     }
 
-    return false;
+    return "already_sent";
   }
 
   /**

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -150,10 +150,20 @@ export type ReengagementPushKind =
  * Why a re-engagement push that had something to say was not sent.
  *
  * Restated here rather than imported for the same reason the kinds above are.
- * `window` is the only one that is not a cadence decision: the candidate was
- * due but the run caught the user outside their evening slot.
+ * Three of these are not cadence decisions. `window` is the candidate being
+ * due while the run caught the user outside their evening slot.
+ * `already_sent` is every nudge in that person's queue having had its dedupe
+ * key claimed by a run racing this one. `dead_token` doubles as the device
+ * having a token Expo will not accept at all, which is decided at the send
+ * rather than by the cadence.
+ *
+ * The list is closed on purpose: a candidate leaves a run either sent or with
+ * one of these against their name, so the two numbers add up to the people the
+ * run looked at. Anything that escaped both used to vanish, which is what made
+ * a week of zero sends unreadable.
  */
 export type ReengagementSuppressionReason =
+  | "already_sent"
   | "cooldown"
   | "dead_token"
   | "gave_up"
@@ -641,9 +651,35 @@ export type ServerEventProperties = {
    */
   [ANALYTICS_EVENTS.REENGAGEMENT_CRON_RAN]: {
     candidates: number;
+    /**
+     * People the run looked at and reached no decision about.
+     *
+     * Zero in a healthy run. It is above zero when the per run push ceiling
+     * cut the loop short, when a user was deleted between the selector and the
+     * decision, or when their send threw. The first is a backlog, the other
+     * two are bugs, and before this existed all three left the person out of
+     * every count on this row.
+     */
+    held: number;
+    /**
+     * Distinct users behind `candidates`.
+     *
+     * `candidates` counts rows and one person can hold several, so the two are
+     * different units and reading `candidates` against `sent` invites the
+     * wrong subtraction. This is the number that reconciles: `people` equals
+     * `sent` plus every `suppressed_*` plus `held`, always.
+     */
+    people: number;
     sent: number;
     skipped_already_sent: number;
     skipped_unreachable: number;
+    /**
+     * Every one of these counts people once per run, including the people
+     * whose per user `Reengagement Push Suppressed` event was held back by the
+     * once a day report hour. A hold that only shows up in the events is
+     * invisible for twenty three hours out of twenty four; here it is not.
+     */
+    suppressed_already_sent: number;
     suppressed_cooldown: number;
     suppressed_dead_token: number;
     suppressed_gave_up: number;

--- a/packages/shared/analytics/events.ts
+++ b/packages/shared/analytics/events.ts
@@ -152,8 +152,11 @@ export type ReengagementPushKind =
  * Restated here rather than imported for the same reason the kinds above are.
  * Three of these are not cadence decisions. `window` is the candidate being
  * due while the run caught the user outside their evening slot.
- * `already_sent` is every nudge in that person's queue having had its dedupe
- * key claimed by a run racing this one. `dead_token` doubles as the device
+ * `already_sent` is every nudge that person was due having had its dedupe key
+ * claimed already, by an earlier run or by one racing this one. It is only
+ * reported for somebody the cadence would otherwise have allowed, inside their
+ * own hour, so it reads as "due and nothing left to say" rather than burying
+ * the schedule reasons underneath it. `dead_token` doubles as the device
  * having a token Expo will not accept at all, which is decided at the send
  * rather than by the cadence.
  *
@@ -651,6 +654,15 @@ export type ServerEventProperties = {
    */
   [ANALYTICS_EVENTS.REENGAGEMENT_CRON_RAN]: {
     candidates: number;
+    /**
+     * The run threw before it finished deciding.
+     *
+     * A failed run reports whatever it had counted, and a failure in the
+     * selectors or the cadence read means that is zero across the board. That
+     * is the same row a quiet evening produces, so without this flag a
+     * database outage reads as an evening with nobody to nudge.
+     */
+    failed: boolean;
     /**
      * People the run looked at and reached no decision about.
      *

--- a/scripts/metrics/daily.mjs
+++ b/scripts/metrics/daily.mjs
@@ -27,6 +27,7 @@ import {
   buildOtaUpdatesQuery,
   buildPushAttributedReturnsQuery,
   buildReengagementCronQuery,
+  buildReengagementCronRunsQuery,
   buildTotalsQuery,
   buildWindows,
 } from "./queries.mjs";
@@ -80,6 +81,7 @@ export async function runDailyMetrics({
     activeUsersByCity,
     activeUsersByVersion,
     cronRun,
+    cronRuns,
     deckSupply,
     otaUpdates,
     totals,
@@ -99,6 +101,10 @@ export async function runDailyMetrics({
     run(
       "pegada daily metrics: reengagement cron runs",
       buildReengagementCronQuery(windows),
+    ),
+    run(
+      "pegada daily metrics: reengagement cron, last 24 runs",
+      buildReengagementCronRunsQuery(windows),
     ),
     run("pegada daily metrics: deck supply", buildDeckSupplyQuery(windows)),
     run(
@@ -135,6 +141,7 @@ export async function runDailyMetrics({
     activeUsersByVersion,
     breakdowns,
     cronRun,
+    cronRuns,
     deckSupply,
     generatedAt: now,
     otaUpdates,

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -106,6 +106,28 @@ function fakeWorld({ existingComment = null } = {}) {
           results: [[168, "2026-09-02 11:00:00", 512, 3, 1, 2, 24, 9]],
         });
       }
+      if (name.endsWith("reengagement cron, last 24 runs")) {
+        return json({
+          columns: [
+            "run_at",
+            "candidates",
+            "people",
+            "sent",
+            "held",
+            "suppressed_already_sent",
+            "suppressed_cooldown",
+            "suppressed_dead_token",
+            "suppressed_gave_up",
+            "suppressed_monthly_cap",
+            "suppressed_window",
+            "suppressed",
+          ],
+          results: [
+            ["2026-09-02 11:00:00", 3, 3, 1, 0, 0, 1, 0, 0, 0, 1, 2],
+            ["2026-09-02 10:00:00", 4, 4, 1, 0, 0, 3, 0, 0, 0, 0, 3],
+          ],
+        });
+      }
       if (name.endsWith("deck supply")) {
         return json({
           columns: [
@@ -191,7 +213,7 @@ test("a dry run renders the comment and never touches GitHub", async () => {
 test("one query goes out per metric block", async () => {
   const fetchImpl = fakeWorld();
   await runDailyMetrics({ argv: ["--dry-run"], env: ENV, fetchImpl, now: NOW });
-  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 9);
+  assert.equal(fetchImpl.calls.length, BREAKDOWNS.length + 10);
 });
 
 test("both push return windows are asked for separately and land in the table", async () => {
@@ -345,4 +367,28 @@ test("the cron heartbeat reaches the push section", async () => {
   assert.match(result.body, /\| Last run \| 2026-09-02 11:00 UTC \|/);
   assert.match(result.body, /\| Users in weekly floor \(last run\) \| 512 \|/);
   assert.match(result.body, /\| Sent \(last 7 days\) \| 9 \|/);
+});
+
+test("the per run table reaches the readout with its reasons", async () => {
+  const fetchImpl = fakeWorld();
+  const result = await runDailyMetrics({
+    argv: ["--dry-run"],
+    env: ENV,
+    fetchImpl,
+    now: NOW,
+  });
+
+  const call = fetchImpl.calls.find((entry) =>
+    entry.body?.name?.endsWith("reengagement cron, last 24 runs"),
+  );
+  assert.match(call.body.query.query, /ORDER BY run_at DESC/);
+  assert.match(result.body, /#### Reengagement cron, last 24 runs/);
+  assert.match(
+    result.body,
+    /\| 2026-09-02 11:00 UTC \| 3 \| 3 \| 1 \| 2 \| 0 \| cooldown 1, window 1 \|/,
+  );
+  assert.match(
+    result.body,
+    /\| 2026-09-02 10:00 UTC \| 4 \| 4 \| 1 \| 3 \| 0 \| cooldown 3 \|/,
+  );
 });

--- a/scripts/metrics/daily.test.mjs
+++ b/scripts/metrics/daily.test.mjs
@@ -114,6 +114,7 @@ function fakeWorld({ existingComment = null } = {}) {
             "people",
             "sent",
             "held",
+            "failed",
             "suppressed_already_sent",
             "suppressed_cooldown",
             "suppressed_dead_token",
@@ -123,8 +124,8 @@ function fakeWorld({ existingComment = null } = {}) {
             "suppressed",
           ],
           results: [
-            ["2026-09-02 11:00:00", 3, 3, 1, 0, 0, 1, 0, 0, 0, 1, 2],
-            ["2026-09-02 10:00:00", 4, 4, 1, 0, 0, 3, 0, 0, 0, 0, 3],
+            ["2026-09-02 11:00:00", 3, 3, 1, 0, false, 0, 1, 0, 0, 0, 1, 2],
+            ["2026-09-02 10:00:00", 4, 4, 1, 0, false, 0, 3, 0, 0, 0, 0, 3],
           ],
         });
       }

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -728,7 +728,12 @@ export function buildReengagementCronRunsQuery(windows) {
     `  ifNull(${numericProperty("people")}, 0) AS people,`,
     `  ${numericProperty("sent")} AS sent,`,
     `  ifNull(${numericProperty("held")}, 0) AS held,`,
-    "  ifNull(toBool(properties.failed), false) AS failed,",
+    // Read as a string like every other boolean in this file. Every run
+    // emitted before this shipped carries no `failed` property at all, so the
+    // missing case is the common one on the day it deploys, and a comparison
+    // that reads absent as false is what keeps those rows out of the failed
+    // bucket.
+    `  toString(properties.failed) = 'true' AS failed,`,
     ...CRON_SUPPRESSION_PROPERTIES.map(
       (property) => `  ifNull(${numericProperty(property)}, 0) AS ${property},`,
     ),

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -624,6 +624,14 @@ export function buildPushAttributedReturnsQuery({ end, start }) {
 }
 
 /**
+ * How many runs the per run table asks for.
+ *
+ * One day of an hourly job. Enough to see a gap in the cadence without turning
+ * the readout into a log.
+ */
+export const CRON_RUN_ROWS = 24;
+
+/**
  * The five ways the cron can decide against a nudge it had ready.
  *
  * Summed into one number for the run table rather than split: the split
@@ -631,6 +639,7 @@ export function buildPushAttributedReturnsQuery({ end, start }) {
  * this row answers is only how much of the run was held back.
  */
 export const CRON_SUPPRESSION_PROPERTIES = [
+  "suppressed_already_sent",
   "suppressed_cooldown",
   "suppressed_dead_token",
   "suppressed_gave_up",
@@ -678,6 +687,57 @@ export function buildReengagementCronQuery(windows) {
     `WHERE timestamp >= toDateTime(${quote(clickhouseTime(windows.currentStart))}, 'UTC')`,
     `  AND timestamp < toDateTime(${quote(clickhouseTime(windows.currentEnd))}, 'UTC')`,
     `  AND event = ${quote(EVENTS.REENGAGEMENT_CRON_RAN)}`,
+  ].join("\n");
+}
+
+/**
+ * The last 24 cron runs, one row each.
+ *
+ * The heartbeat above collapses the whole week into one latest run, which
+ * answers whether the job is alive and nothing after that. A day where the
+ * cron ran every hour and held everybody back reads exactly like a day where
+ * it ran once and found nobody, and those two have different fixes, so this
+ * pulls the runs apart and keeps every suppression reason beside the run it
+ * belongs to.
+ *
+ * 24 rows rather than a fixed day: the job reports hourly, so this is the last
+ * day while it is healthy and reaches further back once it starts skipping
+ * hours, which is the stretch worth looking at.
+ *
+ * Newest first, because the run being asked about is almost always the last
+ * one. The reasons are read with `ifNull` for the same reason the heartbeat
+ * does it: a run that predates a reason carries no property for it, and a null
+ * in the sum would take the run's whole suppressed total with it. `people` and
+ * `held` are read the same way and for the same reason: every run older than
+ * the change that added them carries neither.
+ *
+ * `people` is the column the row is checked against. `candidates` counts rows
+ * and one person can hold several, so sent and suppressed were never meant to
+ * add up to it. They do add up to `people`, together with `held`, and a row
+ * where they do not is a run that lost somebody.
+ */
+export function buildReengagementCronRunsQuery(windows) {
+  const suppressed = CRON_SUPPRESSION_PROPERTIES.map(
+    (property) => `ifNull(${numericProperty(property)}, 0)`,
+  ).join(" + ");
+
+  return [
+    "SELECT",
+    "  timestamp AS run_at,",
+    `  ${numericProperty("candidates")} AS candidates,`,
+    `  ifNull(${numericProperty("people")}, 0) AS people,`,
+    `  ${numericProperty("sent")} AS sent,`,
+    `  ifNull(${numericProperty("held")}, 0) AS held,`,
+    ...CRON_SUPPRESSION_PROPERTIES.map(
+      (property) => `  ifNull(${numericProperty(property)}, 0) AS ${property},`,
+    ),
+    `  ${suppressed} AS suppressed`,
+    "FROM events",
+    `WHERE timestamp >= toDateTime(${quote(clickhouseTime(windows.currentStart))}, 'UTC')`,
+    `  AND timestamp < toDateTime(${quote(clickhouseTime(windows.currentEnd))}, 'UTC')`,
+    `  AND event = ${quote(EVENTS.REENGAGEMENT_CRON_RAN)}`,
+    "ORDER BY run_at DESC",
+    `LIMIT ${CRON_RUN_ROWS}`,
   ].join("\n");
 }
 

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -728,6 +728,7 @@ export function buildReengagementCronRunsQuery(windows) {
     `  ifNull(${numericProperty("people")}, 0) AS people,`,
     `  ${numericProperty("sent")} AS sent,`,
     `  ifNull(${numericProperty("held")}, 0) AS held,`,
+    "  ifNull(toBool(properties.failed), false) AS failed,",
     ...CRON_SUPPRESSION_PROPERTIES.map(
       (property) => `  ifNull(${numericProperty(property)}, 0) AS ${property},`,
     ),

--- a/scripts/metrics/queries.mjs
+++ b/scripts/metrics/queries.mjs
@@ -632,7 +632,7 @@ export function buildPushAttributedReturnsQuery({ end, start }) {
 export const CRON_RUN_ROWS = 24;
 
 /**
- * The five ways the cron can decide against a nudge it had ready.
+ * The six ways the cron can decide against a nudge it had ready.
  *
  * Summed into one number for the run table rather than split: the split
  * already has a table of its own further down the readout, and the question

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   BREAKDOWNS,
   CITY_TABLE_ROWS,
+  CRON_RUN_ROWS,
   CRON_SUPPRESSION_PROPERTIES,
   CITY_UNKNOWN_BUCKET,
   CLIENT_LIBS,
@@ -24,6 +25,7 @@ import {
   buildDeckSupplyQuery,
   buildPushAttributedReturnsQuery,
   buildReengagementCronQuery,
+  buildReengagementCronRunsQuery,
   buildTotalsQuery,
   buildWindows,
   quote,
@@ -585,6 +587,7 @@ test("the cron heartbeat reads the latest run and the window sums", () => {
 test("the cron heartbeat adds up every suppression reason the event carries", () => {
   const query = buildReengagementCronQuery(buildWindows(NOW));
   assert.deepEqual(CRON_SUPPRESSION_PROPERTIES, [
+    "suppressed_already_sent",
     "suppressed_cooldown",
     "suppressed_dead_token",
     "suppressed_gave_up",
@@ -608,4 +611,47 @@ test("the cron heartbeat reads one window and no comparison", () => {
   assert.match(query, /timestamp < toDateTime\('2026-09-02 12:00:00', 'UTC'\)/);
   assert.equal(query.includes("'current', 'previous'"), false);
   assert.equal(query.includes("GROUP BY"), false);
+});
+
+test("the per run table reads one row per run, newest first", () => {
+  const query = buildReengagementCronRunsQuery(buildWindows(NOW));
+  assert.match(query, /AND event = 'Reengagement Cron Ran'/);
+  assert.match(query, /timestamp AS run_at/);
+  assert.match(
+    query,
+    /toFloat64OrNull\(toString\(properties\.candidates\)\) AS candidates/,
+  );
+  assert.match(
+    query,
+    /toFloat64OrNull\(toString\(properties\.sent\)\) AS sent/,
+  );
+  assert.match(query, /ORDER BY run_at DESC/);
+  assert.match(query, new RegExp(`LIMIT ${CRON_RUN_ROWS}`));
+  assert.equal(CRON_RUN_ROWS, 24);
+  // One row per run, so nothing is collapsed on the way out.
+  assert.equal(query.includes("GROUP BY"), false);
+  assert.equal(query.includes("argMax"), false);
+});
+
+test("the per run table carries every suppression reason and their total", () => {
+  const query = buildReengagementCronRunsQuery(buildWindows(NOW));
+  for (const property of CRON_SUPPRESSION_PROPERTIES) {
+    assert.match(
+      query,
+      new RegExp(
+        `ifNull\\(toFloat64OrNull\\(toString\\(properties\\.${property}\\)\\), 0\\) AS ${property}`,
+      ),
+    );
+  }
+  assert.match(query, /\) AS suppressed$/m);
+});
+
+test("the per run table reads the current window only", () => {
+  const query = buildReengagementCronRunsQuery(buildWindows(NOW));
+  assert.match(
+    query,
+    /timestamp >= toDateTime\('2026-08-26 12:00:00', 'UTC'\)/,
+  );
+  assert.match(query, /timestamp < toDateTime\('2026-09-02 12:00:00', 'UTC'\)/);
+  assert.equal(query.includes("'current', 'previous'"), false);
 });

--- a/scripts/metrics/queries.test.mjs
+++ b/scripts/metrics/queries.test.mjs
@@ -584,6 +584,14 @@ test("the cron heartbeat reads the latest run and the window sums", () => {
   );
 });
 
+test("a run that never carried the failed property is not read as failed", () => {
+  const query = buildReengagementCronRunsQuery(buildWindows(NOW));
+  // Absent has to read as false. Every heartbeat sent before the flag existed
+  // has no property here, and reading those as failures would paint the whole
+  // history red on the day this ships.
+  assert.match(query, /toString\(properties\.failed\) = 'true' AS failed/);
+});
+
 test("the cron heartbeat adds up every suppression reason the event carries", () => {
   const query = buildReengagementCronQuery(buildWindows(NOW));
   assert.deepEqual(CRON_SUPPRESSION_PROPERTIES, [

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -376,6 +376,16 @@ export function reengagementCronTable(rows) {
 const NO_REASONS = "-";
 
 /**
+ * What a reasons cell says when the run threw.
+ *
+ * A failed run reports whatever it had counted, which for a failure in the
+ * selection is zero everywhere, and that is the row a quiet evening produces
+ * too. Saying so in the cell the reader is already looking at beats a column
+ * that is false on every healthy row.
+ */
+const RUN_FAILED = "run failed";
+
+/**
  * A suppression reason as the table writes it.
  *
  * The property name without its prefix, so `suppressed_monthly_cap` reads
@@ -419,6 +429,10 @@ export function reengagementCronRunsTable(rows) {
     "| Hour (UTC) | Candidates | People | Sent | Suppressed | Held | Reasons |",
     "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
     ...ordered.map(({ row }) => {
+      if (row.failed === true || row.failed === 1) {
+        return `| ${utcMoment(row.run_at)} | ${wholeCount(row.candidates)} | ${wholeCount(row.people)} | ${wholeCount(row.sent)} | ${wholeCount(row.suppressed)} | ${wholeCount(row.held)} | ${RUN_FAILED} |`;
+      }
+
       const reasons = CRON_SUPPRESSION_PROPERTIES.filter(
         (property) => Number(row[property] ?? 0) > 0,
       )

--- a/scripts/metrics/report.mjs
+++ b/scripts/metrics/report.mjs
@@ -10,13 +10,14 @@ import {
   BREAKDOWNS,
   CITY_TABLE_ROWS,
   CITY_UNKNOWN_BUCKET,
+  CRON_SUPPRESSION_PROPERTIES,
   DECK_TIERS,
   EVENTS,
   OTA_UNKNOWN_BUCKET,
   PUSH_RETURN_WINDOW_MINUTES,
   STORE_BUILD_COVERAGE,
 } from "./queries.mjs";
-import { utcMoment, utcStamp } from "./timestamps.mjs";
+import { parseTimestamp, utcMoment, utcStamp } from "./timestamps.mjs";
 
 export const COMMENT_MARKER = "<!-- pegada-daily-metrics -->";
 
@@ -325,6 +326,17 @@ export const CRON_SOURCE_NOTE =
   "The cron reports one row an hour. Users in weekly floor is how many people had already been notified inside the last week when it last ran, and they are never candidates, so a large floor next to zero sends is the cadence holding people rather than a broken job. A last run several hours old is the job.";
 
 /**
+ * A cron count, printed as whole people.
+ *
+ * The counts cross the wire as JSON and come back through `sum`, so they
+ * arrive as floats. They count people, so they are printed as whole numbers
+ * rather than with a stray decimal.
+ */
+function wholeCount(value) {
+  return number(Math.round(Number(value ?? 0)));
+}
+
+/**
  * The reengagement cron heartbeat.
  *
  * The last run rather than a window average, because the floor is a level: the
@@ -339,26 +351,85 @@ export function reengagementCronTable(rows) {
     return CRON_SILENT_LINE;
   }
 
-  // The counts cross the wire as JSON and come back through `sum`, so they
-  // arrive as floats. They are counts of people, so they are printed as whole
-  // numbers rather than with a stray decimal.
-  const count = (value) => number(Math.round(Number(value ?? 0)));
-
   const readings = [
     ["Last run", utcMoment(row.last_run_at)],
     ["Runs in the last 7 days", number(runs)],
-    ["Users in weekly floor (last run)", count(row.last_users_in_weekly_floor)],
-    ["Candidates (last run)", count(row.last_candidates)],
-    ["Sent (last run)", count(row.last_sent)],
-    ["Suppressed (last run)", count(row.last_suppressed)],
-    ["Candidates (last 7 days)", count(row.candidates)],
-    ["Sent (last 7 days)", count(row.sent)],
+    [
+      "Users in weekly floor (last run)",
+      wholeCount(row.last_users_in_weekly_floor),
+    ],
+    ["Candidates (last run)", wholeCount(row.last_candidates)],
+    ["Sent (last run)", wholeCount(row.last_sent)],
+    ["Suppressed (last run)", wholeCount(row.last_suppressed)],
+    ["Candidates (last 7 days)", wholeCount(row.candidates)],
+    ["Sent (last 7 days)", wholeCount(row.sent)],
   ];
 
   return [
     "| Reading | Value |",
     "| --- | ---: |",
     ...readings.map(([label, value]) => `| ${label} | ${value} |`),
+  ].join("\n");
+}
+
+/** What a reasons cell says when the run held nobody back. */
+const NO_REASONS = "-";
+
+/**
+ * A suppression reason as the table writes it.
+ *
+ * The property name without its prefix, so `suppressed_monthly_cap` reads
+ * `monthly cap`. Derived rather than spelled out in a second list, so a reason
+ * added to the event shows up here without anybody remembering to add it.
+ */
+function suppressionLabel(property) {
+  return property.replace("suppressed_", "").replaceAll("_", " ");
+}
+
+/**
+ * Every cron run of the last day, one row each.
+ *
+ * The heartbeat above prints a single run, so an hour that sent nothing and a
+ * day that sent nothing look the same in it. This is the table that tells them
+ * apart: a gap in the hours is the job, and a full column of hours with zero
+ * sends is the rules. The reasons cell names which rule did the holding, which
+ * is the part a suppressed total cannot say.
+ *
+ * Only the non zero reasons are printed. A row carrying six zeroes reads the
+ * same as an empty cell and takes the width the real ones need.
+ *
+ * People rather than candidates is what sent and suppressed are checked
+ * against: candidates counts rows and a person can hold several. Held is
+ * whoever the run reached no decision about, so it should read zero, and a
+ * column of it that does not is the thing to go and look at.
+ *
+ * Sorted here as well as in the query. The rows are read newest first whatever
+ * order they arrive in, and a fixture is allowed to hand them over unsorted.
+ */
+export function reengagementCronRunsTable(rows) {
+  const ordered = (rows ?? [])
+    .map((row) => ({ at: parseTimestamp(row.run_at), row }))
+    .sort((a, b) => (b.at?.getTime() ?? 0) - (a.at?.getTime() ?? 0));
+
+  if (ordered.length === 0) {
+    return CRON_SILENT_LINE;
+  }
+
+  return [
+    "| Hour (UTC) | Candidates | People | Sent | Suppressed | Held | Reasons |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ...ordered.map(({ row }) => {
+      const reasons = CRON_SUPPRESSION_PROPERTIES.filter(
+        (property) => Number(row[property] ?? 0) > 0,
+      )
+        .map(
+          (property) =>
+            `${suppressionLabel(property)} ${wholeCount(row[property])}`,
+        )
+        .join(", ");
+
+      return `| ${utcMoment(row.run_at)} | ${wholeCount(row.candidates)} | ${wholeCount(row.people)} | ${wholeCount(row.sent)} | ${wholeCount(row.suppressed)} | ${wholeCount(row.held)} | ${reasons || NO_REASONS} |`;
+    }),
   ].join("\n");
 }
 
@@ -421,6 +492,7 @@ export function buildReport({
   activeUsersByVersion,
   breakdowns,
   cronRun = [],
+  cronRuns = [],
   deckSupply,
   generatedAt,
   otaUpdates,
@@ -615,6 +687,10 @@ export function buildReport({
     reengagementCronTable(cronRun),
     "",
     CRON_SOURCE_NOTE,
+    "",
+    "#### Reengagement cron, last 24 runs",
+    "",
+    reengagementCronRunsTable(cronRuns),
     "",
     coverageNote(),
     "",

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -46,13 +46,17 @@ const cities = versions;
  * `people` defaults to whatever the run accounted for, so a fixture that does
  * not care about it still balances the way a real run has to.
  */
-function cronRunRow(runAt, { candidates, held = 0, people, sent, ...reasons }) {
+function cronRunRow(
+  runAt,
+  { candidates, failed = false, held = 0, people, sent, ...reasons },
+) {
   const suppressed = Object.values(reasons).reduce(
     (total, value) => total + value,
     0,
   );
   return {
     candidates,
+    failed,
     held,
     people: people ?? sent + suppressed + held,
     run_at: runAt,
@@ -908,6 +912,19 @@ test("a run that reached no decision about somebody says so", () => {
   assert.match(
     table,
     /\| 2026-09-02 09:00 UTC \| 3 \| 3 \| 2 \| 0 \| 1 \| - \|/,
+  );
+});
+
+test("a run that threw says so instead of reading as a quiet hour", () => {
+  // A failed run reports whatever it had counted, which for a failure in the
+  // selection is zero everywhere, and that is the row a quiet evening
+  // produces too.
+  const table = reengagementCronRunsTable([
+    cronRunRow("2026-09-02 09:00:00", { candidates: 0, failed: true, sent: 0 }),
+  ]);
+  assert.match(
+    table,
+    /\| 2026-09-02 09:00 UTC \| 0 \| 0 \| 0 \| 0 \| 0 \| run failed \|/,
   );
 });
 

--- a/scripts/metrics/report.test.mjs
+++ b/scripts/metrics/report.test.mjs
@@ -14,6 +14,7 @@ import {
   formatDelta,
   formatRateDelta,
   noCityLine,
+  reengagementCronRunsTable,
   reengagementCronTable,
 } from "./report.mjs";
 
@@ -38,6 +39,34 @@ function versions(rows) {
 
 /** The city split comes back in the same shape as the version split. */
 const cities = versions;
+
+/**
+ * One cron run, with the reasons it did not carry left at zero.
+ *
+ * `people` defaults to whatever the run accounted for, so a fixture that does
+ * not care about it still balances the way a real run has to.
+ */
+function cronRunRow(runAt, { candidates, held = 0, people, sent, ...reasons }) {
+  const suppressed = Object.values(reasons).reduce(
+    (total, value) => total + value,
+    0,
+  );
+  return {
+    candidates,
+    held,
+    people: people ?? sent + suppressed + held,
+    run_at: runAt,
+    sent,
+    suppressed,
+    suppressed_already_sent: 0,
+    suppressed_cooldown: 0,
+    suppressed_dead_token: 0,
+    suppressed_gave_up: 0,
+    suppressed_monthly_cap: 0,
+    suppressed_window: 0,
+    ...reasons,
+  };
+}
 
 function otaRows(rows) {
   return rows.map(
@@ -209,6 +238,20 @@ const FIXTURE = {
       runs: 168,
       sent: 9,
     },
+  ],
+  cronRuns: [
+    cronRunRow("2026-09-02 09:00:00", { candidates: 2, sent: 2 }),
+    cronRunRow("2026-09-02 11:00:00", {
+      candidates: 3,
+      sent: 1,
+      suppressed_cooldown: 1,
+      suppressed_window: 1,
+    }),
+    cronRunRow("2026-09-02 10:00:00", {
+      candidates: 4,
+      sent: 1,
+      suppressed_cooldown: 3,
+    }),
   ],
   deckSupply: deck([
     ["current", 100, 840, 1000, 700, 90, 30, 20, 40],
@@ -808,6 +851,71 @@ test("a week with no cron run says the job is the reason, not the week", () => {
   const body = buildReport({ ...FIXTURE, cronRun: [] });
   assert.equal(body.includes(CRON_SILENT_LINE), true);
   assert.equal(body.includes("| Last run |"), false);
+});
+
+test("the per run table prints the runs newest first", () => {
+  const body = buildReport(FIXTURE);
+  const [, section] = body.split("#### Reengagement cron, last 24 runs");
+  const hours = [...section.matchAll(/\| (2026-09-02 \d{2}:00) UTC \|/g)].map(
+    (match) => match[1],
+  );
+  assert.deepEqual(hours, [
+    "2026-09-02 11:00",
+    "2026-09-02 10:00",
+    "2026-09-02 09:00",
+  ]);
+  assert.match(
+    section,
+    /\| Hour \(UTC\) \| Candidates \| People \| Sent \| Suppressed \| Held \| Reasons \|/,
+  );
+  assert.match(
+    section,
+    /\| --- \| ---: \| ---: \| ---: \| ---: \| ---: \| --- \|/,
+  );
+});
+
+test("the reasons cell names only the rules that held somebody", () => {
+  const table = reengagementCronRunsTable(FIXTURE.cronRuns);
+  assert.match(
+    table,
+    /\| 2026-09-02 11:00 UTC \| 3 \| 3 \| 1 \| 2 \| 0 \| cooldown 1, window 1 \|/,
+  );
+  assert.match(
+    table,
+    /\| 2026-09-02 10:00 UTC \| 4 \| 4 \| 1 \| 3 \| 0 \| cooldown 3 \|/,
+  );
+  assert.equal(table.includes("dead token"), false);
+  assert.equal(table.includes("monthly cap"), false);
+});
+
+test("a run that held nobody back prints a dash instead of a list of zeroes", () => {
+  const table = reengagementCronRunsTable([
+    cronRunRow("2026-09-02 09:00:00", { candidates: 2, sent: 2 }),
+  ]);
+  assert.match(
+    table,
+    /\| 2026-09-02 09:00 UTC \| 2 \| 2 \| 2 \| 0 \| 0 \| - \|/,
+  );
+});
+
+test("a run that reached no decision about somebody says so", () => {
+  // The number the fix exists to make visible. Held is people the run walked
+  // past, so a column of zeroes is the healthy reading and anything else is
+  // worth opening.
+  const table = reengagementCronRunsTable([
+    cronRunRow("2026-09-02 09:00:00", { candidates: 3, held: 1, sent: 2 }),
+  ]);
+  assert.match(
+    table,
+    /\| 2026-09-02 09:00 UTC \| 3 \| 3 \| 2 \| 0 \| 1 \| - \|/,
+  );
+});
+
+test("no runs at all reads as the job rather than a quiet day", () => {
+  assert.equal(reengagementCronRunsTable([]), CRON_SILENT_LINE);
+  assert.equal(reengagementCronRunsTable(), CRON_SILENT_LINE);
+  const body = buildReport({ ...FIXTURE, cronRuns: [] });
+  assert.equal(body.includes("| Hour (UTC) |"), false);
 });
 
 test("a heartbeat that reports no runs reads the same as no heartbeat", () => {


### PR DESCRIPTION
## Summary
Every candidate the re-engagement cron looks at now leaves the run either sent or suppressed with a reason, instead of six branches that ended a person's turn counting nothing.
The daily readout gains a per run table so the same arithmetic can be checked from the outside.

## Details
- Six branches used to end without a send and without a reason: a user deleted between the selector and the decision, a run that hit its push ceiling, a token Expo refuses, a queue claimed by a racing run, a queue claimed before the run even started, and a send that threw.
- The last two are the ones that mattered most. A queue already claimed when the run began was filtered out before the grouping, so the person never reached the decision loop and appeared in no count but a row level tally. On an hourly cron that is most of the people the job looks at.
- The send that threw was the other one. There was no per user catch, so one failure escaped the whole run, took every person behind it, and took the heartbeat with it. That hour reported nothing at all, which reads exactly like a cron that stopped being scheduled. The heartbeat now goes out from a `finally`, so a failure in the selectors or the cadence read still reports the hour and still surfaces as an error rather than as a quiet evening.
- Three of the six branches are decisions about the person and now carry a reason, under two names: `dead_token` for a token Expo will not take, and a new `already_sent` for a queue with nothing left to claim, whether the claim came from an earlier run or from one racing this one.
- The cadence is decided before the queue as well as before the clock. A claimed key is a log row, and that same row is what puts the person inside the weekly floor, so naming the key first would have put `already_sent` on most of the base and buried every reason anybody can act on. It is left for the narrow case it describes: due, inside their own hour, and nothing left to say.
- A run that throws before it finishes deciding now says so on its heartbeat and in the readout. Every count on a failed run is whatever it had reached, which for a failure in the selection is zero across the board, and that is the row a quiet evening produces too.
- The other three are the absence of a decision, so they get their own `held` count rather than a reason that would read as one. It reads zero in a healthy run. At the push ceiling a non zero `held` is a backlog waiting for the next hour rather than anybody lost.
- The run summary and the hourly heartbeat gain `people`, the distinct users behind the candidate rows. `candidates` counts rows and one person can hold several, so `sent` and `suppressed` were never meant to add up to it. They add up to `people`, together with `held`, and the tests assert that on every path.
- Readout: a new table of the last 24 runs with the hour, candidates, people, sent, suppressed, held and the reasons that were not zero. The single row heartbeat cannot tell an hour that sent nothing from a day that sent nothing.
- The selectors move to their own module. The service was over its line budget and the two halves answer different questions, who is due and who gets it. Every name callers already imported is re-exported from the old path, so no call site moves.
- No change to who gets a push or when. The cadence, the caps and the evening window are untouched.
- Worth recording for whoever reads the readout next: there is no timezone column on the user, so a user with coordinates and a user without both resolve a local hour the same way, longitude when there is one and America/Sao_Paulo when there is not. Neither is where the missing candidates went.
- The metric this serves is retention, and the open rate of these pushes is unreadable while the denominator leaks. The number to watch is `held` on the hourly heartbeat, and the new table is where a run that lost somebody becomes visible within the hour rather than after a day of digging.

## Testing steps
1. Open the daily metrics issue after the next run and find the re-engagement section.
2. Read the new table of the last 24 hours. Each row is one run of the job.
3. Check that the people column equals sent plus suppressed plus held on every row. That is the whole point of the change.
4. Check that the held column reads zero. The one case where it should not is an hour that reached the send ceiling, and that reads as a backlog for the next hour rather than anybody lost.
5. Check that a row with nobody sent names the rule that held them in the reasons column, rather than leaving it blank.

## Screenshots
No user facing surface changes. The visible output is the new readout table:

```
| Hour (UTC) | Candidates | People | Sent | Suppressed | Held | Reasons |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| 2026-09-07 21:00 UTC | 7 | 5 | 3 | 2 | 0 | cooldown 1, window 1 |
| 2026-09-07 20:00 UTC | 5 | 3 | 0 | 3 | 0 | window 3 |
| 2026-09-07 19:00 UTC | 5 | 3 | 0 | 3 | 0 | cooldown 3 |
| 2026-09-07 18:00 UTC | 0 | 0 | 0 | 0 | 0 | run failed |
```
