### PR TITLE
fix(api): await every seeded dog in the suggestion preference tests

### DIFF
--- a/packages/api/src/services/SuggestionService/suggestion-service.test.ts
+++ b/packages/api/src/services/SuggestionService/suggestion-service.test.ts
@@ -403,7 +403,7 @@ describe("SuggestionService", () => {
             preferredSize: Size.MEDIUM,
           }),
           generateFakeUserWithDog({ gender: Gender.FEMALE, size: Size.GIANT }),
-          Array.from({ length: numberOfMediumDogs }).map(() =>
+          ...Array.from({ length: numberOfMediumDogs }).map(() =>
             generateFakeUserWithDog({
               gender: Gender.FEMALE,
               size: Size.MEDIUM,
@@ -435,7 +435,7 @@ describe("SuggestionService", () => {
             gender: Gender.FEMALE,
             color: Color.BLACK,
           }),
-          Array.from({ length: numberOfGoldenDogs }).map(() =>
+          ...Array.from({ length: numberOfGoldenDogs }).map(() =>
             generateFakeUserWithDog({
               gender: Gender.FEMALE,
               color: Color.GOLDEN,


### PR DESCRIPTION
## Summary
The color and size preference tests in the suggestion service suite raced against their own fixture setup, so they sometimes counted dogs that had not finished being created yet.

## Details
- Both tests placed a batch of `Array.from({ length }).map(...)` promises as a single array element inside `Promise.all`, instead of spreading them, so `Promise.all` did not wait for that batch to resolve.
- Spread the batches with `...Array.from(...)` so every seeded dog is awaited before the assertions run.
- Checked the age preference test as well. It derives birth dates from `new Date()` in JS while the service compares ages using SQL `NOW()`, so there is a theoretical year boundary gap between the two. The service has no injectable clock to pin against, so this is left as is; the gap only matters if the suite happens to run at the exact moment a fixture crosses a year mark, which is not the source of the observed flakiness.

## Testing steps
1. Open the suggestion service test file for the api package.
2. Run the suggestion service tests five times in a row using the tracked test environment file.
3. Confirm all tests pass every time, including the color and size preference tests.

## Screenshots
Not applicable